### PR TITLE
support any cluster domain

### DIFF
--- a/deploy/example_configs/cr-config-onprem.yaml
+++ b/deploy/example_configs/cr-config-onprem.yaml
@@ -11,3 +11,4 @@ metadata:
 spec:
   defaultServiceType: "NodePort"
   nativeSystemdSupport: true
+  clusterSvcDomainBase: ".svc.cluster.local"

--- a/deploy/kubedirector/kubedirector_v1alpha1_kubedirectorconfig_crd.yaml
+++ b/deploy/kubedirector/kubedirector_v1alpha1_kubedirectorconfig_crd.yaml
@@ -38,6 +38,8 @@ spec:
               type: boolean
             requiredSecretPrefix:
               type: string
+            clusterSvcDomainBase:
+              type: string
         status:
           properties:
             generationUID:

--- a/pkg/apis/kubedirector.bluedata.io/v1alpha1/kubedirectorconfig_types.go
+++ b/pkg/apis/kubedirector.bluedata.io/v1alpha1/kubedirectorconfig_types.go
@@ -25,6 +25,7 @@ type KubeDirectorConfigSpec struct {
 	ServiceType          *string `json:"defaultServiceType,omitempty"`
 	NativeSystemdSupport *bool   `json:"nativeSystemdSupport"`
 	RequiredSecretPrefix *string `json:"requiredSecretPrefix,omitempty"`
+	ClusterSvcDomainBase *string `json:"clusterSvcDomainBase"`
 }
 
 // KubeDirectorConfigStatus defines the observed state of KubeDirectorConfig.

--- a/pkg/catalog/configmeta.go
+++ b/pkg/catalog/configmeta.go
@@ -21,7 +21,7 @@ import (
 
 	kdv1 "github.com/bluek8s/kubedirector/pkg/apis/kubedirector.bluedata.io/v1alpha1"
 	"github.com/bluek8s/kubedirector/pkg/shared"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 )
 
 // allServiceRefkeys is a subroutine of getServices, used to generate a
@@ -228,7 +228,7 @@ func ConfigmetaGenerator(
 	// returned function, since we won't always actually need to call the
 	// function. However it's really handy to know up front if any errors
 	// would be generated.
-	domain := cr.Status.ClusterService + "." + cr.Namespace + shared.DomainBase
+	domain := cr.Status.ClusterService + "." + cr.Namespace + shared.GetDefaultSvcClusterDomainBase()
 	perNodeConfig := make(map[string]*node)
 	c := clusterBaseConfig(cr, appCR, membersForRole, domain)
 	for roleName, members := range membersForRole {

--- a/pkg/catalog/configmeta.go
+++ b/pkg/catalog/configmeta.go
@@ -228,7 +228,7 @@ func ConfigmetaGenerator(
 	// returned function, since we won't always actually need to call the
 	// function. However it's really handy to know up front if any errors
 	// would be generated.
-	domain := cr.Status.ClusterService + "." + cr.Namespace + shared.GetDefaultSvcClusterDomainBase()
+	domain := cr.Status.ClusterService + "." + cr.Namespace + shared.GetSvcClusterDomainBase()
 	perNodeConfig := make(map[string]*node)
 	c := clusterBaseConfig(cr, appCR, membersForRole, domain)
 	for roleName, members := range membersForRole {

--- a/pkg/controller/kubedirectorcluster/members.go
+++ b/pkg/controller/kubedirectorcluster/members.go
@@ -952,7 +952,7 @@ func fqdnsList(
 		s := []string{
 			m.Pod,
 			cr.Status.ClusterService,
-			cr.Namespace + shared.DomainBase,
+			cr.Namespace + shared.GetDefaultSvcClusterDomainBase(),
 		}
 		return strings.Join(s, ".")
 	}

--- a/pkg/controller/kubedirectorcluster/members.go
+++ b/pkg/controller/kubedirectorcluster/members.go
@@ -952,7 +952,7 @@ func fqdnsList(
 		s := []string{
 			m.Pod,
 			cr.Status.ClusterService,
-			cr.Namespace + shared.GetDefaultSvcClusterDomainBase(),
+			cr.Namespace + shared.GetSvcClusterDomainBase(),
 		}
 		return strings.Join(s, ".")
 	}

--- a/pkg/shared/globalconfig.go
+++ b/pkg/shared/globalconfig.go
@@ -75,10 +75,10 @@ func GetDefaultServiceType() string {
 	return DefaultServiceType
 }
 
-// GetDefaultSvcClusterDomainBase extracts the default svc cluster domain
+// GetSvcClusterDomainBase extracts the default svc cluster domain
 // from the globalConfig CR data if present, otherwise returns the default
 // value (NodePort).
-func GetDefaultSvcClusterDomainBase() string {
+func GetSvcClusterDomainBase() string {
 
 	globalConfigLock.RLock()
 	defer globalConfigLock.RUnlock()

--- a/pkg/shared/globalconfig.go
+++ b/pkg/shared/globalconfig.go
@@ -75,6 +75,19 @@ func GetDefaultServiceType() string {
 	return DefaultServiceType
 }
 
+// GetDefaultSvcClusterDomainBase extracts the default svc cluster domain
+// from the globalConfig CR data if present, otherwise returns the default
+// value (NodePort).
+func GetDefaultSvcClusterDomainBase() string {
+
+	globalConfigLock.RLock()
+	defer globalConfigLock.RUnlock()
+	if globalConfig != nil && globalConfig.Spec.ClusterSvcDomainBase != nil {
+		return *globalConfig.Spec.ClusterSvcDomainBase
+	}
+	return DefaultSvcDomainBase
+}
+
 // RemoveGlobalConfig removes the current globalConfig
 func RemoveGlobalConfig() {
 

--- a/pkg/shared/types.go
+++ b/pkg/shared/types.go
@@ -15,9 +15,9 @@
 package shared
 
 const (
-	// DomainBase contains the initial segments used to build FQDNs
+	// DefaultSvcDomainBase contains the initial segments used to build FQDNs
 	// for cluster members
-	DomainBase = ".svc.cluster.local"
+	DefaultSvcDomainBase = ".svc.cluster.local"
 
 	// KubeDirectorNamespaceEnvVar is the constant for env variable MY_NAMESPACE
 	// which is the namespace of the kubedirector pod.

--- a/pkg/triple/triple.go
+++ b/pkg/triple/triple.go
@@ -57,7 +57,7 @@ func NewCA(name string) (*KeyPair, error) {
 }
 
 // NewServerKeyPair ...
-func NewServerKeyPair(ca *KeyPair, commonName, svcName, svcNamespace, dnsDomain string, ips, hostnames []string) (*KeyPair, error) {
+func NewServerKeyPair(ca *KeyPair, commonName, svcName, svcNamespace string, ips, hostnames []string) (*KeyPair, error) {
 
 	key, err := certutil.NewPrivateKey()
 	if err != nil {
@@ -69,7 +69,6 @@ func NewServerKeyPair(ca *KeyPair, commonName, svcName, svcNamespace, dnsDomain 
 		svcName,
 		namespacedName,
 		fmt.Sprintf("%s.svc", namespacedName),
-		fmt.Sprintf("%s.svc.%s", namespacedName, dnsDomain),
 	}
 
 	altNames := certutil.AltNames{}

--- a/pkg/validator/config.go
+++ b/pkg/validator/config.go
@@ -215,6 +215,21 @@ func admitKDConfigCR(
 		)
 	}
 
+	// Populate the default ClusterSvcDomainBase if necessary
+	if configCR.Spec.ClusterSvcDomainBase == nil {
+		svcDomainBase := shared.DefaultSvcDomainBase
+		patches = append(
+			patches,
+			configPatchSpec{
+				Op:   "add",
+				Path: "/spec/clusterSvcDomainBase",
+				Value: configPatchValue{
+					ValueStr: &svcDomainBase,
+				},
+			},
+		)
+	}
+
 	if len(valErrors) == 0 {
 		if len(patches) != 0 {
 			patchResult, patchErr := json.Marshal(patches)

--- a/pkg/validator/util.go
+++ b/pkg/validator/util.go
@@ -172,7 +172,6 @@ func createCertsSecret(
 		strings.Join([]string{serviceName, namespace, "svc"}, "."),
 		serviceName,
 		namespace,
-		"cluster.local",
 		[]string{},
 		[]string{},
 	)


### PR DESCRIPTION
Fix for issue 
https://github.com/bluek8s/kubedirector/issues/57

I didn't want to use /etc/resolv.conf. We have to rely on the format populated by k8s, which is kind of fragile. So ended up changing the Config CRD, so user can define the actual domain. Also when we create the mutating webhook we don't need to use a full domain name for creating the self-signed cert. 
