### PR TITLE
Multiple Namespace watch support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -185,10 +185,9 @@ undeploy:
 	@echo \* Deleting any managed virtual clusters...
 	@set -e; \
 		all_namespaces=`kubectl get ns --no-headers| awk '{print $$1}'`; \
-		echo $$all_namespaces; \
 		for ns in $$all_namespaces; do \
 			echo kubectl -n $$ns delete ${cluster_resource_name} --all --now; \
-			kubectl -n $$ns delete ${cluster_resource_name} --all --now; \
+			kubectl -n $$ns delete ${cluster_resource_name} --all --now || true; \
 		done;
 	@echo
 	@echo \* Deleting application types...

--- a/Makefile
+++ b/Makefile
@@ -183,7 +183,13 @@ redeploy:
 undeploy:
 	@echo
 	@echo \* Deleting any managed virtual clusters...
-	-kubectl delete ${cluster_resource_name} --all --now
+	@set -e; \
+		all_namespaces=`kubectl get ns --no-headers| awk '{print $$1}'`; \
+		echo $$all_namespaces; \
+		for ns in $$all_namespaces; do \
+			echo kubectl -n $$ns delete ${cluster_resource_name} --all --now; \
+			kubectl -n $$ns delete ${cluster_resource_name} --all --now; \
+		done;
 	@echo
 	@echo \* Deleting application types...
 	-kubectl delete ${app_resource_name} --all --now
@@ -218,14 +224,14 @@ undeploy:
 	@set -e; \
         retries=100; \
         while [ $$retries ]; do \
-            if kubectl get all -l kubedirectorcluster 2>&1 >/dev/null | grep "No resources found." &> /dev/null; then \
+            if kubectl get all -l kubedirectorcluster --all-namespaces 2>&1 >/dev/null | grep "No resources found." &> /dev/null; then \
                 exit 0; \
             else \
                 retries=`expr $$retries - 1`; \
                 if [ $$retries -le 0 ]; then \
                     echo; \
                     echo Some KubeDirector-managed resources seem to remain.; \
-                    echo Use "kubectl get all -l kubedirectorcluster" to check and do manual cleanup.; \
+                    echo Use "kubectl get all -l kubedirectorcluster --all-namespaces" to check and do manual cleanup.; \
                     exit 1; \
                 fi; \
                 sleep 3; \

--- a/cmd/kubedirector/main.go
+++ b/cmd/kubedirector/main.go
@@ -70,6 +70,7 @@ func main() {
 	type watchInfo struct {
 		kind         string
 		resyncPeriod time.Duration
+		namespace    string
 	}
 
 	// Add all CR kinds that we want to watch.
@@ -82,17 +83,19 @@ func main() {
 			// within KubeDirector but also especially with the cluster's app config
 			// scripts.
 			resyncPeriod: time.Duration(30) * time.Second,
+			namespace:    "",
 		},
 		{
 			kind:         "KubeDirectorConfig",
 			resyncPeriod: 0,
+			namespace:    namespace,
 		},
 	}
 
 	resource := "kubedirector.bluedata.io/v1alpha1"
 	for _, w := range watchParams {
-		logrus.Infof("Watching %s, %s, %s, %d", resource, w.kind, namespace, w.resyncPeriod)
-		sdk.Watch(resource, w.kind, namespace, w.resyncPeriod)
+		logrus.Infof("Watching %s, %s, %s, %d", resource, w.kind, w.namespace, w.resyncPeriod)
+		sdk.Watch(resource, w.kind, w.namespace, w.resyncPeriod)
 	}
 	sdk.Handle(handler)
 	sdk.Run(context.TODO())


### PR DESCRIPTION
- Change sdk.Watch to add support for all namespaces for cluster cr

Config CR and App CR will still have to be deployed in the same namespace where kubedirector is running from.

- Change Makefile to delete kubedirectorclusters from all namespace during teardown
