### PR TITLE
Send stdout to /dev/null because we don't care about it.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -296,7 +296,7 @@ golint:
     fi
 
 check-format:
-	@make clean
+	@make clean > /dev/null
 	@if [ "$$(gofmt -d $$(go list -f '{{.Dir}}' ./...))" == "" ] ; then \
 	    echo "No formatting changes needed, good job!" ; \
     else \


### PR DESCRIPTION
Remove the `make clean` output from the `make check-format` output. Just pipe it to `/dev/null` since we don't want it.

Previously:

<img width="729" alt="screen shot 2019-03-04 at 12 24 08 pm" src="https://user-images.githubusercontent.com/2186874/53761208-d9f22200-3e79-11e9-94f8-81dd51e72644.png">

Previously, with error:

<img width="1063" alt="screen shot 2019-03-04 at 12 53 43 pm" src="https://user-images.githubusercontent.com/2186874/53762293-94832400-3e7c-11e9-9565-e69c10f83774.png">

Now:

<img width="391" alt="screen shot 2019-03-04 at 12 34 09 pm" src="https://user-images.githubusercontent.com/2186874/53761215-de1e3f80-3e79-11e9-9836-7b021e3a34ff.png">

Now, with error:

<img width="1045" alt="screen shot 2019-03-04 at 12 53 01 pm" src="https://user-images.githubusercontent.com/2186874/53762259-774e5580-3e7c-11e9-8aab-188073402d62.png">

