### PR TITLE
have "make build" be the default again

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,10 +22,6 @@ endif
 
 build_dir = 'tmp/_output'
 
-compile:
-	make clean
-	go build -o tmp/_output/bin ./cmd/kubedirector
-
 build: pkg/apis/kubedirector.bluedata.io/v1alpha1/zz_generated.deepcopy.go | $(build_dir)
 	@echo
 	@echo \* Creating node prep package...
@@ -197,6 +193,10 @@ undeploy:
 	@echo
 
 teardown: undeploy
+
+compile:
+	make clean
+	go build -o tmp/_output/bin ./cmd/kubedirector
 
 format:
 	go fmt $(shell go list ./... | grep -v /vendor/)


### PR DESCRIPTION
"make compile" was introduced as a new target at the top of the file at one point, but really we want "make build" to be the thing that happens if someone just types "make".