### PR TITLE
persist_dirs related changes/fixes

### DIFF
--- a/deploy/kubedirector/crd-app.yaml
+++ b/deploy/kubedirector/crd-app.yaml
@@ -128,7 +128,7 @@ spec:
               type: array
               items:
                 type: string
-                pattern: '^/[^/]+$'
+                pattern: '^/.*[^/]$'
             capabilities:
               type: array
               items:

--- a/deploy/kubedirector/crd-app.yaml
+++ b/deploy/kubedirector/crd-app.yaml
@@ -101,6 +101,11 @@ spec:
                       import_url:
                         type: string
                         pattern: '^https?://.+\.tgz$'
+                  persist_dirs:
+                    type: array
+                    items:
+                      type: string
+                      pattern: '^/.*[^/]$'
             config:
               required: [selected_roles, role_services]
               properties:

--- a/pkg/apis/kubedirector.bluedata.io/v1alpha1/types.go
+++ b/pkg/apis/kubedirector.bluedata.io/v1alpha1/types.go
@@ -132,7 +132,7 @@ type AppSpec struct {
 	Services        []Service       `json:"services"`
 	NodeRoles       []NodeRole      `json:"roles"`
 	Config          NodeGroupConfig `json:"config"`
-	PersistDirs     []string        `json:"persist_dirs"`
+	PersistDirs     *[]string       `json:"persist_dirs"`
 	Capabilities    []v1.Capability `json:"capabilities"`
 	SystemdRequired bool            `json:"systemdRequired"`
 }
@@ -184,7 +184,7 @@ type NodeRole struct {
 	Cardinality  string       `json:"cardinality"`
 	Image        Image        `json:"image,omitempty"`
 	SetupPackage SetupPackage `json:"setup_package,omitempty"`
-	PersistDirs  []string     `json:"persist_dirs"`
+	PersistDirs  *[]string    `json:"persist_dirs"`
 }
 
 // NodeGroupConfig identifies a set of roles, and the services on those roles.

--- a/pkg/apis/kubedirector.bluedata.io/v1alpha1/types.go
+++ b/pkg/apis/kubedirector.bluedata.io/v1alpha1/types.go
@@ -184,6 +184,7 @@ type NodeRole struct {
 	Cardinality  string       `json:"cardinality"`
 	Image        Image        `json:"image,omitempty"`
 	SetupPackage SetupPackage `json:"setup_package,omitempty"`
+	PersistDirs  []string     `json:"persist_dirs"`
 }
 
 // NodeGroupConfig identifies a set of roles, and the services on those roles.

--- a/pkg/apis/kubedirector.bluedata.io/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/kubedirector.bluedata.io/v1alpha1/zz_generated.deepcopy.go
@@ -32,8 +32,16 @@ func (in *AppSpec) DeepCopyInto(out *AppSpec) {
 	in.Config.DeepCopyInto(&out.Config)
 	if in.PersistDirs != nil {
 		in, out := &in.PersistDirs, &out.PersistDirs
-		*out = make([]string, len(*in))
-		copy(*out, *in)
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new([]string)
+			if **in != nil {
+				in, out := *in, *out
+				*out = make([]string, len(*in))
+				copy(*out, *in)
+			}
+		}
 	}
 	if in.Capabilities != nil {
 		in, out := &in.Capabilities, &out.Capabilities
@@ -363,8 +371,16 @@ func (in *NodeRole) DeepCopyInto(out *NodeRole) {
 	out.SetupPackage = in.SetupPackage
 	if in.PersistDirs != nil {
 		in, out := &in.PersistDirs, &out.PersistDirs
-		*out = make([]string, len(*in))
-		copy(*out, *in)
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new([]string)
+			if **in != nil {
+				in, out := *in, *out
+				*out = make([]string, len(*in))
+				copy(*out, *in)
+			}
+		}
 	}
 	return
 }

--- a/pkg/apis/kubedirector.bluedata.io/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/kubedirector.bluedata.io/v1alpha1/zz_generated.deepcopy.go
@@ -25,7 +25,9 @@ func (in *AppSpec) DeepCopyInto(out *AppSpec) {
 	if in.NodeRoles != nil {
 		in, out := &in.NodeRoles, &out.NodeRoles
 		*out = make([]NodeRole, len(*in))
-		copy(*out, *in)
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
 	}
 	in.Config.DeepCopyInto(&out.Config)
 	if in.PersistDirs != nil {
@@ -359,6 +361,11 @@ func (in *NodeRole) DeepCopyInto(out *NodeRole) {
 	*out = *in
 	out.Image = in.Image
 	out.SetupPackage = in.SetupPackage
+	if in.PersistDirs != nil {
+		in, out := &in.PersistDirs, &out.PersistDirs
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/catalog/interrogate.go
+++ b/pkg/catalog/interrogate.go
@@ -250,14 +250,14 @@ func AppCapabilities(
 func AppPersistDirs(
 	cr *kdv1.KubeDirectorCluster,
 	role string,
-) ([]string, error) {
+) (*[]string, error) {
 
-	var appPersistDirs []string
+	var appPersistDirs *[]string
 	// Fetch the app type definition if we haven't yet cached it in this
 	// handler pass.
 	appCR, err := GetApp(cr)
 	if err != nil {
-		return []string{}, err
+		return nil, err
 	}
 
 	// Check to see if there is a role-specific setup package.
@@ -269,7 +269,7 @@ func AppPersistDirs(
 	}
 
 	// If role-specific persist_dirs is not present, use the main one.
-	if len(appPersistDirs) == 0 {
+	if appPersistDirs == nil {
 		appPersistDirs = cr.AppSpec.Spec.PersistDirs
 	}
 

--- a/pkg/catalog/interrogate.go
+++ b/pkg/catalog/interrogate.go
@@ -244,12 +244,15 @@ func AppCapabilities(
 	return appCR.Spec.Capabilities, nil
 }
 
-// AppPersistDirs fetches the required directories for a given app that
-// has be persisted on a PVC
+// AppPersistDirs fetches the required directories for a given role that
+// has be persisted on a PVC. If the role doesn't have an explicit list, use
+// the top level list.
 func AppPersistDirs(
 	cr *kdv1.KubeDirectorCluster,
+	role string,
 ) ([]string, error) {
 
+	var appPersistDirs []string
 	// Fetch the app type definition if we haven't yet cached it in this
 	// handler pass.
 	appCR, err := GetApp(cr)
@@ -257,7 +260,20 @@ func AppPersistDirs(
 		return []string{}, err
 	}
 
-	return appCR.Spec.PersistDirs, nil
+	// Check to see if there is a role-specific setup package.
+	for _, nodeRole := range appCR.Spec.NodeRoles {
+		if nodeRole.ID == role {
+			appPersistDirs = nodeRole.PersistDirs
+			break
+		}
+	}
+
+	// If role-specific persist_dirs is not present, use the main one.
+	if len(appPersistDirs) == 0 {
+		appPersistDirs = cr.AppSpec.Spec.PersistDirs
+	}
+
+	return appPersistDirs, nil
 }
 
 // GetApp returns the app type definition for the given virtual cluster. If

--- a/pkg/executor/statefulset.go
+++ b/pkg/executor/statefulset.go
@@ -145,7 +145,7 @@ func getStatefulset(
 	}
 
 	// Check to see if app has requested additional directories to be persisted
-	appPersistDirs, persistErr := catalog.AppPersistDirs(cr)
+	appPersistDirs, persistErr := catalog.AppPersistDirs(cr, role.Name)
 	if persistErr != nil {
 		return nil, persistErr
 	}
@@ -167,7 +167,7 @@ func getStatefulset(
 			if !strings.HasPrefix(rel, "..") {
 				shared.LogInfof(
 					cr,
-					"skipping {%s} from volume claim mounts. defaul dir {%s} covers it",
+					"skipping {%s} from volume claim mounts. default dir {%s} covers it",
 					appDir,
 					defaultDir,
 				)


### PR DESCRIPTION
This is to address issue #29 

- Add --parent option to init Container "cp" command so non-top level directories can be supported.
- Add role based persist_dirs which will override any top level persist_dirs
- When creating the statefulset spec for volume claims, ignore any subdirectories that are already covered by default mounts.