### PR TITLE
change names of top-level default image/package props

### DIFF
--- a/deploy/example_catalog/cr-app-cassandra-3.11.json
+++ b/deploy/example_catalog/cr-app-cassandra-3.11.json
@@ -35,7 +35,7 @@
                 "worker"
             ]
         },
-        "image_repo_tag": "docker.io/bluedata/cassandra:3.0",
+        "default_image_repo_tag": "docker.io/bluedata/cassandra:3.0",
         "label": {
             "name": "Cassandra 3.11",
             "description": "Cassandra 3.11 on centos 7.x"
@@ -66,7 +66,7 @@
                 }
             }
         ],
-        "config_package": {
+        "default_config_package": {
             "package_url": "https://s3.amazonaws.com/bluek8s/kubedirector/cassandra311/appconfig-3.1.tgz"
         },
         "roles": [

--- a/deploy/example_catalog/cr-app-cdh5142cm.json
+++ b/deploy/example_catalog/cr-app-cdh5142cm.json
@@ -69,7 +69,7 @@
                 "worker"
             ]
         },
-        "image_repo_tag": "docker.io/bluedata/cdh5142cm:3.0",
+        "default_image_repo_tag": "docker.io/bluedata/cdh5142cm:3.0",
         "label": {
             "name": "CDH 5.14.2 on 7x with Cloudera Manager",
             "description": "CDH 5.14.2 with YARN support. Includes Pig, Hive, and Hue."
@@ -236,7 +236,7 @@
                 }
             }
         ],
-        "config_package":  {
+        "default_config_package":  {
             "package_url": "https://s3.amazonaws.com/bluek8s/kubedirector/cdh5142cm/cdh5-cm-setup-1.4.tgz"
         },
         "roles": [

--- a/deploy/example_catalog/cr-app-centos7.json
+++ b/deploy/example_catalog/cr-app-centos7.json
@@ -45,8 +45,8 @@
                 }
             }
         ],
-        "image_repo_tag": "docker.io/bluedata/centos7:4.1",
-        "config_package": null,
+        "default_image_repo_tag": "docker.io/bluedata/centos7:4.1",
+        "default_config_package": null,
         "roles": [
             {
                 "cardinality": "1+",

--- a/deploy/example_catalog/cr-app-spark221e2.json
+++ b/deploy/example_catalog/cr-app-spark221e2.json
@@ -105,7 +105,7 @@
                 }
             }
         ],
-        "config_package":  {
+        "default_config_package":  {
             "package_url": "https://s3.amazonaws.com/bluek8s/kubedirector/spark221e2/appconfig-2.6.tgz"
         },
         "roles": [

--- a/deploy/example_catalog/cr-app-tensorflowcpu.json
+++ b/deploy/example_catalog/cr-app-tensorflowcpu.json
@@ -59,7 +59,7 @@
                 }
             }
         ],
-        "config_package": {
+        "default_config_package": {
             "package_url" : "https://s3.amazonaws.com/bluek8s/kubedirector/tensorflowcpu/appconfig-1.8.tgz"
         },
         "roles": [

--- a/deploy/kubedirector/crd-app.yaml
+++ b/deploy/kubedirector/crd-app.yaml
@@ -34,10 +34,10 @@ spec:
             config_schema_version:
               type: integer
               minimum: 7
-            image_repo_tag:
+            default_image_repo_tag:
               type: string
               minLength: 1
-            config_package:
+            default_config_package:
               required: [package_url]
               properties:
                 package_url:

--- a/pkg/apis/kubedirector.bluedata.io/v1alpha1/types.go
+++ b/pkg/apis/kubedirector.bluedata.io/v1alpha1/types.go
@@ -126,18 +126,18 @@ type KubeDirectorApp struct {
 
 // AppSpec is the spec provided for an app definition.
 type AppSpec struct {
-	Label           Label           `json:"label"`
-	DistroID        string          `json:"distro_id"`
-	Version         string          `json:"version"`
-	SchemaVersion   int             `json:"schema_version"`
-	Image           Image           `json:"image_repo_tag,omitempty"`
-	SetupPackage    SetupPackage    `json:"config_package,omitempty"`
-	Services        []Service       `json:"services"`
-	NodeRoles       []NodeRole      `json:"roles"`
-	Config          NodeGroupConfig `json:"config"`
-	PersistDirs     *[]string       `json:"persist_dirs"`
-	Capabilities    []v1.Capability `json:"capabilities"`
-	SystemdRequired bool            `json:"systemdRequired"`
+	Label               Label           `json:"label"`
+	DistroID            string          `json:"distro_id"`
+	Version             string          `json:"version"`
+	SchemaVersion       int             `json:"schema_version"`
+	DefaultImage        Image           `json:"default_image_repo_tag,omitempty"`
+	DefaultSetupPackage SetupPackage    `json:"default_config_package,omitempty"`
+	Services            []Service       `json:"services"`
+	NodeRoles           []NodeRole      `json:"roles"`
+	Config              NodeGroupConfig `json:"config"`
+	PersistDirs         *[]string       `json:"persist_dirs"`
+	Capabilities        []v1.Capability `json:"capabilities"`
+	SystemdRequired     bool            `json:"systemdRequired"`
 }
 
 // Label is a short name and long description for the app definition.
@@ -163,7 +163,7 @@ type SetupPackage struct {
 	PackageURL SetupPackageURL
 }
 
-// SetupPacakgeURL is the URL of the setup package.
+// SetupPackageURL is the URL of the setup package.
 type SetupPackageURL struct {
 	PackageURL string `json:"package_url"`
 }

--- a/pkg/apis/kubedirector.bluedata.io/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/kubedirector.bluedata.io/v1alpha1/zz_generated.deepcopy.go
@@ -13,8 +13,8 @@ import (
 func (in *AppSpec) DeepCopyInto(out *AppSpec) {
 	*out = *in
 	out.Label = in.Label
-	out.Image = in.Image
-	out.SetupPackage = in.SetupPackage
+	out.DefaultImage = in.DefaultImage
+	out.DefaultSetupPackage = in.DefaultSetupPackage
 	if in.Services != nil {
 		in, out := &in.Services, &out.Services
 		*out = make([]Service, len(*in))

--- a/pkg/validator/app.go
+++ b/pkg/validator/app.go
@@ -157,30 +157,30 @@ func validateRoles(
 	var globalImageRepoTag *string
 	var globalSetupPackageURL *string
 
-	if appCR.Spec.Image.IsSet == false {
+	if appCR.Spec.DefaultImage.IsSet == false {
 		globalImageRepoTag = nil
 	} else {
-		globalImageRepoTag = &appCR.Spec.Image.RepoTag
+		globalImageRepoTag = &appCR.Spec.DefaultImage.RepoTag
 
 		patches = append(
 			patches,
 			appPatchSpec{
 				Op:   "remove",
-				Path: "/spec/image_repo_tag",
+				Path: "/spec/default_image_repo_tag",
 			},
 		)
 	}
 
-	if (appCR.Spec.SetupPackage.IsSet == false) || (appCR.Spec.SetupPackage.IsNull == true) {
+	if (appCR.Spec.DefaultSetupPackage.IsSet == false) || (appCR.Spec.DefaultSetupPackage.IsNull == true) {
 		globalSetupPackageURL = nil
 	} else {
-		globalSetupPackageURL = &appCR.Spec.SetupPackage.PackageURL.PackageURL
+		globalSetupPackageURL = &appCR.Spec.DefaultSetupPackage.PackageURL.PackageURL
 
 		patches = append(
 			patches,
 			appPatchSpec{
 				Op:   "remove",
-				Path: "/spec/config_package",
+				Path: "/spec/default_config_package",
 			},
 		)
 	}


### PR DESCRIPTION
Since these behave differently than the per-role props in certain ways -- they act only as defaults during CR create and are then removed -- let's rename them to mark them as such.