### PR TITLE
Remove replicasets from the RBAC, issue #181

### DIFF
--- a/deploy/kubedirector/rbac-default.yaml
+++ b/deploy/kubedirector/rbac-default.yaml
@@ -39,7 +39,6 @@ rules:
   - apps
   resources:
   - deployments
-  - replicasets
   verbs:
   - "get"
 - apiGroups:


### PR DESCRIPTION
I removed replicasets from deploy/kubedirector/rbac-default.yaml and was unable to reproduce the error that I got before. It's safe to remove it.