### PR TITLE
delete headless service on teardown

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -184,6 +184,8 @@ undeploy:
         echo kubectl delete -f deploy/kubedirector/rbac-default.yaml --now; \
         kubectl delete -f deploy/kubedirector/rbac-default.yaml --now; \
     fi
+	@echo \* Deleting headless service...
+	-kubectl delete svc/${project_name}
 	@echo
 	@echo
 	@echo done


### PR DESCRIPTION
During initialization, a headless service is created by operator sdk for tracking metrics. This doesn't have any ownerReference pointing back to our deployment. So on teardown this service is left behind. Ideally we want to do a merge patch to update the Service. k8s is not letting us do a merge patch on "/metadata/ownerReferences". Tried both add and replace.

So instead, just adding an explicit delete service on teardown