### PR TITLE
don't allow app delete/modify while in use

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -186,6 +186,7 @@ undeploy:
         echo kubectl delete -f deploy/kubedirector/rbac-default.yaml --now; \
         kubectl delete -f deploy/kubedirector/rbac-default.yaml --now; \
     fi
+	@echo
 	@echo \* Deleting headless service...
 	-kubectl delete svc/${project_name}
 	@echo

--- a/pkg/reconciler/cluster.go
+++ b/pkg/reconciler/cluster.go
@@ -218,6 +218,7 @@ func handleStatusGen(
 		)
 		WriteStatusGen(cr, handlerState, incoming)
 		ValidateStatusGen(cr, handlerState)
+		AddClusterAppReference(cr, handlerState)
 		return true
 	}
 

--- a/pkg/reconciler/handler.go
+++ b/pkg/reconciler/handler.go
@@ -30,6 +30,7 @@ func NewHandler() *Handler {
 		ClusterState: handlerClusterState{
 			lock:              sync.RWMutex{},
 			clusterStatusGens: make(map[types.UID]StatusGen),
+			clusterAppTypes:   make(map[string]string),
 		},
 	}
 }

--- a/pkg/reconciler/types.go
+++ b/pkg/reconciler/types.go
@@ -30,6 +30,7 @@ type StatusGen struct {
 type handlerClusterState struct {
 	lock              sync.RWMutex
 	clusterStatusGens map[types.UID]StatusGen
+	clusterAppTypes   map[string]string
 }
 
 type Handler struct {

--- a/pkg/reconciler/util.go
+++ b/pkg/reconciler/util.go
@@ -30,9 +30,9 @@ func ReadStatusGen(
 	return val, ok
 }
 
-// WriteStatusGen provides threadsafe write of a status gen UID string.
+// writeStatusGen provides threadsafe write of a status gen UID string.
 // The validated flag will begin as false.
-func WriteStatusGen(
+func writeStatusGen(
 	cr *kdv1.KubeDirectorCluster,
 	handlerState *handlerClusterState,
 	newGenUid string,
@@ -56,8 +56,8 @@ func ValidateStatusGen(
 	}
 }
 
-// DeleteStatusGen provides threadsafe delete of a status gen.
-func DeleteStatusGen(
+// deleteStatusGen provides threadsafe delete of a status gen.
+func deleteStatusGen(
 	cr *kdv1.KubeDirectorCluster,
 	handlerState *handlerClusterState,
 ) {
@@ -87,8 +87,8 @@ func ClustersUsingApp(
 	return clusters
 }
 
-// AddClusterForApp notes that an app type is in use by this cluster.
-func AddClusterAppReference(
+// ensureClusterAppReference notes that an app type is in use by this cluster.
+func ensureClusterAppReference(
 	cr *kdv1.KubeDirectorCluster,
 	handlerState *handlerClusterState,
 ) {
@@ -98,14 +98,13 @@ func AddClusterAppReference(
 	handlerState.clusterAppTypes[clusterKey] = cr.Spec.AppID
 }
 
-// RemoveClusterForApp notes that an app type is no longer in use by this
-// cluster.
-func RemoveClusterAppReference(
-	namespace string,
-	clusterName string,
+// removeClusterAppReference notes that an app type is no longer in use by
+// this cluster.
+func removeClusterAppReference(
+	cr *kdv1.KubeDirectorCluster,
 	handlerState *handlerClusterState,
 ) {
-	clusterKey := namespace + "/" + clusterName
+	clusterKey := cr.Namespace + "/" + cr.Name
 	handlerState.lock.Lock()
 	defer handlerState.lock.Unlock()
 	delete(handlerState.clusterAppTypes, clusterKey)

--- a/pkg/reconciler/util.go
+++ b/pkg/reconciler/util.go
@@ -75,10 +75,12 @@ func ClustersUsingApp(
 	handlerState.lock.RLock()
 	defer handlerState.lock.RUnlock()
 	// This is a relationship that needs to be query-able given either ONLY
-	// the app name (this function) or ONLY cluster name (RemoveClusterForApp).
-	// Since the app CR deletion/update triggers for this function are very
-	// infrequent, we'll implement this app-name check by just walking the
-	// list of associations.
+	// the app name (in this function) or ONLY the cluster name (in
+	// removeClusterAppReference). Since the app CR deletion/update triggers
+	// for this function are very infrequent, we'll implement this app-name
+	// check by just walking the list of associations. It's also nice to go
+	// ahead and gather all the offending cluster CR names to report back to
+	// the client.
 	for clusterKey, appName := range handlerState.clusterAppTypes {
 		if appName == app {
 			clusters = append(clusters, clusterKey)

--- a/pkg/validator/cluster.go
+++ b/pkg/validator/cluster.go
@@ -23,11 +23,9 @@ import (
 
 	kdv1 "github.com/bluek8s/kubedirector/pkg/apis/kubedirector.bluedata.io/v1alpha1"
 	"github.com/bluek8s/kubedirector/pkg/catalog"
-	"github.com/bluek8s/kubedirector/pkg/observer"
 	"github.com/bluek8s/kubedirector/pkg/reconciler"
 	"github.com/bluek8s/kubedirector/pkg/shared"
 	"k8s.io/api/admission/v1beta1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -265,32 +263,52 @@ func admitClusterCR(
 		Allowed: false,
 	}
 
+	// If this is a delete, all we need to do is note that this cluster is
+	// no longer referencing its app type.
+	if ar.Request.Operation == v1beta1.Delete {
+		reconciler.RemoveClusterAppReference(
+			ar.Request.Namespace,
+			ar.Request.Name,
+			&(handlerState.ClusterState),
+		)
+		admitResponse.Allowed = true
+		return &admitResponse
+	}
+
+	// Deserialize the object.
 	raw := ar.Request.Object.Raw
 	clusterCR := kdv1.KubeDirectorCluster{}
-
-	if err := json.Unmarshal(raw, &clusterCR); err != nil {
+	if jsonErr := json.Unmarshal(raw, &clusterCR); jsonErr != nil {
 		admitResponse.Result = &metav1.Status{
-			Message: "\n" + err.Error(),
+			Message: "\n" + jsonErr.Error(),
 		}
 		return &admitResponse
 	}
 
-	// For various checks we'll need to compare to the current cluster object.
-	prevCluster, prevClusterErr := observer.GetCluster(
-		clusterCR.Namespace,
-		clusterCR.Name,
-	)
-	prevClusterExists := true
-	if prevClusterErr != nil {
-		// We'll handle not-found as needed in different cases below. Other
-		// kinds of errors here are bad though.
-		if !errors.IsNotFound(prevClusterErr) {
+	// Make sure that if we're adding a new cluster, we don't escape from
+	// this handler without recording a reference to its app type.
+	defer func() {
+		if ar.Request.Operation == v1beta1.Create && admitResponse.Allowed == true {
+			reconciler.AddClusterAppReference(
+				&clusterCR,
+				&(handlerState.ClusterState),
+			)
+		}
+	}()
+
+	// Now do validation for create/update.
+
+	prevClusterCR := kdv1.KubeDirectorCluster{}
+	if ar.Request.Operation == v1beta1.Update {
+		// On update, get the previous version of the object ready for use in
+		// some checks.
+		prevRaw := ar.Request.OldObject.Raw
+		if prevJsonErr := json.Unmarshal(prevRaw, &prevClusterCR); prevJsonErr != nil {
 			admitResponse.Result = &metav1.Status{
-				Message: "\nError when fetching current cluster object",
+				Message: "\n" + prevJsonErr.Error(),
 			}
 			return &admitResponse
 		}
-		prevClusterExists = false
 	}
 
 	// Don't allow Status to be updated except by KubeDirector. Do this by
@@ -313,14 +331,7 @@ func admitClusterCR(
 		// it's OK to write the status again as long as nothing is changing.
 		// (For example we'll see this when a PATCH happens.)
 		if expectedStatusGen.Validated {
-			if !prevClusterExists {
-				// This is a not-found error for a cluster UID that DID
-				// previously exist. Has to be a delete/update race, so go
-				// ahead and let the core API controller reject or ignore this.
-				admitResponse.Allowed = true
-				return &admitResponse
-			}
-			if !reflect.DeepEqual(clusterCR.Status, prevCluster.Status) {
+			if !reflect.DeepEqual(clusterCR.Status, prevClusterCR.Status) {
 				admitResponse.Result = &metav1.Status{
 					Message: "\nKubeDirector-related status properties are read-only",
 				}
@@ -333,10 +344,18 @@ func admitClusterCR(
 		&(handlerState.ClusterState),
 	)
 
-	// Validate app first
-	appCR, err := catalog.GetApp(&clusterCR)
+	// Shortcut out of here if the spec is not being changed. Among other
+	// things this allows KD to update status or metadata even if the
+	// referenced app is bad/gone.
+	if ar.Request.Operation == v1beta1.Update {
+		if reflect.DeepEqual(clusterCR.Spec, prevClusterCR.Spec) {
+			admitResponse.Allowed = true
+			return &admitResponse
+		}
+	}
 
-	// If app is bad, no need to continue with rest of the validation
+	// At this point, if app is bad, no need to continue with validation.
+	appCR, err := catalog.GetApp(&clusterCR)
 	if err != nil {
 		admitResponse.Result = &metav1.Status{
 			Message: "\n" + fmt.Sprintf(invalidAppMessage, clusterCR.Spec.AppID),
@@ -345,9 +364,9 @@ func admitClusterCR(
 	}
 
 	// If cluster already exists, check for property changes.
-	if prevClusterExists {
-		valErrors = validateGeneralChanges(&clusterCR, prevCluster, valErrors)
-		valErrors = validateRoleChanges(&clusterCR, prevCluster, valErrors)
+	if ar.Request.Operation == v1beta1.Update {
+		valErrors = validateGeneralChanges(&clusterCR, &prevClusterCR, valErrors)
+		valErrors = validateRoleChanges(&clusterCR, &prevClusterCR, valErrors)
 		// We coooooould continue to do other validation at this point, but
 		// that could be misleading. Let's not do other validation unless we
 		// know that only change-able properties are being changed.

--- a/pkg/validator/util.go
+++ b/pkg/validator/util.go
@@ -114,7 +114,11 @@ func createAdmissionService(
 	webhookHandler := v1beta1.Webhook{
 		Name: webhookHandlerName,
 		Rules: []v1beta1.RuleWithOperations{{
-			Operations: []v1beta1.OperationType{v1beta1.Create, v1beta1.Update},
+			Operations: []v1beta1.OperationType{
+				v1beta1.Create,
+				v1beta1.Update,
+				v1beta1.Delete,
+			},
 			Rule: v1beta1.Rule{
 				APIGroups:   []string{"kubedirector.bluedata.io"},
 				APIVersions: []string{"v1alpha1"},


### PR DESCRIPTION
Addresses issue #7 (and #89, see below).

This change adds another map in the handler state, which associates a "cluster key" (namespace+name) to the app ID used by that cluster. We're going to use that in-memory object to track when a KubeDirectorApp is referenced by any KubeDirectorCluster, and prevent app delete/modify in that situation. The functions that reference the map have a bit more commentary about why that data structure is used.

Note that if you want to try out this branch, you'll probably want to set your Local.mk to deploy from my bluek8s/kubedirector:joel-dev image. Because this changes the webhook properties it's not easy to get it running correctly just by using "make redeploy" after deploying from the normal image.

----------

### reconciler/types.go

Adding the above-mentioned map to the handler state.

### reconciler/handler.go

Initializing the map.

### reconciler/util.go

Functions for reading/writing the map.

I also lowercased some existing functions that I don't expect to need to be exported.

### reconciler/cluster.go

The first few chunks in this diff handle updating the map on cluster delete or create. We'll also update it on cluster update, which is currently a nop -- since we prevent changing the app on an existing cluster -- but I think that's fine. We could spend a bit of effort to try to distinguish between create and update cases here (this is not as trivial as it would be in the admission handler) but I don't think it's worth it.

Bonus fix for issue #89 in the next few chunks here.

Last chunk: If we're discovering existing clusters on KD startup (for example during a redeploy), add them to the map.

### validator/util.go

Adding "DELETE" to the set of REST ops that our webhook will pay attention to.

### validator/cluster.go

Bail out early if it's a delete operation.

When processing an update, we don't need to do a K8s API GET to obtain the pre-update resource. We can just get it out of the OldObject in the admission request.

Minor improvement: Don't validate anything (other than the protections for the Status) if the spec is not changing. Some comments in the code about that.

### validator/app.go

On delete or update, check to see if the app is in use; fail admission if so.
