### PR TITLE
[WIP] Added initial helm chart

### DIFF
--- a/chart/.helmignore
+++ b/chart/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/chart/kubedirector/.helmignore
+++ b/chart/kubedirector/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/chart/kubedirector/Chart.yaml
+++ b/chart/kubedirector/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "unstable"
+description: The KubeDirector Helm chart
+name: kubedirector
+version: 0.1.0

--- a/chart/kubedirector/templates/NOTES.txt
+++ b/chart/kubedirector/templates/NOTES.txt
@@ -1,0 +1,1 @@
+KubeDirector is now running. You can create and manage virtual clusters as described in https://github.com/bluek8s/kubedirector/blob/master/doc/virtual-clusters.md

--- a/chart/kubedirector/templates/_helpers.tpl
+++ b/chart/kubedirector/templates/_helpers.tpl
@@ -1,0 +1,33 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "kubedirector.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "kubedirector.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "kubedirector.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+

--- a/chart/kubedirector/templates/crd-app.yaml
+++ b/chart/kubedirector/templates/crd-app.yaml
@@ -1,0 +1,143 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: {{ .Values.appCrdName }}
+  labels:
+    app: {{ template "kubedirector.name" . }}
+    chart: {{ template "kubedirector.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  group: kubedirector.bluedata.io
+  names:
+    kind: KubeDirectorApp
+    listKind: KubeDirectorAppList
+    plural: kubedirectorapps
+    singular: kubedirectorapp
+  scope: Namespaced
+  version: v1alpha1
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          required: [label, distro_id, version, roles, config]
+          properties:
+            label:
+              required: [name]
+              properties:
+                name:
+                  type: string
+                  minLength: 1
+                description:
+                  type: string
+            distro_id:
+              type: string
+              minLength: 1
+            version:
+              type: string
+              minLength: 1
+            image:
+              required: [repoTag]
+              properties:
+                repoTag:
+                  type: string
+                  minLength: 1
+            setup_package:
+              required: [config_api_version, import_url]
+              properties:
+                config_api_version:
+                  type: integer
+                  minimum: 7
+                import_url:
+                  type: string
+                  pattern: '^https?://.+\.tgz$'
+            services:
+              type: array
+              items:
+                required: [id]
+                properties:
+                  id:
+                    type: string
+                    minLength: 1
+                  label:
+                    required: [name]
+                    properties:
+                      name:
+                        type: string
+                        minLength: 1
+                      description:
+                        type: string
+                  endpoint:
+                    required: [port]
+                    properties:
+                      port:
+                        type: integer
+                        minimum: 0
+                      url_scheme:
+                        type: string
+                        minLength: 1
+                      path:
+                        type: string
+                      is_dashboard:
+                        type: boolean
+            roles:
+              type: array
+              items:
+                required: [id, cardinality]
+                properties:
+                  id:
+                    type: string
+                    minLength: 1
+                  cardinality:
+                    type: string
+                    pattern: '^\d+\+?$'
+                  image:
+                    required: [repoTag]
+                    properties:
+                      repoTag:
+                        type: string
+                        minLength: 1
+                  setup_package:
+                    required: [config_api_version, import_url]
+                    properties:
+                      config_api_version:
+                        type: integer
+                        minimum: 7
+                      import_url:
+                        type: string
+                        pattern: '^https?://.+\.tgz$'
+            config:
+              required: [selected_roles, role_services]
+              properties:
+                config_meta:
+                  type: object
+                selected_roles:
+                  type: array
+                  items:
+                    type: string
+                    minLength: 1
+                role_services:
+                  type: array
+                  items:
+                    required: [role_id, service_ids]
+                    properties:
+                      role_id:
+                        type: string
+                        minLength: 1
+                      service_ids:
+                        type: array
+                        items:
+                          type: string
+                          minLength: 1
+            persist_dirs:
+              type: array
+              items:
+                type: string
+                pattern: '^/[^/]+$'
+            capabilities:
+              type: array
+              items:
+                type: string
+                minLength: 1
+            systemdRequired:
+              type: boolean

--- a/chart/kubedirector/templates/crd-cluster.yaml
+++ b/chart/kubedirector/templates/crd-cluster.yaml
@@ -1,0 +1,109 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: {{ .Values.clusterCrdName }}
+  labels:
+    app: {{ template "kubedirector.name" . }}
+    chart: {{ template "kubedirector.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  group: kubedirector.bluedata.io
+  names:
+    kind: KubeDirectorCluster
+    listKind: KubeDirectorClusterList
+    plural: kubedirectorclusters
+    singular: kubedirectorcluster
+  scope: Namespaced
+  version: v1alpha1
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          required: [app, roles]
+          properties:
+            app:
+              type: string
+              minLength: 1
+            serviceType:
+              type: string
+              pattern: '^NodePort$|^LoadBalancer$'
+            roles:
+              type: array
+              items:
+                required: [id, resources]
+                properties:
+                  id:
+                    type: string
+                    minLength: 1
+                  members:
+                    type: integer
+                    minimum: 0
+                  resources:
+                    required: [limits]
+                    properties:
+                      limits:
+                        required: [memory, cpu]
+                        properties:
+                          memory:
+                            type: string
+                            pattern: '^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'
+                          cpu:
+                            type: string
+                            pattern: '^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'
+                      requests:
+                        properties:
+                          memory:
+                            type: string
+                            pattern: '^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'
+                          cpu:
+                            type: string
+                            pattern: '^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'
+                  env:
+                    type: array
+                    items:
+                      required: [name, value]
+                      properties:
+                        name:
+                          type: string
+                          minLength: 1
+                        value:
+                          type: string
+                  storage:
+                    required: [size, storageClassName]
+                    properties:
+                        size:
+                          type: string
+                          pattern: '^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'
+                        storageClassName:
+                          type: string
+                          minLength: 1
+        status:
+          properties:
+            state:
+              type: string
+            generation_uid:
+              type: string
+            cluster_service:
+              type: string
+            roles:
+              type: array
+              items:
+                properties:
+                  id:
+                    type: string
+                  stateful_set:
+                    type: string
+                  members:
+                    type: array
+                    items:
+                      properties:
+                        pod:
+                          type: string
+                        service:
+                          type: string
+                        pvc:
+                          type: string
+                        state:
+                          type: string
+

--- a/chart/kubedirector/templates/deployment-prebuilt.yaml
+++ b/chart/kubedirector/templates/deployment-prebuilt.yaml
@@ -1,0 +1,57 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "kubedirector.fullname" . }}
+  labels:
+    app: {{ template "kubedirector.name" . }}
+    chart: {{ template "kubedirector.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "kubedirector.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "kubedirector.name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+          - containerPort: 60000
+            name: metrics
+          command:
+          - "/bin/sh"
+          args:
+          - "-c"
+          - "mkfifo /tmp/fifo; (/root/kubedirector &> /tmp/fifo) & while true; do cat /tmp/fifo; done"
+          env:
+          - name: MY_NAMESPACE
+            value: {{ .Release.Namespace }}
+          - name: WATCH_NAMESPACE
+            value: {{ default .Release.Namespace .Values.watchNamespace }}
+          - name: OPERATOR_NAME
+            value: "kubedirector"
+      serviceAccountName: {{ .Values.serviceAccount.name }}
+    {{- with .Values.resources }}
+      resources:
+{{ toYaml . | indent 12 }}
+      {{- end }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/chart/kubedirector/templates/rbac-default.yaml
+++ b/chart/kubedirector/templates/rbac-default.yaml
@@ -1,0 +1,74 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: {{ template "kubedirector.fullname" . }}
+  labels:
+    app: {{ template "kubedirector.name" . }}
+    chart: {{ template "kubedirector.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+- apiGroups:
+  - kubedirector.bluedata.io
+  resources:
+  - "*"
+  verbs:
+  - "*"
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  - endpoints
+  - persistentvolumeclaims
+  - events
+  - configmaps
+  - secrets
+  - pods/exec
+  verbs:
+  - "*"
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - "*"
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - "get"
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  verbs:
+  - "get"
+  - "create"
+
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: {{ .Values.serviceAccount.name}}
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: {{ template "kubedirector.fullname" . }}
+  labels:
+    app: {{ template "kubedirector.name" . }}
+    chart: {{ template "kubedirector.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "kubedirector.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ template "kubedirector.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io

--- a/chart/kubedirector/values.yaml
+++ b/chart/kubedirector/values.yaml
@@ -1,0 +1,22 @@
+# Default values for kubedirector.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+appCrdName: kubedirectorapps.kubedirector.bluedata.io
+clusterCrdName: kubedirectorclusters.kubedirector.bluedata.io
+image:
+  repository: bluek8s/kubedirector
+  tag: unstable
+  pullPolicy: Always
+serviceAccount:
+  name: kubedirector
+
+resources: {}
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
This commit adds initial support for installing the KubeDirector
Deployment via Helm.  Values are provided to override the number of
replicas, the CRD names, image name/tag, and the service account names.
This chart is configured to pull from bluek8s/kubedirector:unstable from
the master branch and should be updated in other release branches.

Related to #63