### PR TITLE
ensure that shell snippets use bash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 # can use Local.mk to override the image var
 -include Local.mk
 
+SHELL = bash
+
 default_image := bluek8s/kubedirector:unstable
 image ?= ${default_image}
 


### PR DESCRIPTION
I was working from a new (Ubuntu-derived) system and came across this issue. Some of the shell snippets use bash-ish syntax... which is apparently supported OK in the macOS "sh" and on some other systems' "sh", but not on this one.

One fix would be to change all the syntax to make sure it is strictly sh-compatible... but I think it's also legit just to request bash. Let me know what you guys think.