### PR TITLE
Handle config errors properly instead of retrying

### DIFF
--- a/pkg/reconciler/cluster.go
+++ b/pkg/reconciler/cluster.go
@@ -123,15 +123,6 @@ func syncCluster(
 			cr.Status.State = string(clusterReady)
 		}
 		return nil
-	} else if state == clusterMembersError {
-		if cr.Status.State != string(clusterWarning) {
-			shared.LogInfo(
-				cr,
-				"warning",
-			)
-			cr.Status.State = string(clusterWarning)
-		}
-		return nil
 	} else {
 		if cr.Status.State != string(clusterCreating) {
 			cr.Status.State = string(clusterUpdating)

--- a/pkg/reconciler/cluster.go
+++ b/pkg/reconciler/cluster.go
@@ -127,7 +127,7 @@ func syncCluster(
 		if cr.Status.State != string(clusterWarning) {
 			shared.LogInfo(
 				cr,
-				"error",
+				"warning",
 			)
 			cr.Status.State = string(clusterWarning)
 		}
@@ -235,7 +235,7 @@ func handleFinalizers(
 
 // calcMemberNamesForRoles generates a map of role name to list of all member
 // names the role that are intended to exist -- i.e. members in states
-// memberCreatePending, memberCreating, memberReady or memberError
+// memberCreatePending, memberCreating, memberReady or memberConfigError
 func calcMemberNamesForRoles(
 	roles []*roleInfo,
 ) map[string][]string {
@@ -251,7 +251,7 @@ func calcMemberNamesForRoles(
 					),
 					roleInfo.membersByState[memberReady]...,
 				),
-				roleInfo.membersByState[memberError]...,
+				roleInfo.membersByState[memberConfigError]...,
 			)
 			var memberNamesForRole []string
 			for _, member := range membersStatus {

--- a/pkg/reconciler/members.go
+++ b/pkg/reconciler/members.go
@@ -223,9 +223,9 @@ func handleCreatingMembers(
 		go func(m *kdv1.MemberStatus) {
 			defer wgSetup.Done()
 			configmeta := configmetaGenerator(m.Pod)
-			// Set member state to error. On successful return from this function
+			// Set member state to configError. On successful return from this function
 			// state will be set to configured.
-			m.State = string(memberError)
+			m.State = string(memberConfigError)
 			createFileErr := executor.CreateFile(
 				cr,
 				m.Pod,
@@ -297,7 +297,7 @@ func handleCreatingMembers(
 	}
 	wgSetup.Wait()
 
-	// Now let any ready nodes know that some new nodes (non-errored) have appeared.
+	// Now let any ready nodes know that some new nodes have appeared.
 	if setupUrl != "" {
 		if !notifyReadyNodes(cr, role, allRoles) {
 			shared.LogWarn(
@@ -457,7 +457,7 @@ func checkMemberCount(
 	replicas := int32(len(role.membersByState[memberCreatePending]) +
 		len(role.membersByState[memberCreating]) +
 		len(role.membersByState[memberReady]) +
-		len(role.membersByState[memberError]))
+		len(role.membersByState[memberConfigError]))
 
 	// Fix the statefulset if we haven't successfully resized it yet.
 	if *(role.statefulSet.Spec.Replicas) != replicas {

--- a/pkg/reconciler/roles.go
+++ b/pkg/reconciler/roles.go
@@ -295,7 +295,7 @@ func handleRoleReCreate(
 			switch memberState(member.State) {
 			case memberDeletePending:
 			case memberReady:
-			case memberError:
+			case memberConfigError:
 				member.State = string(memberDeletePending)
 			default:
 				member.State = string(memberDeleting)
@@ -364,7 +364,7 @@ func handleRoleResize(
 	calcRoleMembersByState(role)
 	currentPop :=
 		len(role.membersByState[memberReady]) +
-			len(role.membersByState[memberError]) +
+			len(role.membersByState[memberConfigError]) +
 			len(role.membersByState[memberCreating]) +
 			len(role.membersByState[memberCreatePending])
 	if role.desiredPop == currentPop {
@@ -435,7 +435,7 @@ func deleteMemberStatuses(
 	createPendingPop := len(role.membersByState[memberCreatePending])
 	creatingPop := len(role.membersByState[memberCreating])
 	readyPop := len(role.membersByState[memberReady])
-	errorPop := len(role.membersByState[memberError])
+	errorPop := len(role.membersByState[memberConfigError])
 	for i := role.desiredPop; i < currentPop; i++ {
 		member := &(role.roleStatus.Members[i])
 		switch memberState(member.State) {
@@ -460,7 +460,7 @@ func deleteMemberStatuses(
 				member,
 			)
 			readyPop -= 1
-		case memberError:
+		case memberConfigError:
 			member.State = string(memberDeletePending)
 			role.membersByState[memberDeletePending] = append(
 				role.membersByState[memberDeletePending],
@@ -489,10 +489,10 @@ func deleteMemberStatuses(
 		delete(role.membersByState, memberReady)
 	}
 	if errorPop > 0 {
-		role.membersByState[memberError] =
-			role.membersByState[memberError][:errorPop]
+		role.membersByState[memberConfigError] =
+			role.membersByState[memberConfigError][:errorPop]
 	} else {
-		delete(role.membersByState, memberError)
+		delete(role.membersByState, memberConfigError)
 	}
 }
 
@@ -532,12 +532,12 @@ func allRoleMembersReady(
 }
 
 // anyRoleMemberError examines the members-by-state map and returns whether
-// any existing members are in an error state
+// any existing members are in an error state.
 func anyRoleMemberError(
 	role *roleInfo,
 ) bool {
 
-	if len(role.membersByState[memberError]) == 0 {
+	if len(role.membersByState[memberConfigError]) == 0 {
 		return false
 	}
 

--- a/pkg/reconciler/services.go
+++ b/pkg/reconciler/services.go
@@ -29,7 +29,7 @@ var serviceShouldExist = map[memberState]bool{
 	memberCreatePending: true,
 	memberCreating:      true,
 	memberReady:         true,
-	memberError:         true,
+	memberConfigError:   true,
 	memberDeletePending: false,
 	memberDeleting:      false,
 }

--- a/pkg/reconciler/services.go
+++ b/pkg/reconciler/services.go
@@ -29,6 +29,7 @@ var serviceShouldExist = map[memberState]bool{
 	memberCreatePending: true,
 	memberCreating:      true,
 	memberReady:         true,
+	memberError:         true,
 	memberDeletePending: false,
 	memberDeleting:      false,
 }

--- a/pkg/reconciler/types.go
+++ b/pkg/reconciler/types.go
@@ -42,6 +42,7 @@ const (
 	clusterCreating clusterState = "creating"
 	clusterUpdating              = "updating"
 	clusterReady                 = "ready"
+	clusterWarning               = "warning"
 )
 
 type clusterStateInternal int
@@ -50,6 +51,7 @@ const (
 	clusterMembersChangedUnready clusterStateInternal = iota
 	clusterMembersStableUnready
 	clusterMembersStableReady
+	clusterMembersError
 	clusterMembersUnknown
 )
 
@@ -62,6 +64,7 @@ const (
 	memberReady                     = "ready"
 	memberDeletePending             = "delete_pending"
 	memberDeleting                  = "deleting"
+	memberError                     = "error"
 )
 
 const (

--- a/pkg/reconciler/types.go
+++ b/pkg/reconciler/types.go
@@ -42,7 +42,6 @@ const (
 	clusterCreating clusterState = "creating"
 	clusterUpdating              = "updating"
 	clusterReady                 = "ready"
-	clusterWarning               = "warning"
 )
 
 type clusterStateInternal int
@@ -51,7 +50,6 @@ const (
 	clusterMembersChangedUnready clusterStateInternal = iota
 	clusterMembersStableUnready
 	clusterMembersStableReady
-	clusterMembersError
 	clusterMembersUnknown
 )
 

--- a/pkg/reconciler/types.go
+++ b/pkg/reconciler/types.go
@@ -64,7 +64,7 @@ const (
 	memberReady                     = "ready"
 	memberDeletePending             = "delete_pending"
 	memberDeleting                  = "deleting"
-	memberError                     = "error"
+	memberConfigError               = "config_error"
 )
 
 const (


### PR DESCRIPTION
This addresses issue #22 in an implicit way. 
- Create a new member state called memberConfigError. If any of the configuration process (creating config meta, injecting bdvcli or setting up appconfig) fails, member state will be put into memberConfigError.
- cluster will be put into warning state if one or more member is in memberConfigError stat
- for rest of the code, memberConfigError is treated similar to memberReady

