### PR TITLE
advertise the 0.2.0 release

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,4 @@
-# v0.2.0 - ??? insert release date here when finalized ???
+# v0.2.0 - Feb 19, 2019
 
 Welcome to the first public update of KubeDirector! This release focuses on making the app and virtual cluster CRs more complete, consistent, and bulletproof to use. In the process other operational improvements have fallen into place, and of course bugfixing is always going on.
 

--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -36,13 +36,13 @@ So if you intend to later work with the KubeDirector source, you would clone the
     git clone https://github.com/bluek8s/kubedirector
 ```
 
-If you want to work with a specific released version of KubeDirector (instead of the tip of the master branch), now is the time to switch the repo to that. This is recommended, especially for your first time trying out KubeDirector. At the time of last updating this doc, the most recent KubeDirector release was v0.1.0; you can set the repo to that release as follows:
+If you want to work with a specific released version of KubeDirector (instead of the tip of the master branch), now is the time to switch the repo to that. This is recommended, especially for your first time trying out KubeDirector. At the time of last updating this doc, the most recent KubeDirector release was v0.2.0; you can set the repo to that release as follows:
 ```bash
     cd kubedirector
-    git checkout v0.1.0
+    git checkout v0.2.0
 ```
 
-If you have switched to a tagged version of KubeDirector in your local repo, make sure that when you read the doc files (like this one) you reference the files that are consistent with that version. The files in your local repo will be consistent; you could also reference the online files at a particular tag, for example the [doc files for v0.1.0](https://github.com/bluek8s/kubedirector/tree/v0.1.0/doc).
+If you have switched to a tagged version of KubeDirector in your local repo, make sure that when you read the doc files (like this one) you reference the files that are consistent with that version. The files in your local repo will be consistent; you could also reference the online files at a particular tag, for example the [doc files for v0.2.0](https://github.com/bluek8s/kubedirector/tree/v0.2.0/doc).
 
 Now you can deploy KubeDirector:
 ```bash


### PR DESCRIPTION
Modifying the docs on master to indicate that [0.2.0](https://github.com/bluek8s/kubedirector/releases/tag/v0.2.0) is the latest release.