### PR TITLE
Fix issue where storage.size KDC property is always required.

### DIFF
--- a/deploy/kubedirector/kubedirector_v1alpha1_kubedirectorcluster_crd.yaml
+++ b/deploy/kubedirector/kubedirector_v1alpha1_kubedirectorcluster_crd.yaml
@@ -84,14 +84,14 @@ spec:
                         value:
                           type: string
                   storage:
-                    # required: [size]
+                    required: [size]
                     properties:
-                        size:
-                          type: string
-                          pattern: '^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'
-                        storageClassName:
-                          type: string
-                          minLength: 1
+                      size:
+                        type: string
+                        pattern: '^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'
+                      storageClassName:
+                        type: string
+                        minLength: 1
         status:
           properties:
             state:

--- a/pkg/apis/kubedirector.bluedata.io/v1alpha1/kubedirectorcluster_types.go
+++ b/pkg/apis/kubedirector.bluedata.io/v1alpha1/kubedirectorcluster_types.go
@@ -81,15 +81,15 @@ type Role struct {
 	Name      string                  `json:"id"`
 	Members   *int32                  `json:"members"`
 	Resources v1.ResourceRequirements `json:"resources"`
-	Storage   ClusterStorage          `json:"storage,omitempty"`
+	Storage   *ClusterStorage         `json:"storage,omitempty"`
 	EnvVars   []v1.EnvVar             `json:"env,omitempty"`
 }
 
 // ClusterStorage defines the persistent storage size/type, if any, to be used
 // for certain specified directories of each container filesystem in a role.
 type ClusterStorage struct {
-	Size         string  `json:"size,omitempty"`
-	StorageClass *string `json:"storageClassName,omitempty"`
+	Size         string  `json:"size"`
+	StorageClass *string `json:"storageClassName"`
 }
 
 // RoleStatus describes the component objects of a virtual cluster role.

--- a/pkg/apis/kubedirector.bluedata.io/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/kubedirector.bluedata.io/v1alpha1/zz_generated.deepcopy.go
@@ -489,7 +489,11 @@ func (in *Role) DeepCopyInto(out *Role) {
 		**out = **in
 	}
 	in.Resources.DeepCopyInto(&out.Resources)
-	in.Storage.DeepCopyInto(&out.Storage)
+	if in.Storage != nil {
+		in, out := &in.Storage, &out.Storage
+		*out = new(ClusterStorage)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.EnvVars != nil {
 		in, out := &in.EnvVars, &out.EnvVars
 		*out = make([]v1.EnvVar, len(*in))

--- a/pkg/controller/kubedirectorcluster/roles.go
+++ b/pkg/controller/kubedirectorcluster/roles.go
@@ -498,7 +498,7 @@ func addMemberStatuses(
 		// avoid realloc, so we can safely grow it w/o disturbing our
 		// pointers to its elements.
 		var pvcName string
-		if role.roleSpec.Storage.Size == "" {
+		if role.roleSpec.Storage == nil {
 			pvcName = ""
 		} else {
 			pvcName = "pvc-" + memberName

--- a/pkg/executor/statefulset.go
+++ b/pkg/executor/statefulset.go
@@ -314,7 +314,7 @@ func getInitContainer(
 	persistDirs []string,
 ) (initContainer []v1.Container) {
 
-	if role.Storage.Size == "" {
+	if role.Storage == nil {
 		return
 	}
 
@@ -357,7 +357,7 @@ func getVolumeClaimTemplate(
 	pvcName string,
 ) (volTemplate []v1.PersistentVolumeClaim) {
 
-	if role.Storage.Size == "" {
+	if role.Storage == nil {
 		return
 	}
 
@@ -439,7 +439,7 @@ func generateVolumeMounts(
 	var volumeMounts []v1.VolumeMount
 	var volumes []v1.Volume
 
-	if role.Storage.Size != "" {
+	if role.Storage != nil {
 		volumeMounts = generateClaimMounts(pvcName, persistDirs)
 	}
 

--- a/pkg/validator/cluster.go
+++ b/pkg/validator/cluster.go
@@ -278,7 +278,7 @@ func validateRoleStorageClass(
 	numRoles := len(cr.Spec.Roles)
 	for i := 0; i < numRoles; i++ {
 		role := &(cr.Spec.Roles[i])
-		if role.Storage.Size == "" {
+		if role.Storage == nil {
 			// No storage section.
 			continue
 		}


### PR DESCRIPTION
I believe the new operator-sdk schema validator was getting confused because Role.Storage is an optional property but it was a struct and not a pointer. The same goes for ClusterStorage.Size. I made Role.Storage a pointer and it resolved the issue.