### PR TITLE
Set command

### DIFF
--- a/deploy/kubedirector/deployment-prebuilt.yaml
+++ b/deploy/kubedirector/deployment-prebuilt.yaml
@@ -15,6 +15,7 @@ spec:
       containers:
         - name: kubedirector
           image: bluek8s/kubedirector:unstable
+          command: /usr/local/bin/entrypoint
           ports:
           - containerPort: 60000
             name: metrics

--- a/deploy/kubedirector/deployment-prebuilt.yaml
+++ b/deploy/kubedirector/deployment-prebuilt.yaml
@@ -15,7 +15,7 @@ spec:
       containers:
         - name: kubedirector
           image: bluek8s/kubedirector:unstable
-          command: /usr/local/bin/entrypoint
+          command: [/usr/local/bin/entrypoint]
           ports:
           - containerPort: 60000
             name: metrics


### PR DESCRIPTION
@joel-bluedata mentioned that we were having some problems bringing up the kubedirector process when the host that the pod lived on was restarted. Took a look, found that we weren't pointing kubernetes to a command to run when it started the pod. Added a command, redeployed kubedirector, rebooted the host, and:

```bash
➜  ~ kubectl exec -it kubedirector-5dc767bbf9-6sbx9 bash -n kubedirector
bash-4.2$ pstree
entrypoint-+-cat
           `-kubedirector---12*[{kubedirector}]
bash-4.2$ exit
➜  ~
```