### PR TITLE
run initial config asynchronously

### DIFF
--- a/cmd/kubedirector/main.go
+++ b/cmd/kubedirector/main.go
@@ -48,7 +48,12 @@ func main() {
 	if err != nil {
 		logrus.Fatalf("failed to get watch namespace: %v", err)
 	}
-	resyncPeriod := time.Duration(20) * time.Second
+	// The resync period essentially determines how granularly we can detect
+	// the completion of cluster config changes. Making this too small can
+	// actually be bad in that there is benefit to batch-resolving changes,
+	// within KubeDirector but also especially with the cluster's app config
+	// scripts.
+	resyncPeriod := time.Duration(30) * time.Second
 	logrus.Infof("Watching %s, %s, %s, %d", resource, kind, namespace, resyncPeriod)
 
 	// Fetch our deployment object

--- a/pkg/executor/guest.go
+++ b/pkg/executor/guest.go
@@ -105,6 +105,32 @@ func CreateFile(
 	return nil
 }
 
+// ReadFile takes the stream from the given reader, and writes to it the
+// contents of the indicated filepath in the filesystem of the given pod.
+func ReadFile(
+	cr *kdv1.KubeDirectorCluster,
+	podName string,
+	filePath string,
+	writer io.Writer,
+) error {
+
+	command := []string{"cat", filePath}
+	ioStreams := &streams{
+		out: writer,
+	}
+	shared.LogInfof(
+		cr,
+		"reading file{%s} in pod{%s}",
+		filePath,
+		podName,
+	)
+	execErr := execCommand(cr, podName, command, ioStreams)
+	if execErr != nil {
+		return execErr
+	}
+	return nil
+}
+
 // RunScript takes the stream from the given reader, and executes it as a
 // shell script in the given pod.
 func RunScript(

--- a/pkg/executor/guest.go
+++ b/pkg/executor/guest.go
@@ -105,7 +105,7 @@ func CreateFile(
 	return nil
 }
 
-// ReadFile takes the stream from the given reader, and writes to it the
+// ReadFile takes the stream from the given writer, and writes to it the
 // contents of the indicated filepath in the filesystem of the given pod.
 func ReadFile(
 	cr *kdv1.KubeDirectorCluster,

--- a/pkg/reconciler/members.go
+++ b/pkg/reconciler/members.go
@@ -238,6 +238,11 @@ func handleCreatingMembers(
 				configmetaGenerator,
 			)
 			if !isFinal {
+				shared.LogInfof(
+					cr,
+					"initial config ongoing for member{%s}",
+					m.Pod,
+				)
 				return
 			}
 			if configErr != nil {

--- a/pkg/reconciler/types.go
+++ b/pkg/reconciler/types.go
@@ -79,6 +79,13 @@ const (
 	tar xzf appconfig.tgz;
 	chmod +x ` + appPrepStartscript + `;
 	rm -rf /opt/guestconfig/appconfig.tgz`
+	appPrepConfigStatus = "/opt/guestconfig/configure.status"
+	appPrepConfigRunCmd = `rm -f /opt/guestconfig/configure.*;
+	touch ` + appPrepConfigStatus + `;
+	nohup sh -c "` + appPrepStartscript + ` --configure
+	2> /opt/guestconfig/configure.stderr
+	1> /opt/guestconfig/configure.stdout;
+	echo -n $? > /opt/guestconfig/configure.status" &`
 )
 
 type roleInfo struct {


### PR DESCRIPTION
This addresses issue #64.

Now we won't occupy a handler while a startscript is running, at least not for initial configuration. Add/del notifies are still synchronous.

One consequence of this is that we have to be careful that we don't make changes to the set of cluster members while an initial config is running on some member. That member will have some idea of the current member set, and it's not yet in a state where it can receive notifies.

Another consequence is that the completion of initial configs can be staggered somewhat across members, if they take a noticeably different amount of time to run. Previously if you had nodes A, B, and C all entering "creating" state together, they would all finish together (as long as they all succeeded). Now however let's say A and B finish first, then C on some subsequent pass. A and B will now get an add notify for C. This means that add notifies can therefore happen even when a cluster is just initially deployed and not resized, and they can happen for nodes in a non-scaleout role.

Changes by file:

### main.go

Raised the polling period from 20 seconds to 30 seconds, to batch config completions together a little bit more strongly.

### executor/guest.go

Implemented a new ReadFile utility function, used to check a file inside the container where the configure status will be dumped.

### reconciler/members.go

Allow processing "creating" members in a role even while there are "create_pending" members. The previous reason for this ordering restriction should now be moot. This is important since now "creating" member presence blocks role changes. We need to allow the "creating" processing to finish so that we can then shrink if necessary to get rid of some permanent "create_pending". 

Split the app config handling into two functions; one for initial config (appConfig) and one for notify (appReConfig). The notify code is unchanged.

In the new initial config code (appConfig), we handle running the startscript in the background and checking on a file where it will drop its status. Also the initial setup (configmeta, nodeprep, etc.) is moved in here so that we don't keep re-doing it each time we cycle back through the handler to check the status. The main change here is that previously a "creating" node would only get processed across multiple handlers if it were failing its config... now however it will get processed across multiple handlers as we check on its config status repeatedly.

### reconciler/roles.go

Implement the above-mentioned restriction on changing stuff while we have creating-state members. One prerequisite for this is that I had to move when/where we calculate membersByState, so that it is now done immediately during initRoleInfo rather than later.

Added more logging about what we are doing with creating/resizing/etc. the roles.

Removed some code for handling creating-state members during resize, since that is no longer allowed.

### reconciler/types.go

Our beautiful background-configure command.