### PR TITLE
event/logging tweaks

### DIFF
--- a/pkg/reconciler/cluster.go
+++ b/pkg/reconciler/cluster.go
@@ -209,7 +209,7 @@ func handleStatusGen(
 		}
 		shared.LogWarnf(
 			cr,
-			shared.EventReasonCluster,
+			shared.EventReasonNoEvent,
 			"unknown with incoming gen uid %s",
 			incoming,
 		)
@@ -224,7 +224,7 @@ func handleStatusGen(
 
 	shared.LogInfo(
 		cr,
-		shared.EventReasonCluster,
+		shared.EventReasonNoEvent,
 		"dropping stale poll",
 	)
 	return false

--- a/pkg/reconciler/services.go
+++ b/pkg/reconciler/services.go
@@ -167,9 +167,10 @@ func handleMemberService(
 			if member.Service != "" {
 				shared.LogWarnf(
 					cr,
-					shared.EventReasonCluster,
-					"re-creating missing service for member{%s}",
+					shared.EventReasonMember,
+					"re-creating missing service for member{%s} in role{%s}",
 					member.Pod,
+					role.roleStatus.Name,
 				)
 			}
 			// Need to create a service.
@@ -212,8 +213,9 @@ func handleMemberServiceCreate(
 		shared.LogErrorf(
 			cr,
 			shared.EventReasonMember,
-			"failed to create member service for member{%s}: %v",
+			"failed to create member service for member{%s} in role{%s}: %v",
 			member.Pod,
+			role.roleStatus.Name,
 			createErr,
 		)
 		member.Service = ""


### PR DESCRIPTION
If logging a member, also log the role now (since member name no longer includes role). Partially addresses issue #90.

Also tweaked some of the event reasons.