### PR TITLE
advertise the 0.3.0 release

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,4 @@
-# v0.3.0 - ???
+# v0.3.0 - Nov 16, 2019
 
 The most extensive change in this release is that the version of the operator SDK used by KubeDirector has been updated from v0.0.6 to v0.8.1. This picks up the operator SDK's transition to being based on the Kubernetes controller-runtime project. The effects from that change propagated into most corners of the KubeDirector codebase; while the functional difference is not generally visible to the end user, this should put us on a better footing for future updates and maintenance.
 

--- a/doc/kd-release-process.md
+++ b/doc/kd-release-process.md
@@ -37,6 +37,7 @@ In your local clone of your own repo, create the x.y.z-release-info branch from 
 Working on your local x.y.z-release-info branch:
 * Change references to the previous KD version to x.y.z in doc/quickstart.md - for example changing from "v0.1.0" to "v0.2.0".
 * Update/finalize HISTORY.md (i.e. release date and changes for version x.y.z).
+* Change the version string to "x.y.z-unstable" in version.go.
 
 Push your local x.y.z-release-info branch to your own GitHub repo.
 
@@ -53,6 +54,7 @@ In your local clone of your own repo, create the x.y.z-release branch from x.y.z
 Working on your local x.y.z-release branch:
 * Search docs for links that include "kubedirector/wiki/Type-Definitions" (i.e. CR docs) and replace each with a link to the appropriate version-snapshot page.
 * Change image version from unstable to x.y.z in Makefile and deployment-prebuilt.yaml.
+* Change the version string to "x.y.z" in version.go.
 * Build and push that KD image (modify Local.mk to enable push_default if necessary).
 * Regression test this image.
 

--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -36,13 +36,13 @@ So if you intend to later work with the KubeDirector source, you would clone the
     git clone https://github.com/bluek8s/kubedirector
 ```
 
-If you want to work with a specific released version of KubeDirector (instead of the tip of the master branch), now is the time to switch the repo to that. This is recommended, especially for your first time trying out KubeDirector. At the time of last updating this doc, the most recent KubeDirector release was v0.2.0; you can set the repo to that release as follows:
+If you want to work with a specific released version of KubeDirector (instead of the tip of the master branch), now is the time to switch the repo to that. This is recommended, especially for your first time trying out KubeDirector. At the time of last updating this doc, the most recent KubeDirector release was v0.3.0; you can set the repo to that release as follows:
 ```bash
     cd kubedirector
-    git checkout v0.2.0
+    git checkout v0.3.0
 ```
 
-If you have switched to a tagged version of KubeDirector in your local repo, make sure that when you read the doc files (like this one) you reference the files that are consistent with that version. The files in your local repo will be consistent; you could also reference the online files at a particular tag, for example the [doc files for v0.2.0](https://github.com/bluek8s/kubedirector/tree/v0.2.0/doc).
+If you have switched to a tagged version of KubeDirector in your local repo, make sure that when you read the doc files (like this one) you reference the files that are consistent with that version. The files in your local repo will be consistent; you could also reference the online files at a particular tag, for example the [doc files for v0.3.0](https://github.com/bluek8s/kubedirector/tree/v0.3.0/doc).
 
 Now you can deploy KubeDirector:
 ```bash

--- a/version/version.go
+++ b/version/version.go
@@ -2,5 +2,5 @@ package version
 
 var (
 	// Version is the current KubeDirector version
-	Version = "0.3.0"
+	Version = "0.3.0-unstable"
 )


### PR DESCRIPTION
This will be merged to master AFTER the v0.3.0 release tag has been created (to point to the 0.3.0 release-point commit).

In the changelog I've dated the release for tomorrow (the 16th) so that the 0.3.0 image can be test-soaked for a bit.