### PR TITLE
camelCase our CR property names

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1105,7 +1105,6 @@
   analyzer-version = 1
   input-imports = [
     "github.com/go-logr/logr",
-    "github.com/go-openapi/spec",
     "github.com/google/uuid",
     "github.com/operator-framework/operator-sdk/pkg/k8sutil",
     "github.com/operator-framework/operator-sdk/pkg/leader",
@@ -1143,7 +1142,6 @@
     "k8s.io/code-generator/cmd/lister-gen",
     "k8s.io/gengo/args",
     "k8s.io/kube-openapi/cmd/openapi-gen",
-    "k8s.io/kube-openapi/pkg/common",
     "sigs.k8s.io/controller-runtime/pkg/client",
     "sigs.k8s.io/controller-runtime/pkg/client/config",
     "sigs.k8s.io/controller-runtime/pkg/controller",

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ sedignorecase =
 endif
 
 build_dir := build/_output
-configcli_dest := $(build_dir)/configcli.tgz
+configcli_dest := build/configcli.tgz
 goarch := amd64
 cgo_enabled := 0 
 
@@ -55,9 +55,9 @@ build: configcli pkg/apis/kubedirector.bluedata.io/v1alpha1/zz_generated.deepcop
 	@echo done
 	@echo
 
-configcli:  | $(build_dir)
+configcli:
 	@if [ -e $(configcli_dest) ]; then exit 0; fi;                             \
-     echo "\* Downloading configcli package ...";                              \
+     echo "* Downloading configcli package ...";                               \
      curl -L -o $(configcli_dest) https://github.com/bluek8s/configcli/archive/v$(configcli_version).tar.gz
 
 pkg/apis/kubedirector.bluedata.io/v1alpha1/zz_generated.deepcopy.go:  \
@@ -169,7 +169,7 @@ redeploy:
 	@set -e; \
         podname=`kubectl get -o jsonpath='{.items[0].metadata.name}' pods -l name=${project_name}`; \
         kubectl exec $$podname -- mv -f ${home_dir}/configcli.tgz ${home_dir}/configcli.tgz.bak || true; \
-        kubectl cp ${build_dir}/configcli.tgz $$podname:${home_dir}/configcli.tgz; \
+        kubectl cp ${configcli_dest} $$podname:${home_dir}/configcli.tgz; \
         kubectl exec $$podname -- chgrp 0 ${home_dir}/configcli.tgz; \
         kubectl exec $$podname -- chmod ug=rw ${home_dir}/configcli.tgz
 	@echo
@@ -307,7 +307,7 @@ undeploy:
 
 teardown: undeploy
 
-compile: version-check pkg/apis/kubedirector.bluedata.io/v1alpha1/zz_generated.deepcopy.go
+compile: version-check configcli pkg/apis/kubedirector.bluedata.io/v1alpha1/zz_generated.deepcopy.go
 	-rm -rf ${build_dir}
 	GOOS=linux GOARCH=${goarch} CGO_ENABLED=${cgo_enabled} \
         go build -o ${build_dir}/bin/${bin_name} ./cmd/manager

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -28,7 +28,7 @@ RUN mkdir -p ${USER_HOME} && \
     chown ${USER_UID}:0 ${USER_HOME} && \
     chmod ug=rwx ${USER_HOME}
 COPY ${OPERATOR_BUILD_SRC} ${OPERATOR}
-COPY build/_output/configcli.tgz ${USER_HOME}/configcli.tgz
+COPY build/configcli.tgz ${USER_HOME}/configcli.tgz
 RUN chown ${USER_UID}:0 ${OPERATOR} && \
     chmod ug=rwx ${OPERATOR} && \
     chown ${USER_UID}:0 ${USER_HOME}/configcli.tgz && \

--- a/deploy/example_catalog/cr-app-cassandra-3.11.json
+++ b/deploy/example_catalog/cr-app-cassandra-3.11.json
@@ -67,7 +67,7 @@
             }
         ],
         "defaultConfigPackage": {
-            "packageUrl": "https://s3.amazonaws.com/bluek8s/kubedirector/cassandra311/appconfig-3.1.tgz"
+            "packageURL": "https://s3.amazonaws.com/bluek8s/kubedirector/cassandra311/appconfig-3.1.tgz"
         },
         "roles": [
             {

--- a/deploy/example_catalog/cr-app-cassandra-3.11.json
+++ b/deploy/example_catalog/cr-app-cassandra-3.11.json
@@ -7,47 +7,47 @@
 
     "spec" : {
         "systemdRequired" : true,
-        "default_persist_dirs" : ["/data"],
+        "defaultPersistDirs" : ["/data"],
         "capabilities" : [
             "SYS_RESOURCE",
             "IPC_LOCK"
         ],
         "config": {
-            "config_meta": {},
-            "role_services": [
+            "configMeta": {},
+            "roleServices": [
                 {
-                    "service_ids": [
+                    "serviceIDs": [
                         "ssh",
                         "cassandra"
                     ],
-                    "role_id": "seed"
+                    "roleID": "seed"
                 },
                 {
-                    "service_ids": [
+                    "serviceIDs": [
                         "ssh",
                         "cassandra"
                     ],
-                    "role_id": "worker"
+                    "roleID": "worker"
                 }
             ],
-            "selected_roles": [
+            "selectedRoles": [
                 "seed",
                 "worker"
             ]
         },
-        "default_image_repo_tag": "docker.io/bluedata/cassandra:3.0",
+        "defaultImageRepoTag": "docker.io/bluedata/cassandra:3.0",
         "label": {
             "name": "Cassandra 3.11",
             "description": "Cassandra 3.11 on centos 7.x"
         },
-        "distro_id": "bluedata/cassandra311",
+        "distroID": "bluedata/cassandra311",
         "version": "3.1",
-        "config_schema_version": 7,
+        "configSchemaVersion": 7,
         "services": [
             {
                 "endpoint": {
                     "port": 22,
-                    "is_dashboard": false
+                    "isDashboard": false
                 },
                 "id": "ssh",
                 "label": {
@@ -56,8 +56,8 @@
             },
             {
                 "endpoint": {
-                    "url_scheme": "cql",
-                    "is_dashboard": false,
+                    "urlScheme": "cql",
+                    "isDashboard": false,
                     "port": 9042
                 },
                 "id": "cassandra",
@@ -66,8 +66,8 @@
                 }
             }
         ],
-        "default_config_package": {
-            "package_url": "https://s3.amazonaws.com/bluek8s/kubedirector/cassandra311/appconfig-3.1.tgz"
+        "defaultConfigPackage": {
+            "packageUrl": "https://s3.amazonaws.com/bluek8s/kubedirector/cassandra311/appconfig-3.1.tgz"
         },
         "roles": [
             {

--- a/deploy/example_catalog/cr-app-cdh5142cm.json
+++ b/deploy/example_catalog/cr-app-cdh5142cm.json
@@ -7,7 +7,7 @@
 
     "spec" : {
         "systemdRequired" : true,
-        "default_persist_dirs" : ["/data"],
+        "defaultPersistDirs" : ["/data"],
         "capabilities" : [
             "SYS_PACCT",
             "SYS_RESOURCE",
@@ -23,7 +23,7 @@
         ],
 
         "config": {
-            "config_meta": {
+            "configMeta": {
                 "streaming_jar": "/opt/cloudera/parcels/CDH/lib/hadoop-mapreduce/hadoop-streaming.jar",
                 "cdh_major_version": "CDH5",
                 "cdh_parcel_repo": "http://archive.cloudera.com/cdh5/parcels/5.14.2",
@@ -31,9 +31,9 @@
                 "cdh_parcel_version": "5.14.2-1.cdh5.14.2.p0.3",
                 "impala_jar_version": "0.1-SNAPSHOT"
             },
-            "role_services": [
+            "roleServices": [
                 {
-                    "service_ids": [
+                    "serviceIDs": [
                         "cdh-scm-srvr",
                         "cdh-scm-srvr-db",
                         "cdh-scm-agent",
@@ -52,36 +52,36 @@
                         "yarn-rm",
                         "hdfs-nn"
                     ],
-                    "role_id": "controller"
+                    "roleID": "controller"
                 },
                 {
-                    "service_ids": [
+                    "serviceIDs": [
                         "cdh-scm-agent",
                         "yarn-nm",
                         "ssh",
                         "hdfs-dn"
                     ],
-                    "role_id": "worker"
+                    "roleID": "worker"
                 }
             ],
-            "selected_roles": [
+            "selectedRoles": [
                 "controller",
                 "worker"
             ]
         },
-        "default_image_repo_tag": "docker.io/bluedata/cdh5142cm:3.0",
+        "defaultImageRepoTag": "docker.io/bluedata/cdh5142cm:3.0",
         "label": {
             "name": "CDH 5.14.2 on 7x with Cloudera Manager",
             "description": "CDH 5.14.2 with YARN support. Includes Pig, Hive, and Hue."
         },
-        "distro_id": "bluedata/cdh51427x",
+        "distroID": "bluedata/cdh51427x",
         "version": "1.4",
-        "config_schema_version": 7,
+        "configSchemaVersion": 7,
         "services": [
             {
                 "endpoint": {
-                    "is_dashboard": true,
-                    "url_scheme": "http",
+                    "isDashboard": true,
+                    "urlScheme": "http",
                     "port": 7180,
                     "path": "/"
                 },
@@ -107,8 +107,8 @@
                     "name": "ResourceManager"
                 },
                 "endpoint": {
-                    "is_dashboard": true,
-                    "url_scheme": "http",
+                    "isDashboard": true,
+                    "urlScheme": "http",
                     "port": 8088,
                     "path": "/cluster"
                 },
@@ -119,8 +119,8 @@
             },
             {
                 "endpoint": {
-                    "is_dashboard": true,
-                    "url_scheme": "http",
+                    "isDashboard": true,
+                    "urlScheme": "http",
                     "port": 8042,
                     "path": "/"
                 },
@@ -131,8 +131,8 @@
             },
             {
                 "endpoint": {
-                    "is_dashboard": true,
-                    "url_scheme": "http",
+                    "isDashboard": true,
+                    "urlScheme": "http",
                     "port": 50070,
                     "path": "/"
                 },
@@ -143,8 +143,8 @@
             },
             {
                 "endpoint": {
-                    "is_dashboard": true,
-                    "url_scheme": "http",
+                    "isDashboard": true,
+                    "urlScheme": "http",
                     "port": 50075,
                     "path": "/"
                 },
@@ -155,8 +155,8 @@
             },
             {
                 "endpoint": {
-                    "is_dashboard": true,
-                    "url_scheme": "http",
+                    "isDashboard": true,
+                    "urlScheme": "http",
                     "port": 19888,
                     "path": "/jobhistory"
                 },
@@ -185,8 +185,8 @@
             },
             {
                 "endpoint": {
-                    "is_dashboard": true,
-                    "url_scheme": "http",
+                    "isDashboard": true,
+                    "urlScheme": "http",
                     "port": 8888,
                     "path": "/"
                 },
@@ -216,7 +216,7 @@
             {
                 "endpoint": {
                     "port": 22,
-                    "is_dashboard": false
+                    "isDashboard": false
                 },
                 "id": "ssh",
                 "label": {
@@ -236,8 +236,8 @@
                 }
             }
         ],
-        "default_config_package":  {
-            "package_url": "https://s3.amazonaws.com/bluek8s/kubedirector/cdh5142cm/cdh5-cm-setup-1.4.tgz"
+        "defaultConfigPackage":  {
+            "packageUrl": "https://s3.amazonaws.com/bluek8s/kubedirector/cdh5142cm/cdh5-cm-setup-1.4.tgz"
         },
         "roles": [
             {

--- a/deploy/example_catalog/cr-app-cdh5142cm.json
+++ b/deploy/example_catalog/cr-app-cdh5142cm.json
@@ -237,7 +237,7 @@
             }
         ],
         "defaultConfigPackage":  {
-            "packageUrl": "https://s3.amazonaws.com/bluek8s/kubedirector/cdh5142cm/cdh5-cm-setup-1.4.tgz"
+            "packageURL": "https://s3.amazonaws.com/bluek8s/kubedirector/cdh5142cm/cdh5-cm-setup-1.4.tgz"
         },
         "roles": [
             {

--- a/deploy/example_catalog/cr-app-centos7.json
+++ b/deploy/example_catalog/cr-app-centos7.json
@@ -8,15 +8,15 @@
     "spec" : {
         "systemdRequired": true,
         "config": {
-            "role_services": [
+            "roleServices": [
                 {
-                    "service_ids": [
+                    "serviceIDs": [
                         "ssh"
                     ],
-                    "role_id": "vanilla_centos"
+                    "roleID": "vanilla_centos"
                 }
             ],
-            "selected_roles": [
+            "selectedRoles": [
                 "vanilla_centos"
             ]
         },
@@ -24,14 +24,14 @@
             "name": "CentOS 7.x utility.",
             "description": "CentOS 7x utility with no preinstalled apps"
         },
-        "distro_id": "bluedata/centos7x",
+        "distroID": "bluedata/centos7x",
         "version": "1.0",
-        "config_schema_version": 7,
+        "configSchemaVersion": 7,
         "services": [
             {
                 "endpoint": {
                     "port": 22,
-                    "is_dashboard": false
+                    "isDashboard": false
                 },
                 "id": "ssh",
                 "label": {
@@ -39,8 +39,8 @@
                 }
             }
         ],
-        "default_image_repo_tag": "docker.io/bluedata/centos7:4.1",
-        "default_config_package": null,
+        "defaultImageRepoTag": "docker.io/bluedata/centos7:4.1",
+        "defaultConfigPackage": null,
         "roles": [
             {
                 "cardinality": "1+",

--- a/deploy/example_catalog/cr-app-spark221e2.json
+++ b/deploy/example_catalog/cr-app-spark221e2.json
@@ -107,7 +107,7 @@
         ],
         "defaultImageRepoTag": "docker.io/bluedata/sparkbase:2.0",
         "defaultConfigPackage":  {
-            "packageUrl": "https://s3.amazonaws.com/bluek8s/kubedirector/spark221e2/appconfig-2.6.tgz"
+            "packageURL": "https://s3.amazonaws.com/bluek8s/kubedirector/spark221e2/appconfig-2.6.tgz"
         },
         "roles": [
             {

--- a/deploy/example_catalog/cr-app-spark221e2.json
+++ b/deploy/example_catalog/cr-app-spark221e2.json
@@ -8,32 +8,32 @@
     "spec" : {
         "systemdRequired": true,
         "config": {
-            "role_services": [
+            "roleServices": [
                 {
-                    "service_ids": [
+                    "serviceIDs": [
                         "ssh",
                         "spark",
                         "spark-master",
                         "spark-worker"
                     ],
-                    "role_id": "controller"
+                    "roleID": "controller"
                 },
                 {
-                    "service_ids": [
+                    "serviceIDs": [
                         "ssh",
                         "spark-worker"
                     ],
-                    "role_id": "worker"
+                    "roleID": "worker"
                 },
                 {
-                    "service_ids": [
+                    "serviceIDs": [
                         "ssh",
                         "jupyter-nb"
                     ],
-                    "role_id": "jupyter"
+                    "roleID": "jupyter"
                 }
             ],
-            "selected_roles": [
+            "selectedRoles": [
                 "controller",
                 "worker",
                 "jupyter"
@@ -43,14 +43,14 @@
             "name": "Spark 2.2.1 on centos7x with Jupyter",
             "description": "Spark 2.2.1 with Jupyter"
         },
-        "distro_id": "bluedata/spark221e2",
+        "distroID": "bluedata/spark221e2",
         "version": "2.6",
-        "config_schema_version": 7,
+        "configSchemaVersion": 7,
         "services": [
             {
                 "endpoint": {
                     "port": 22,
-                    "is_dashboard": false
+                    "isDashboard": false
                 },
                 "id": "ssh",
                 "label": {
@@ -59,9 +59,9 @@
             },
             {
                 "endpoint": {
-                    "url_scheme": "http",
+                    "urlScheme": "http",
                     "path": "/",
-                    "is_dashboard": true,
+                    "isDashboard": true,
                     "port": 8080
                 },
                 "id": "spark",
@@ -71,8 +71,8 @@
             },
             {
                 "endpoint": {
-                    "url_scheme": "spark",
-                    "is_dashboard": false,
+                    "urlScheme": "spark",
+                    "isDashboard": false,
                     "port": 7077
                 },
                 "id": "spark-master",
@@ -82,9 +82,9 @@
             },
             {
                 "endpoint": {
-                    "url_scheme": "http",
+                    "urlScheme": "http",
                     "path": "/",
-                    "is_dashboard": true,
+                    "isDashboard": true,
                     "port": 8081
                 },
                 "id": "spark-worker",
@@ -94,9 +94,9 @@
             },
             {
                 "endpoint": {
-                    "url_scheme": "http",
+                    "urlScheme": "http",
                     "path": "/",
-                    "is_dashboard": true,
+                    "isDashboard": true,
                     "port": 8888
                 },
                 "id": "jupyter-nb",
@@ -105,9 +105,9 @@
                 }
             }
         ],
-        "default_image_repo_tag": "docker.io/bluedata/sparkbase:2.0",
-        "default_config_package":  {
-            "package_url": "https://s3.amazonaws.com/bluek8s/kubedirector/spark221e2/appconfig-2.6.tgz"
+        "defaultImageRepoTag": "docker.io/bluedata/sparkbase:2.0",
+        "defaultConfigPackage":  {
+            "packageUrl": "https://s3.amazonaws.com/bluek8s/kubedirector/spark221e2/appconfig-2.6.tgz"
         },
         "roles": [
             {
@@ -119,7 +119,7 @@
                 "id": "worker"
             },
             {
-                "image_repo_tag": "docker.io/bluedata/jupyter:2.2",
+                "imageRepoTag": "docker.io/bluedata/jupyter:2.2",
                 "cardinality": "0+",
                 "id": "jupyter"
             }

--- a/deploy/example_catalog/cr-app-tensorflowcpu.json
+++ b/deploy/example_catalog/cr-app-tensorflowcpu.json
@@ -60,7 +60,7 @@
             }
         ],
         "defaultConfigPackage": {
-            "packageUrl" : "https://s3.amazonaws.com/bluek8s/kubedirector/tensorflowcpu/appconfig-1.8.tgz"
+            "packageURL" : "https://s3.amazonaws.com/bluek8s/kubedirector/tensorflowcpu/appconfig-1.8.tgz"
         },
         "roles": [
             {

--- a/deploy/example_catalog/cr-app-tensorflowcpu.json
+++ b/deploy/example_catalog/cr-app-tensorflowcpu.json
@@ -8,22 +8,22 @@
     "spec" : {
         "systemdRequired": true,
         "config": {
-            "role_services": [
+            "roleServices": [
                 {
-                    "service_ids": [
+                    "serviceIDs": [
                         "ssh",
                         "jupyter-nb"
                     ],
-                    "role_id": "controller"
+                    "roleID": "controller"
                 },
                 {
-                    "service_ids": [
+                    "serviceIDs": [
                         "ssh"
                     ],
-                    "role_id": "worker"
+                    "roleID": "worker"
                 }
             ],
-            "selected_roles": [
+            "selectedRoles": [
                 "controller",
                 "worker"
             ]
@@ -32,14 +32,14 @@
             "name": "Tensorflow distributed 1.9 on CPU with jupyter notebook & centos7x",
             "description": "TensorFlow1.9 CPU with centos7x"
         },
-        "distro_id": "bluedata/tensorflow19cpu",
+        "distroID": "bluedata/tensorflow19cpu",
         "version": "1.8",
-        "config_schema_version": 7,
+        "configSchemaVersion": 7,
         "services": [
             {
                 "endpoint": {
                     "port": 22,
-                    "is_dashboard": false
+                    "isDashboard": false
                 },
                 "id": "ssh",
                 "label": {
@@ -48,9 +48,9 @@
             },
             {
                 "endpoint": {
-                    "url_scheme": "http",
+                    "urlScheme": "http",
                     "path": "/",
-                    "is_dashboard": true,
+                    "isDashboard": true,
                     "port": 8888
                 },
                 "id": "jupyter-nb",
@@ -59,17 +59,17 @@
                 }
             }
         ],
-        "default_config_package": {
-            "package_url" : "https://s3.amazonaws.com/bluek8s/kubedirector/tensorflowcpu/appconfig-1.8.tgz"
+        "defaultConfigPackage": {
+            "packageUrl" : "https://s3.amazonaws.com/bluek8s/kubedirector/tensorflowcpu/appconfig-1.8.tgz"
         },
         "roles": [
             {
-                "image_repo_tag": "docker.io/bluedata/tensorflowcpu-jupyter:2.0",
+                "imageRepoTag": "docker.io/bluedata/tensorflowcpu-jupyter:2.0",
                 "cardinality": "1",
                 "id": "controller"
             },
             {
-                "image_repo_tag": "docker.io/bluedata/tensorflowcpu-jupyter:2.0",
+                "imageRepoTag": "docker.io/bluedata/tensorflowcpu-jupyter:2.0",
                 "cardinality": "0+",
                 "id": "worker"
             }

--- a/deploy/example_catalog/cr-app-tensorflowgpu.json
+++ b/deploy/example_catalog/cr-app-tensorflowgpu.json
@@ -8,17 +8,17 @@
     "spec": {
         "systemdRequired": true,
         "config": {
-            "config_meta": {},
+            "configMeta": {},
             "config_choices": [],
-            "role_services": [
+            "roleServices": [
                 {
-                    "service_ids": [
+                    "serviceIDs": [
                         "jupyter-nb"
                     ],
-                    "role_id": "controller"
+                    "roleID": "controller"
                 }
             ],
-            "selected_roles": [
+            "selectedRoles": [
                 "controller"
             ]
         },
@@ -26,16 +26,16 @@
             "name": "Tensorflow GPU with jupyter notebook",
             "description": "TensorFlow GPU with jupyter notebook"
         },
-        "default_image_repo_tag": "tensorflow/tensorflow:latest-gpu-jupyter",
-        "distro_id": "tensorflow/tensorflow:latest-gpu-jupyter",
+        "defaultImageRepoTag": "tensorflow/tensorflow:latest-gpu-jupyter",
+        "distroID": "tensorflow/tensorflow:latest-gpu-jupyter",
         "version": "latest-gpu-jupyter",
-        "config_schema_version": 7,
+        "configSchemaVersion": 7,
         "services": [
             {
                 "endpoint": {
-                    "url_scheme": "http",
+                    "urlScheme": "http",
                     "path": "/",
-                    "is_dashboard": true,
+                    "isDashboard": true,
                     "port": 8888
                 },
                 "id": "jupyter-nb",
@@ -44,12 +44,12 @@
                 }
             }
         ],
-        "default_config_package": null,
+        "defaultConfigPackage": null,
         "roles": [
             {
                 "cardinality": "1",
                 "id": "controller",
-                "min_resources" : {
+                "minResources" : {
                     "nvidia.com/gpu" : 1
                 }
             }

--- a/deploy/kubedirector/kubedirector_v1alpha1_kubedirectorapp_crd.yaml
+++ b/deploy/kubedirector/kubedirector_v1alpha1_kubedirectorapp_crd.yaml
@@ -45,9 +45,9 @@ spec:
               type: string
               minLength: 1
             defaultConfigPackage:
-              required: [packageUrl]
+              required: [packageURL]
               properties:
-                packageUrl:
+                packageURL:
                   type: string
                   pattern: '^(file|https?)://.+\.tgz$'
             services:
@@ -98,7 +98,7 @@ spec:
                     minLength: 1
                   configPackage:
                     properties:
-                      packageUrl:
+                      packageURL:
                         type: string
                         pattern: '^(file|https?)://.+\.tgz$'
                   persistDirs:

--- a/deploy/kubedirector/kubedirector_v1alpha1_kubedirectorapp_crd.yaml
+++ b/deploy/kubedirector/kubedirector_v1alpha1_kubedirectorapp_crd.yaml
@@ -22,7 +22,7 @@ spec:
         metadata:
           type: object
         spec:
-          required: [label, distro_id, version, roles, config, config_schema_version]
+          required: [label, distroID, version, roles, config, configSchemaVersion]
           properties:
             label:
               required: [name]
@@ -32,22 +32,22 @@ spec:
                   minLength: 1
                 description:
                   type: string
-            distro_id:
+            distroID:
               type: string
               minLength: 1
             version:
               type: string
               minLength: 1
-            config_schema_version:
+            configSchemaVersion:
               type: integer
               minimum: 7
-            default_image_repo_tag:
+            defaultImageRepoTag:
               type: string
               minLength: 1
-            default_config_package:
-              required: [package_url]
+            defaultConfigPackage:
+              required: [packageUrl]
               properties:
-                package_url:
+                packageUrl:
                   type: string
                   pattern: '^(file|https?)://.+\.tgz$'
             services:
@@ -75,12 +75,12 @@ spec:
                         type: integer
                         minimum: 1
                         maximum: 65535
-                      url_scheme:
+                      urlScheme:
                         type: string
                         minLength: 1
                       path:
                         type: string
-                      is_dashboard:
+                      isDashboard:
                         type: boolean
             roles:
               type: array
@@ -93,20 +93,20 @@ spec:
                   cardinality:
                     type: string
                     pattern: '^\d+\+?$'
-                  image_repo_tag:
+                  imageRepoTag:
                     type: string
                     minLength: 1
-                  config_package:
+                  configPackage:
                     properties:
-                      package_url:
+                      packageUrl:
                         type: string
                         pattern: '^(file|https?)://.+\.tgz$'
-                  persist_dirs:
+                  persistDirs:
                     type: array
                     items:
                       type: string
                       pattern: '^/.*[^/]$'
-                  min_resources:
+                  minResources:
                     properties:
                       memory:
                         type: string
@@ -122,31 +122,31 @@ spec:
                       amd.com/gpu:
                         type: integer
             config:
-              required: [selected_roles, role_services]
+              required: [selectedRoles, roleServices]
               properties:
-                config_meta:
+                configMeta:
                   type: object
-                selected_roles:
+                selectedRoles:
                   type: array
                   items:
                     type: string
                     minLength: 1
-                role_services:
+                roleServices:
                   type: array
                   items:
-                    required: [role_id, service_ids]
+                    required: [roleID, serviceIDs]
                     properties:
-                      role_id:
+                      roleID:
                         type: string
                         minLength: 1
-                      service_ids:
+                      serviceIDs:
                         type: array
                         items:
                           type: string
                           minLength: 1
                           maxLength: 15
                           pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
-            default_persist_dirs:
+            defaultPersistDirs:
               type: array
               items:
                 type: string

--- a/deploy/kubedirector/kubedirector_v1alpha1_kubedirectorcluster_crd.yaml
+++ b/deploy/kubedirector/kubedirector_v1alpha1_kubedirectorcluster_crd.yaml
@@ -128,9 +128,9 @@ spec:
                   fileInjections:
                     type: array
                     items:
-                      required: [srcUrl, destDir]
+                      required: [srcURL, destDir]
                       properties:
-                        srcUrl:
+                        srcURL:
                           type: string
                           pattern: '^https?://.+$'
                         destDir:
@@ -149,7 +149,7 @@ spec:
           properties:
             state:
               type: string
-            generationUid:
+            generationUID:
               type: string
             clusterService:
               type: string

--- a/deploy/kubedirector/kubedirector_v1alpha1_kubedirectorcluster_crd.yaml
+++ b/deploy/kubedirector/kubedirector_v1alpha1_kubedirectorcluster_crd.yaml
@@ -149,11 +149,11 @@ spec:
           properties:
             state:
               type: string
-            generation_uid:
+            generationUid:
               type: string
-            cluster_service:
+            clusterService:
               type: string
-            last_node_id:
+            lastNodeID:
               type: integer
             roles:
               type: array
@@ -161,7 +161,7 @@ spec:
                 properties:
                   id:
                     type: string
-                  stateful_set:
+                  statefulSet:
                     type: string
                   members:
                     type: array
@@ -169,7 +169,7 @@ spec:
                       properties:
                         pod:
                           type: string
-                        node_id:
+                        nodeID:
                           type: integer
                         service:
                           type: string

--- a/deploy/kubedirector/kubedirector_v1alpha1_kubedirectorconfig_crd.yaml
+++ b/deploy/kubedirector/kubedirector_v1alpha1_kubedirectorconfig_crd.yaml
@@ -38,7 +38,7 @@ spec:
               type: boolean
         status:
           properties:
-            generation_uid:
+            generationUid:
               type: string
             state:
               type: string

--- a/deploy/kubedirector/kubedirector_v1alpha1_kubedirectorconfig_crd.yaml
+++ b/deploy/kubedirector/kubedirector_v1alpha1_kubedirectorconfig_crd.yaml
@@ -38,7 +38,7 @@ spec:
               type: boolean
         status:
           properties:
-            generationUid:
+            generationUID:
               type: string
             state:
               type: string

--- a/doc/app-authoring.md
+++ b/doc/app-authoring.md
@@ -6,7 +6,7 @@ You should also be familiar with the process of [creating and managing virtual c
 
 The "deploy/example_catalog" directory contains several KubeDirectorApp resources that are applied when you do "make deploy". These determine what kinds of virtual clusters can be deployed using KubeDirectorCluster resources. Each resource also identifies the Docker image(s) and app setup package(s) that it uses. Before authoring new app definitions, examine these current examples and the contents of each component. Currently the Cassandra example is the easiest non-trivial example to understand, with TensorFlow a close runner-up.
 
-The simplest authoring task would involve making a modification to an existing image or setup package, and then making a modified KubeDirectorApp to reference the modified artifact (and possibly accomodate other roles or services). A modified version of an existing KubeDirectorApp should keep the same "distro_id" value but have a new "version" and a new metadata name; currently there is not a more sophisticated framework for KubeDirectorApp versioning.
+The simplest authoring task would involve making a modification to an existing image or setup package, and then making a modified KubeDirectorApp to reference the modified artifact (and possibly accomodate other roles or services). A modified version of an existing KubeDirectorApp should keep the same "distroID" value but have a new "version" and a new metadata name; currently there is not a more sophisticated framework for KubeDirectorApp versioning.
 
 A more complex authoring task is to make an app definition from scratch. The KubeDirectorApp, image(s), and any app setup packages will need to be iteratively developed and tested together.
 

--- a/pkg/apis/kubedirector.bluedata.io/v1alpha1/decode.go
+++ b/pkg/apis/kubedirector.bluedata.io/v1alpha1/decode.go
@@ -17,7 +17,7 @@ package v1alpha1
 import "encoding/json"
 
 // UnmarshalJSON for SetupPackage handles the unmarshalling of three
-// scenarios wrt 'default_config_package':
+// scenarios wrt 'defaultConfigPackage':
 //   1. omitted                 : IsSet==false
 //   2. explicitly set to null  : IsSet==true && IsNull==true
 //   3. Set to a valid object   : IsSet==true && IsNull==false

--- a/pkg/apis/kubedirector.bluedata.io/v1alpha1/kubedirectorapp_types.go
+++ b/pkg/apis/kubedirector.bluedata.io/v1alpha1/kubedirectorapp_types.go
@@ -15,7 +15,7 @@
 package v1alpha1
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -23,15 +23,15 @@ import (
 // +k8s:openapi-gen=true
 type KubeDirectorAppSpec struct {
 	Label               Label           `json:"label"`
-	DistroID            string          `json:"distro_id"`
+	DistroID            string          `json:"distroID"`
 	Version             string          `json:"version"`
 	SchemaVersion       int             `json:"schema_version"`
-	DefaultImageRepoTag *string         `json:"default_image_repo_tag,omitempty"`
-	DefaultSetupPackage SetupPackage    `json:"default_config_package,omitempty"`
+	DefaultImageRepoTag *string         `json:"defaultImageRepoTag,omitempty"`
+	DefaultSetupPackage SetupPackage    `json:"defaultConfigPackage,omitempty"`
 	Services            []Service       `json:"services"`
 	NodeRoles           []NodeRole      `json:"roles"`
 	Config              NodeGroupConfig `json:"config"`
-	DefaultPersistDirs  *[]string       `json:"default_persist_dirs"`
+	DefaultPersistDirs  *[]string       `json:"defaultPersistDirs"`
 	Capabilities        []v1.Capability `json:"capabilities"`
 	SystemdRequired     bool            `json:"systemdRequired"`
 }
@@ -74,7 +74,7 @@ type SetupPackage struct {
 
 // SetupPackageURL is the URL of the setup package.
 type SetupPackageURL struct {
-	PackageURL string `json:"package_url"`
+	PackageURL string `json:"packageUrl"`
 }
 
 // Service describes a network endpoint that should be exposed for external
@@ -89,10 +89,10 @@ type Service struct {
 // ServiceEndpoint describes the service network address and protocol, and
 // whether it should be displayed through a web browser.
 type ServiceEndpoint struct {
-	URLScheme   string `json:"url_scheme,omitempty"`
+	URLScheme   string `json:"urlScheme,omitempty"`
 	Port        *int32 `json:"port"`
 	Path        string `json:"path,omitempty"`
-	IsDashboard bool   `json:"is_dashboard,omitempty"`
+	IsDashboard bool   `json:"isDashboard,omitempty"`
 }
 
 // NodeRole describes a subset of virtual cluster members that will provide
@@ -101,10 +101,10 @@ type ServiceEndpoint struct {
 type NodeRole struct {
 	ID           string           `json:"id"`
 	Cardinality  string           `json:"cardinality"`
-	ImageRepoTag *string          `json:"image_repo_tag,omitempty"`
-	SetupPackage SetupPackage     `json:"config_package,omitempty"`
-	PersistDirs  *[]string        `json:"persist_dirs"`
-	MinResources *v1.ResourceList `json:"min_resources"`
+	ImageRepoTag *string          `json:"imageRepoTag,omitempty"`
+	SetupPackage SetupPackage     `json:"configPackage,omitempty"`
+	PersistDirs  *[]string        `json:"persistDirs"`
+	MinResources *v1.ResourceList `json:"minResources"`
 }
 
 // NodeGroupConfig identifies a set of roles, and the services on those roles.
@@ -112,15 +112,15 @@ type NodeRole struct {
 // active. Implementation of "config choices" will introduce other conditional
 // configs.
 type NodeGroupConfig struct {
-	RoleServices   []RoleService     `json:"role_services"`
-	SelectedRoles  []string          `json:"selected_roles"`
-	ConfigMetadata map[string]string `json:"config_meta"`
+	RoleServices   []RoleService     `json:"roleServices"`
+	SelectedRoles  []string          `json:"selectedRoles"`
+	ConfigMetadata map[string]string `json:"configMeta"`
 }
 
 // RoleService associates a service with a role.
 type RoleService struct {
-	ServiceIDs []string `json:"service_ids"`
-	RoleID     string   `json:"role_id"`
+	ServiceIDs []string `json:"serviceIDs"`
+	RoleID     string   `json:"roleID"`
 }
 
 func init() {

--- a/pkg/apis/kubedirector.bluedata.io/v1alpha1/kubedirectorapp_types.go
+++ b/pkg/apis/kubedirector.bluedata.io/v1alpha1/kubedirectorapp_types.go
@@ -25,7 +25,7 @@ type KubeDirectorAppSpec struct {
 	Label               Label           `json:"label"`
 	DistroID            string          `json:"distroID"`
 	Version             string          `json:"version"`
-	SchemaVersion       int             `json:"schema_version"`
+	SchemaVersion       int             `json:"configSchemaVersion"`
 	DefaultImageRepoTag *string         `json:"defaultImageRepoTag,omitempty"`
 	DefaultSetupPackage SetupPackage    `json:"defaultConfigPackage,omitempty"`
 	Services            []Service       `json:"services"`
@@ -74,7 +74,7 @@ type SetupPackage struct {
 
 // SetupPackageURL is the URL of the setup package.
 type SetupPackageURL struct {
-	PackageURL string `json:"packageUrl"`
+	PackageURL string `json:"packageURL"`
 }
 
 // Service describes a network endpoint that should be exposed for external

--- a/pkg/apis/kubedirector.bluedata.io/v1alpha1/kubedirectorcluster_types.go
+++ b/pkg/apis/kubedirector.bluedata.io/v1alpha1/kubedirectorcluster_types.go
@@ -39,7 +39,7 @@ type KubeDirectorClusterSpec struct {
 // +k8s:openapi-gen=true
 type KubeDirectorClusterStatus struct {
 	State          string       `json:"state"`
-	GenerationUID  string       `json:"generationUid"`
+	GenerationUID  string       `json:"generationUID"`
 	ClusterService string       `json:"clusterService"`
 	LastNodeID     int64        `json:"lastNodeID"`
 	Roles          []RoleStatus `json:"roles"`
@@ -95,7 +95,7 @@ type FilePermissions struct {
 // FileInjections specifies file injection spec, including
 // file permissions on the destination file
 type FileInjections struct {
-	SrcURL      string           `json:"srcUrl"`
+	SrcURL      string           `json:"srcURL"`
 	DestDir     string           `json:"destDir"`
 	Permissions *FilePermissions `json:"permissions,omitempty"`
 }

--- a/pkg/apis/kubedirector.bluedata.io/v1alpha1/kubedirectorcluster_types.go
+++ b/pkg/apis/kubedirector.bluedata.io/v1alpha1/kubedirectorcluster_types.go
@@ -39,9 +39,9 @@ type KubeDirectorClusterSpec struct {
 // +k8s:openapi-gen=true
 type KubeDirectorClusterStatus struct {
 	State          string       `json:"state"`
-	GenerationUID  string       `json:"generation_uid"`
-	ClusterService string       `json:"cluster_service"`
-	LastNodeID     int64        `json:"last_node_id"`
+	GenerationUID  string       `json:"generationUid"`
+	ClusterService string       `json:"clusterService"`
+	LastNodeID     int64        `json:"lastNodeID"`
 	Roles          []RoleStatus `json:"roles"`
 }
 
@@ -123,7 +123,7 @@ type ClusterStorage struct {
 // RoleStatus describes the component objects of a virtual cluster role.
 type RoleStatus struct {
 	Name        string         `json:"id"`
-	StatefulSet string         `json:"stateful_set"`
+	StatefulSet string         `json:"statefulSet"`
 	Members     []MemberStatus `json:"members"`
 }
 
@@ -133,7 +133,7 @@ type MemberStatus struct {
 	Service string `json:"service"`
 	PVC     string `json:"pvc,omitempty"`
 	State   string `json:"state"`
-	NodeID  int64  `json:"node_id"`
+	NodeID  int64  `json:"nodeID"`
 }
 
 func init() {

--- a/pkg/apis/kubedirector.bluedata.io/v1alpha1/kubedirectorconfig_types.go
+++ b/pkg/apis/kubedirector.bluedata.io/v1alpha1/kubedirectorconfig_types.go
@@ -29,7 +29,7 @@ type KubeDirectorConfigSpec struct {
 // KubeDirectorConfigStatus defines the observed state of KubeDirectorConfig.
 // +k8s:openapi-gen=true
 type KubeDirectorConfigStatus struct {
-	GenerationUID string `json:"generation_uid"`
+	GenerationUID string `json:"generationUid"`
 	State         string `json:"state"`
 }
 

--- a/pkg/apis/kubedirector.bluedata.io/v1alpha1/kubedirectorconfig_types.go
+++ b/pkg/apis/kubedirector.bluedata.io/v1alpha1/kubedirectorconfig_types.go
@@ -29,7 +29,7 @@ type KubeDirectorConfigSpec struct {
 // KubeDirectorConfigStatus defines the observed state of KubeDirectorConfig.
 // +k8s:openapi-gen=true
 type KubeDirectorConfigStatus struct {
-	GenerationUID string `json:"generationUid"`
+	GenerationUID string `json:"generationUID"`
 	State         string `json:"state"`
 }
 

--- a/pkg/controller/kubedirectorcluster/types.go
+++ b/pkg/controller/kubedirectorcluster/types.go
@@ -71,7 +71,7 @@ const (
 	nohup sh -c "` + appPrepStartscript + ` --configure
 	2> /opt/guestconfig/configure.stderr
 	1> /opt/guestconfig/configure.stdout;
-	echo -n $? > /opt/guestconfig/configure.status" &`
+	echo -n $? > ` + appPrepConfigStatus + `" &`
 	fileInjectionCommand = `mkdir -p %s && cd %s &&
 	curl -L %s -o %s &&
 	chmod %s %s &&

--- a/pkg/validator/app.go
+++ b/pkg/validator/app.go
@@ -40,7 +40,7 @@ type appPatchValue struct {
 }
 
 type packageURL struct {
-	URL string `json:"packageUrl"`
+	URL string `json:"packageURL"`
 }
 
 func (obj appPatchValue) MarshalJSON() ([]byte, error) {

--- a/pkg/validator/app.go
+++ b/pkg/validator/app.go
@@ -40,7 +40,7 @@ type appPatchValue struct {
 }
 
 type packageURL struct {
-	URL string `json:"package_url"`
+	URL string `json:"packageUrl"`
 }
 
 func (obj appPatchValue) MarshalJSON() ([]byte, error) {
@@ -92,7 +92,7 @@ func validateRefUniqueness(
 	return valErrors
 }
 
-// validateServiceRoles checks service_ids and role_id from role_services
+// validateServiceRoles checks serviceIDs and roleID from roleServices
 // in the config section, to ensure that they refer to legal/existing service
 // and role definitions. Any generated error messages will be added to the
 // input list and returned.
@@ -126,7 +126,7 @@ func validateServiceRoles(
 	return valErrors
 }
 
-// validateSelectedRoles checks the selected_roles array to make sure it
+// validateSelectedRoles checks the selectedRoles array to make sure it
 // only contains valid role IDs. Any generated error messages will be added to
 // the input list and returned.
 func validateSelectedRoles(
@@ -167,7 +167,7 @@ func validateRoles(
 			patches,
 			appPatchSpec{
 				Op:   "remove",
-				Path: "/spec/default_image_repo_tag",
+				Path: "/spec/defaultImageRepoTag",
 			},
 		)
 	}
@@ -181,7 +181,7 @@ func validateRoles(
 			patches,
 			appPatchSpec{
 				Op:   "remove",
-				Path: "/spec/default_config_package",
+				Path: "/spec/defaultConfigPackage",
 			},
 		)
 	}
@@ -192,7 +192,7 @@ func validateRoles(
 			patches,
 			appPatchSpec{
 				Op:   "remove",
-				Path: "/spec/default_persist_dirs",
+				Path: "/spec/defaultPersistDirs",
 			},
 		)
 	}
@@ -205,7 +205,7 @@ func validateRoles(
 					patches,
 					appPatchSpec{
 						Op:   "add",
-						Path: "/spec/roles/" + strconv.Itoa(index) + "/config_package",
+						Path: "/spec/roles/" + strconv.Itoa(index) + "/configPackage",
 						Value: appPatchValue{
 							stringValue: nil,
 						},
@@ -216,7 +216,7 @@ func validateRoles(
 					patches,
 					appPatchSpec{
 						Op:   "add",
-						Path: "/spec/roles/" + strconv.Itoa(index) + "/config_package",
+						Path: "/spec/roles/" + strconv.Itoa(index) + "/configPackage",
 						Value: appPatchValue{
 							packageURLValue: &packageURL{URL: *globalSetupPackageURL},
 						},
@@ -243,7 +243,7 @@ func validateRoles(
 				patches,
 				appPatchSpec{
 					Op:   "add",
-					Path: "/spec/roles/" + strconv.Itoa(index) + "/image_repo_tag",
+					Path: "/spec/roles/" + strconv.Itoa(index) + "/imageRepoTag",
 					Value: appPatchValue{
 						stringValue: globalImageRepoTag,
 					},
@@ -258,7 +258,7 @@ func validateRoles(
 					patches,
 					appPatchSpec{
 						Op:   "add",
-						Path: "/spec/roles/" + strconv.Itoa(index) + "/persist_dirs",
+						Path: "/spec/roles/" + strconv.Itoa(index) + "/persistDirs",
 						Value: appPatchValue{
 							stringSliceValue: globalPersistDirs,
 						},
@@ -273,7 +273,7 @@ func validateRoles(
 
 // validateServices checks each service for property constraints not
 // expressible in the schema. Currently this just means checking that the
-// service endpoint must specify url_schema if is_dashboard is true. Any
+// service endpoint must specify url_schema if isDashboard is true. Any
 // generated error messages will be added to the input list and returned.
 func validateServices(
 	appCR *kdv1.KubeDirectorApp,

--- a/pkg/validator/types.go
+++ b/pkg/validator/types.go
@@ -51,21 +51,21 @@ const (
 	modifiedProperty = "The %s property is read-only."
 	modifiedRole     = "Role(%s) properties other than the members count cannot be modified while role members exist."
 
-	invalidNodeRoleID     = "Invalid role_id(%s) in role_services array in config section. Valid roles: \"%s\""
-	invalidSelectedRoleID = "Invalid element(%s) in selected_roles array in config section. Valid roles: \"%s\""
-	invalidServiceID      = "Invalid service_id(%s) in role_services array in config section. Valid services: \"%s\""
+	invalidNodeRoleID     = "Invalid roleID(%s) in roleServices array in config section. Valid roles: \"%s\""
+	invalidSelectedRoleID = "Invalid element(%s) in selectedRoles array in config section. Valid roles: \"%s\""
+	invalidServiceID      = "Invalid service_id(%s) in roleServices array in config section. Valid services: \"%s\""
 
 	nonUniqueRoleID       = "Each id in the roles array must be unique."
 	nonUniqueServiceID    = "Each id in the services array must be unique."
-	nonUniqueSelectedRole = "Each element of selected_roles array in config section must be unique."
-	nonUniqueServiceRole  = "Each role_id in role_services array in config section must be unique."
+	nonUniqueSelectedRole = "Each element of selectedRoles array in config section must be unique."
+	nonUniqueServiceRole  = "Each roleID in roleServices array in config section must be unique."
 
 	invalidDefaultSecret = "Unable to fetch defaultSecret (%s) from (%s) namespace."
 	invalidSecret        = "Unable to fetch secret (%s) from (%s) namespace for role(%s)."
 
 	noDefaultImage = "Role(%s) has no specified image, and no top-level default image is specified."
 
-	noURLScheme = "The endpoint for service(%s) must include a url_scheme value because is_dashboard is true."
+	noURLScheme = "The endpoint for service(%s) must include a urlScheme value because isDashboard is true."
 
 	failedToPatch = "Internal error: failed to populate default values for unspecified properties."
 


### PR DESCRIPTION
This follows the style guide for Kubernetes resource properties, and "kubectl describe" works best with camelCased names. So let's bite the bullet.

One bullet not bitten here however is the naming scheme for the config data seen inside the container by config CLI. Changing those property names, although possibly nice for consistency with some parts of the CRs, would require also changing config CLI and app startscripts. I'm not sure if we want to do that, and even if we do, let's not bundle it into this change here.