### PR TITLE
fix validation for storageclassname default

### DIFF
--- a/pkg/validator/cluster.go
+++ b/pkg/validator/cluster.go
@@ -320,13 +320,13 @@ func validateRoleStorageClass(
 	}
 
 	if validateDefault {
-		_, err := observer.GetStorageClass(defaultStorageClassName)
+		_, err := observer.GetStorageClass(globalStorageClass)
 		if err != nil {
 			valErrors = append(
 				valErrors,
 				fmt.Sprintf(
 					undefinedRoleStorageClass,
-					defaultStorageClassName,
+					globalStorageClass,
 				),
 			)
 		}


### PR DESCRIPTION
If the value specified in the config was something other than "standard", this check was not working as desired. We should be checking whatever default is specified in the config here (rather than always checking "standard").