### PR TITLE
initcontainer only needs 1 CPU

### DIFF
--- a/pkg/executor/statefulset.go
+++ b/pkg/executor/statefulset.go
@@ -279,7 +279,7 @@ func getInitContainer(
 	}
 
 	initVolumeMounts := generateInitVolumeMounts(pvcName)
-	cpus, _ := resource.ParseQuantity("2")
+	cpus, _ := resource.ParseQuantity("1")
 	mem, _ := resource.ParseQuantity("512Mi")
 	initContainer = []v1.Container{
 		{


### PR DESCRIPTION
Just to make sure this part won't block us on resources. Resolves issue #125.