### PR TITLE
fixes for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,20 +4,23 @@ go:
   - "1.12"
 
 env:
-  - DEP_VERSION="0.5.2" OPERATOR_SDK_VERSION="v0.8.1"
+  - DEP_VERSION="0.5.2" OPERATOR_SDK_VERSION="v0.8.1" ORIG_HOME="$GOPATH/src/github.com/bluek8s"
 
 before_install:
-  # if we're in a mainline build, don't make a symlink
-  # if we're not in a mainline build, symlink the proper dir to point to this dir.
-  - if [["github.com/BlueK8S" in $(TRAVIS_BUILD_DIR)]]; then echo "mainline build, no symlink"; else mkdir -p $GOPATH/src/github.com/BlueK8S && ln -s $(pwd) $GOPATH/src/github.com/BlueK8S/kubedirector ; fi
+  # Make sure we have the same build directory as the original repo.
+  - export buildroot=$(pwd); export origroot="$ORIG_HOME/kubedirector"; if [[ "$buildroot" != "$origroot" ]]; then cd; mkdir -p "$ORIG_HOME"; mv "$buildroot" "$origroot"; cd "$origroot"; fi
+
+install:
   # Get dep
   - curl -L -s https://github.com/golang/dep/releases/download/${DEP_VERSION}/dep-linux-amd64 -o $GOPATH/bin/dep
   - chmod +x $GOPATH/bin/dep
-  # Get the K8s operator-sdk
+  # Get the operator SDK
   - curl -L -s https://github.com/operator-framework/operator-sdk/releases/download/${OPERATOR_SDK_VERSION}/operator-sdk-${OPERATOR_SDK_VERSION}-x86_64-linux-gnu -o $GOPATH/bin/operator-sdk
   - chmod +x $GOPATH/bin/operator-sdk
+  # Get golint
   - go get -u golang.org/x/lint/golint
-  - make dep
+  # Populate vendor deps
+  - dep ensure -v
 
 script:
   - make compile


### PR DESCRIPTION
Primarily this is to get CI working on forks again (after the generated deepcopy code was removed from the repo), although also some general-goodness changes included.

* Actually move the cloned repo to the desired directory (bluek8s/kubedirector) rather than just making a symlink. At one point I thought this was needed to fix some operator-sdk behavior, now I'm not sure, but things work so I'm going to leave it this way.

* Don't do "make dep" (which does "dep ensure -v -update"); just do "dep ensure -v".

* Move some stuff from before_install into the install step. Partly just because these things make sense there, but also because if we don't define the install step, the default install step (which runs travis_install_go_dependencies) tries to do things that depend on the generated deepcopy code, before it is generated.