### PR TITLE
Nit:  Fixed print datatype to reference the correct definition.

### DIFF
--- a/pkg/validator/cluster.go
+++ b/pkg/validator/cluster.go
@@ -341,7 +341,7 @@ func validateRoleStorageClass(
 				valErrors,
 				fmt.Sprintf(
 					badDefaultStorageClass,
-					globalStorageClass,
+					*globalStorageClass,
 				),
 			)
 		}


### PR DESCRIPTION
This fixes a compile-warning in this file noted during development.

Signed-off-by: Anne Marie Merritt <amm@bluedata.com>