### PR TITLE
Investigate namespace watch behavior with new operator SDK #177 

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -85,12 +85,6 @@ func main() {
 
 	printVersion()
 
-	namespace, err := k8sutil.GetWatchNamespace()
-	if err != nil {
-		log.Error(err, "Failed to get watch namespace")
-		os.Exit(1)
-	}
-
 	// Get a config to talk to the apiserver
 	cfg, err := config.GetConfig()
 	if err != nil {
@@ -108,8 +102,10 @@ func main() {
 	}
 
 	// Create a new Cmd to provide shared dependencies and start components
+	// Watch all namespaces but reject KubeDirectorConfig requests in the
+	// validator when the namespace isn't the kubedirector namespace.
 	mgr, err := manager.New(cfg, manager.Options{
-		Namespace:          namespace,
+		Namespace:          "",
 		MapperProvider:     restmapper.NewDynamicRESTMapper,
 		MetricsBindAddress: fmt.Sprintf("%s:%d", metricsHost, metricsPort),
 	})

--- a/pkg/validator/kdsettings.go
+++ b/pkg/validator/kdsettings.go
@@ -17,6 +17,7 @@ package validator
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/bluek8s/kubedirector/pkg/shared"
 	"strings"
 
 	kdv1 "github.com/bluek8s/kubedirector/pkg/apis/kubedirector.bluedata.io/v1alpha1"
@@ -103,6 +104,24 @@ func admitKDConfigCR(
 	if jsonErr := json.Unmarshal(raw, &configCR); jsonErr != nil {
 		admitResponse.Result = &metav1.Status{
 			Message: "\n" + jsonErr.Error(),
+		}
+		return &admitResponse
+	}
+
+	// Only allow KubeDirectorConfig requests in the kubedirector namespace.
+	kdNamespace, err := shared.GetKubeDirectorNamespace()
+	if err != nil {
+		admitResponse.Result = &metav1.Status{
+			Message: "Failed to get kubedirector namespace",
+		}
+		return &admitResponse
+	}
+	if configCR.Namespace != kdNamespace {
+		admitResponse.Result = &metav1.Status{
+			Message: fmt.Sprintf("Invalid namespace '%s', must be '%s'.\n",
+				configCR.Namespace,
+				kdNamespace,
+			),
 		}
 		return &admitResponse
 	}


### PR DESCRIPTION
Restore namespace watch behavior prior to new operator SDK migration.
- KD watches ALL namespaces for KDC objects.
- KD watches only ITS OWN namespace for KD Config object.