### PR TITLE
Remove fragile check.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,3 @@ before_install:
 
 script:
   - make compile
-  - make verify-modules


### PR DESCRIPTION
This check proved to be too fragile to be useful.
Removing this check to improve project velocity.