### PR TITLE
prepare for 0.2.0 release

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,4 @@
-# v0.2.0 - ??? insert release date here when finalized ???
+# v0.2.0 - Feb 4, 2019
 
 Welcome to the first public update of KubeDirector! This release focuses on making the app and virtual cluster CRs more complete, consistent, and bulletproof to use. In the process other operational improvements have fallen into place, and of course bugfixing is always going on.
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -10,7 +10,7 @@ That's far from the only user-visible change though! The entire list of improvem
 
 ## App/cluster model
 
-* KubeDirector-related custom resource definitions (CRDs) have changed in various ways since the v0.1.0 release. The [wiki](https://github.com/bluek8s/kubedirector/wiki) documents the release-specific format of each CRD (as well as the format in use on the tip of the master branch). Use that documentation as a reference if you need to port old CR specs to v0.2.0. We can also provide porting assistance on our [Slack workspace](https://join.slack.com/t/bluek8s/shared_invite/enQtNDUwMzkwODY5OTM4LTRhYmRmZmE4YzY3OGUzMjA1NDg0MDVhNDQ2MGNkYjRhM2RlMDNjMTI1NDQyMjAzZGVlMDFkNThkNGFjZGZjMGY).
+* KubeDirector-related custom resource definitions (CRDs) have changed in various ways since the v0.1.0 release. The [wiki](https://github.com/bluek8s/kubedirector/wiki) documents the release-specific format of each CRD (as well as the format in use on the tip of the master branch). Use that documentation as a reference if you need to port old CR specs to v0.2.0. We can also provide porting assistance on our [Slack workspace](https://join.slack.com/t/bluek8s/shared_invite/enQtNTQzNDQzNjQwMDMyLTdjYjE0ZTg0OGJhZWUxMzhkZTZjNDg5ODIyNzZmNzZiYTk4ZjQxNDFjYzk4OWM0MjFlNmVkNWNlNmFjNzkzNjQ).
 
 * The CRD schemas and the dynamic validation perform even more validation on app and cluster CRs. It should be extremely unlikely now that an invalid app/cluster CR creation or edit will pass validation.
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ See the files in the "doc" directory for information about deploying and using K
 
 # Contributing
 
-You’re welcome to join the [BlueK8s Slack workspace](https://join.slack.com/t/bluek8s/shared_invite/enQtNDUwMzkwODY5OTM4LTRhYmRmZmE4YzY3OGUzMjA1NDg0MDVhNDQ2MGNkYjRhM2RlMDNjMTI1NDQyMjAzZGVlMDFkNThkNGFjZGZjMGY) for feedback and discussion.
+You’re welcome to join the [BlueK8s Slack workspace](https://join.slack.com/t/bluek8s/shared_invite/enQtNTQzNDQzNjQwMDMyLTdjYjE0ZTg0OGJhZWUxMzhkZTZjNDg5ODIyNzZmNzZiYTk4ZjQxNDFjYzk4OWM0MjFlNmVkNWNlNmFjNzkzNjQ) for feedback and discussion.
 
 Please read through the [CONTRIBUTING](CONTRIBUTING.md) guide before making a pull request. If you run into an issue with the contributing guide, please send a pull request to fix the contributing guide.
 

--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -36,13 +36,13 @@ So if you intend to later work with the KubeDirector source, you would clone the
     git clone https://github.com/bluek8s/kubedirector
 ```
 
-If you want to work with a specific released version of KubeDirector (instead of the tip of the master branch), now is the time to switch the repo to that. This is recommended, especially for your first time trying out KubeDirector. At the time of last updating this doc, the most recent KubeDirector release was v0.1.0; you can set the repo to that release as follows:
+If you want to work with a specific released version of KubeDirector (instead of the tip of the master branch), now is the time to switch the repo to that. This is recommended, especially for your first time trying out KubeDirector. At the time of last updating this doc, the most recent KubeDirector release was v0.2.0; you can set the repo to that release as follows:
 ```bash
     cd kubedirector
-    git checkout v0.1.0
+    git checkout v0.2.0
 ```
 
-If you have switched to a tagged version of KubeDirector in your local repo, make sure that when you read the doc files (like this one) you reference the files that are consistent with that version. The files in your local repo will be consistent; you could also reference the online files at a particular tag, for example the [doc files for v0.1.0](https://github.com/bluek8s/kubedirector/tree/v0.1.0/doc).
+If you have switched to a tagged version of KubeDirector in your local repo, make sure that when you read the doc files (like this one) you reference the files that are consistent with that version. The files in your local repo will be consistent; you could also reference the online files at a particular tag, for example the [doc files for v0.2.0](https://github.com/bluek8s/kubedirector/tree/v0.2.0/doc).
 
 Now you can deploy KubeDirector:
 ```bash


### PR DESCRIPTION
Abbreviated version of the release process is described below FYI. This branch will NOT be merged to master quite yet.

Before Monday:

- The 0.2.0-release branch will be created from this branch. Various changes there e.g. the 0.2.0 tag for the prebuilt image, links to v0.2.0 versions of docs/wiki, etc.

- Create the prebuilt image and regression test.

Assuming everything goes well, then on Monday:

- Tag the 0.2.0-release branch as v0.2.0. Don't merge it to master.

- Advertise the release: merge the 0.2.0-release-info branch to master and promote the v0.2.0 tag into a "release" on the releases page.

- Delete both branches.
