### PR TITLE
omnibus of improvements from work on other forks

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,12 +2,12 @@
 
 
 [[projects]]
-  digest = "1:5ef9a8852f524c7d515adf3262fa1b5d20a10c5c8f33305fdd075bce2c223912"
+  digest = "1:3fde872e9f3a28fba25ceba899bd5ca96d97cd5371ecdeb37bfe30b7fd314144"
   name = "cloud.google.com/go"
   packages = ["compute/metadata"]
   pruneopts = "NT"
-  revision = "5d03b9fdabc3f75630183d940a54b0047106bf8a"
-  version = "v0.48.0"
+  revision = "b4cdc8d6eb508c4e74df26094d1adb678c87f818"
+  version = "v0.51.0"
 
 [[projects]]
   digest = "1:6974cb842e66a4600006200e47a067278ea5671d4f7114be67c01a3af5affa7d"
@@ -57,12 +57,12 @@
   revision = "de5bf2ad457846296e2031421a34e2568e304e35"
 
 [[projects]]
-  digest = "1:680b63a131506e668818d630d3ca36123ff290afa0afc9f4be21940adca3f27d"
+  digest = "1:6d2d39ac81bb11ea9a3acb10f054b4a2efb654cba96cb1c9aff88b48ee41f2c6"
   name = "github.com/appscode/jsonpatch"
   packages = ["."]
   pruneopts = "NT"
-  revision = "7c0e3b262f30165a8ec3d0b4c6059fd92703bfb2"
-  version = "1.0.0"
+  revision = "7f760186a63d02954613b9b22de68a5b2cb2b1bf"
+  version = "v1.0.1"
 
 [[projects]]
   digest = "1:c819830f4f5ef85874a90ac3cbcc96cd322c715f5c96fbe4722eacd3dafbaa07"
@@ -180,27 +180,27 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:97b95774863237dc7589e326d064713cc0372c9ecadbe2e4e7e560a949cbb45d"
+  digest = "1:cdf42620f9a19b1717ee2d35c99cac2114eb5b9361de9b632e2d6ba1d35e6cc1"
   name = "github.com/go-openapi/spec"
   packages = ["."]
   pruneopts = "NT"
-  revision = "744796356cda816d3166723c28d45c5f58f590df"
+  revision = "772572fd19ebcc983369e53bfaed4bde2077fe0c"
 
 [[projects]]
   digest = "1:b318f36b1725220c1580b27504b8ee9d33a2a8e2db58f28c176edf6f0d1b7fb2"
   name = "github.com/go-openapi/swag"
   packages = ["."]
   pruneopts = "NT"
-  revision = "c3d0f7896d589f3babb99eea24bbc7de98108e72"
-  version = "v0.19.5"
+  revision = "8a84ec635f1b280a7062edeab609f0667a053248"
+  version = "v0.19.6"
 
 [[projects]]
   digest = "1:fcd8ddc48ce648d5fbb36029fe3dd98f29c03377eea5c4a3c436701b0e3f2774"
   name = "github.com/gobuffalo/envy"
   packages = ["."]
   pruneopts = "NT"
-  revision = "909ea676d4c90832fefbf55a5a4fb04d8bef8931"
-  version = "v1.7.1"
+  revision = "dc9565002201aca1286f8d6262f5cd568226562a"
+  version = "v1.8.1"
 
 [[projects]]
   digest = "1:c3050a9f4b141fcc3ef805c8b3e8e8242676557755ffb9d2707c26530cd71c9d"
@@ -223,11 +223,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:91f62b7cc037b5f5c68fc9d9ab3566226f287e9e2c043a81e9176b90e822218a"
+  digest = "1:d62eef3a099f2ae9bc12cfa0e00f9a5dd26270a38f213e07da85d4419619c5c0"
   name = "github.com/golang/groupcache"
   packages = ["lru"]
   pruneopts = "NT"
-  revision = "611e8accdfc92c4187d399e95ce826046d4c8d73"
+  revision = "215e87163ea771ffa998a96c611387313bb5a403"
 
 [[projects]]
   digest = "1:440a3032b9e2db5bbf14535c63caf0e886f13d4f1d128a4a4d9deb03f924aa0c"
@@ -285,7 +285,7 @@
   version = "v0.3.1"
 
 [[projects]]
-  digest = "1:c235297e063b04f4dc4af048344b4549512df03ab14747d9ed56cc140f58b9da"
+  digest = "1:f21709256ed66ba16eaa951b63304dadbbc5ae95db8c3ab735721d233e0c22d6"
   name = "github.com/gophercloud/gophercloud"
   packages = [
     ".",
@@ -297,8 +297,8 @@
     "pagination",
   ]
   pruneopts = "NT"
-  revision = "a8bdb516e71d7c586306501b30b80f06f53c013e"
-  version = "v0.6.0"
+  revision = "c99da270f3181ddc1b3d5c5e7d040971024cb71a"
+  version = "v0.7.0"
 
 [[projects]]
   branch = "master"
@@ -351,12 +351,12 @@
   version = "v1.3.0"
 
 [[projects]]
-  digest = "1:04395d3256130279b719634054b20f73fed0e7478b264544cb0f615f89d7bba9"
+  digest = "1:5e349fd839ecbd417975da64c8b69764d78859c5cf9817460b4fb763852eb44e"
   name = "github.com/json-iterator/go"
   packages = ["."]
   pruneopts = "NT"
-  revision = "03217c3e97663914aec3faafde50d081f197a0a2"
-  version = "v1.1.8"
+  revision = "acfec88f7a0d5140ace3dcdbee10184e3684a9e1"
+  version = "v1.1.9"
 
 [[projects]]
   digest = "1:5181790e1f11c6b9cb42c70c5b902926c5e696b1e71bc24d4f82e6862ab3d078"
@@ -442,12 +442,12 @@
   version = "v3.0.0"
 
 [[projects]]
-  digest = "1:14715f705ff5dfe0ffd6571d7d201dd8e921030f8070321a79380d8ca4ec1a24"
+  digest = "1:61df16db1199caa2523f1c19b870cb465af1749f74d6649c694510c3f2b5f823"
   name = "github.com/pkg/errors"
   packages = ["."]
   pruneopts = "NT"
-  revision = "ba968bfe8b2f7e042a574c888954fccecfa385b4"
-  version = "v0.8.1"
+  revision = "49f8f617296114c890ae0b7ac18c5953d2b1ca0f"
+  version = "v0.9.0"
 
 [[projects]]
   digest = "1:e2fde2e6d46505f0d91d6d350410ca82f382870c90d6b05227302f45f78828a7"
@@ -462,15 +462,15 @@
   version = "v0.9.4"
 
 [[projects]]
-  branch = "master"
-  digest = "1:c2cc5049e927e2749c0d5163c9f8d924880d83e84befa732b9aad0b6be227bed"
+  digest = "1:982be0b5396e16a663697899ce69cc7b1e71ddcae4153af157578d4dc9bc3f88"
   name = "github.com/prometheus/client_model"
   packages = ["go"]
   pruneopts = "NT"
-  revision = "14fe0d1b01d4d5fc031dd4bec1823bd3ebbe8016"
+  revision = "d1d2010b5beead3fa1c5f271a5cf626e40b3ad6e"
+  version = "v0.1.0"
 
 [[projects]]
-  digest = "1:b1945ace19342a6519ba481285c65a4a3f5c8aff0d940dec53c62206dc68264e"
+  digest = "1:b46fc5ce8a3af7862c7ec11e6fb787771abe21085d5890256d48304affa8933a"
   name = "github.com/prometheus/common"
   packages = [
     "expfmt",
@@ -478,11 +478,11 @@
     "model",
   ]
   pruneopts = "NT"
-  revision = "287d3e634a1e550c9e463dd7e5a75a422c614505"
-  version = "v0.7.0"
+  revision = "629b6ff9b3aafafba54ab96663903fde9544f037"
+  version = "v0.8.0"
 
 [[projects]]
-  digest = "1:89b4547e3a4ba89ce68dea2e6e6bbf492b561aab450252550af208109a761eed"
+  digest = "1:55bcf4202ec2033988abce4932b6ad0f424fbd3d408e80368c24a23c406998d8"
   name = "github.com/prometheus/procfs"
   packages = [
     ".",
@@ -490,11 +490,11 @@
     "internal/util",
   ]
   pruneopts = "NT"
-  revision = "8a055596020d692cf491851e47ba3e302d9f90ce"
-  version = "v0.0.6"
+  revision = "6d489fc7f1d9cd890a250f3ea3431b1744b9623f"
+  version = "v0.0.8"
 
 [[projects]]
-  digest = "1:3dbe838027ffb0a1bdff516b2d6aa782d3802f8e1716738de9c1a7ff92232bb4"
+  digest = "1:a1f964896c3880fc568b37f42b6a605dc54d2ce0686bf5393ce5a5918aeac980"
   name = "github.com/rogpeppe/go-internal"
   packages = [
     "modfile",
@@ -502,8 +502,8 @@
     "semver",
   ]
   pruneopts = "NT"
-  revision = "d89504fbbf2c313df24867a5ffafcc9b847961ff"
-  version = "v1.5.0"
+  revision = "bc89b17ba21ce5b8a495fa55a94e3fe32ecf4ed8"
+  version = "v1.5.2"
 
 [[projects]]
   digest = "1:49b6e0d199dc20969bf7c9d14647313e1dd1b102178fad4ca999d8a9584edfab"
@@ -552,12 +552,12 @@
   version = "v0.19.3"
 
 [[projects]]
-  digest = "1:0e70a2bca7289a57e94d6452e05667d49319bba2a7457a2d1b3323bb1cd1d7d9"
+  digest = "1:f0635c284d572c51bf57b5e8b2d66ad7c46ea474fc6deb0061f996dc28f97d13"
   name = "go.uber.org/atomic"
   packages = ["."]
   pruneopts = "NT"
-  revision = "9dc4df04d0d1c39369750a9f6c32c39560672089"
-  version = "v1.5.0"
+  revision = "40ae6a40a970ef4cdbffa7b24b280e316db8accc"
+  version = "v1.5.1"
 
 [[projects]]
   digest = "1:a1440ebbcb42dca581a6d557749cb72770e17b3bf7751f953ae2b0606cd65013"
@@ -592,11 +592,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:00f7cb110ec083a03baf86042414b205078e73bd8d0bb4b7c0e7cd738b880e6a"
+  digest = "1:e3bed3cbd48cdd86ada32ecb34ec032c95f79581f28401dfb9b70f7323e269bd"
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
   pruneopts = "NT"
-  revision = "e1110fd1c708ef015366ea01799a23c459593c47"
+  revision = "61a87790db17894570dfb32dbaa0a4af9ce60cb4"
 
 [[projects]]
   branch = "master"
@@ -607,11 +607,11 @@
     "golint",
   ]
   pruneopts = "NT"
-  revision = "16217165b5de779cb6a5e4fc81fa9c1166fda457"
+  revision = "fdd1cda4f05fd1fd86124f0ef9ce31a0b72c8448"
 
 [[projects]]
   branch = "master"
-  digest = "1:024e423b75a02b8cf44579f54fb434b82ab68694969fa6828f4eada4ec7e731b"
+  digest = "1:9502fc6cda0a919c2790e1123ee4beeb437a5d5886d25b0d78f681e76613c4fa"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -624,11 +624,11 @@
     "trace",
   ]
   pruneopts = "NT"
-  revision = "2180aed2234323691e9fd264fb1d32d20ff04b27"
+  revision = "c0dbc17a35534bf2e581d7a942408dc936316da4"
 
 [[projects]]
   branch = "master"
-  digest = "1:39b3fcfdc10f07969cf1e9fcb901bbb600083fff9880739f4ea596b48656c5a1"
+  digest = "1:332075dc741b89b2957b5eb0fec28cf2b681d46ad04c07bb56187c98b737779f"
   name = "golang.org/x/oauth2"
   packages = [
     ".",
@@ -638,7 +638,7 @@
     "jwt",
   ]
   pruneopts = "NT"
-  revision = "0f29369cfe4552d0e4bcddc57cc75f4d7e672a33"
+  revision = "bf48bf16ab8d622ce64ec6ce98d2c98f916b6303"
 
 [[projects]]
   branch = "master"
@@ -650,14 +650,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:9fb304babc294681696a73b55814456194c6cc799b29b5490808bba5795ae8a0"
+  digest = "1:fb17e0f7d116c8f0aa7b2d2f2c9dbb7ca6e13bc654a8df24e8eae67e11a1bf30"
   name = "golang.org/x/sys"
   packages = [
     "unix",
     "windows",
   ]
   pruneopts = "NT"
-  revision = "4c7a9d0fe056d9d1de37e1409ca8a5c17accb46a"
+  revision = "86b910548bc16777f40503131aa424ae0a092199"
 
 [[projects]]
   digest = "1:348fa8283a7c60b5b71ce04d27b37f7c0fce552d4d0b463b5b3ebbd1840d3f1a"
@@ -695,7 +695,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:da10a3d9f70b37f212db7c5c76fdc8d4fd09a0dfc48e1590816cc0a5022668d8"
+  digest = "1:48ce485923ff73d3356bee2426c228a23938994e99fe74fa5d07567b5e4e6444"
   name = "golang.org/x/tools"
   packages = [
     "go/analysis",
@@ -715,18 +715,17 @@
     "internal/imports",
     "internal/module",
     "internal/semver",
-    "internal/span",
   ]
   pruneopts = "NT"
-  revision = "4191b8cbba092238a318a71cdff48b20b4e1e5d8"
+  revision = "544dc8ea2d5f86eca70831850e4d5fe51174a016"
 
 [[projects]]
-  digest = "1:7a87ba69381f0980d18393442ffce0cea39ac14fef1f981d46e717e223531fa9"
+  digest = "1:843430535880602ecf7160e4d057553fe94778834248662c0ca0cebdd77b37bc"
   name = "google.golang.org/api"
   packages = ["support/bundler"]
   pruneopts = "NT"
-  revision = "4f42dad4690a01d7f6fa461106c63889ff1be027"
-  version = "v0.13.0"
+  revision = "aa5d4e47691e7ae1aebb5221ff8e4beea23fad72"
+  version = "v0.15.0"
 
 [[projects]]
   digest = "1:ef33a89dbeefa3d834fff6b9e0b342311d4bf1a90cbe9c646e79797940b61c88"
@@ -749,7 +748,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:272f1577c10ace5f33384f345535d9da64ffa93ad150c772c4f08887cb639fc2"
+  digest = "1:8198908d9d099e162d5598408a5f433ca2d9f0916becddf9de62c80375fa76b3"
   name = "google.golang.org/genproto"
   packages = [
     "googleapis/api/httpbody",
@@ -757,13 +756,14 @@
     "protobuf/field_mask",
   ]
   pruneopts = "NT"
-  revision = "6bbd007550de91f00332b51032ea2cd88b87e799"
+  revision = "e1de0a7b01eb2fc11d735e4bfb79d2e53ec9edb3"
 
 [[projects]]
-  digest = "1:8209a15687f29fb9c5fc49d288a611d71b3f40590acb384ab1d472efa5a46e15"
+  digest = "1:08bd05d2b511385280e54148c2535340162d3f432dc932eaf040eb3a1f0a3592"
   name = "google.golang.org/grpc"
   packages = [
     ".",
+    "attributes",
     "backoff",
     "balancer",
     "balancer/base",
@@ -800,8 +800,8 @@
     "tap",
   ]
   pruneopts = "NT"
-  revision = "1a3960e4bd028ac0cec0a2afd27d7d8e67c11514"
-  version = "v1.25.1"
+  revision = "f5b0812e6fe574d90da76b205e9eb51f6ddb1919"
+  version = "v1.26.0"
 
 [[projects]]
   digest = "1:2d1fbdc6777e5408cabeb02bf336305e724b925ff4546ded0fa8715a7267922a"
@@ -812,12 +812,12 @@
   version = "v0.9.1"
 
 [[projects]]
-  digest = "1:5ad10df0893403ae9fdbd17c6f14814394a635339dd79595600bae52432befcf"
+  digest = "1:1532269ea4c7a7fcb29639a46318dd00c0f99c2f308a2a2860acf5b5354b8acc"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
   pruneopts = "NT"
-  revision = "f90ceb4f409096b60e2e9076b38b304b8246e5fa"
-  version = "v2.2.5"
+  revision = "1f64d6156d11335c3f22d9330b0ad14fc1e789ce"
+  version = "v2.2.7"
 
 [[projects]]
   digest = "1:5e299823796b9c3d7da126bef904b0c882c5b4e1e7f61465f5935b75aa7f2029"
@@ -914,6 +914,7 @@
     "pkg/apis/meta/internalversion",
     "pkg/apis/meta/v1",
     "pkg/apis/meta/v1/unstructured",
+    "pkg/apis/meta/v1/validation",
     "pkg/apis/meta/v1beta1",
     "pkg/conversion",
     "pkg/conversion/queryparams",
@@ -1072,7 +1073,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:991353c7f40631a67ae2d194d4b61ba5495321e831e8c83bbf3402af1ef6f0d8"
+  digest = "1:24f7bb16d06fc479d7ab603baa31d671a57aa21759541bcb3eeb38e918eb3c50"
   name = "k8s.io/gengo"
   packages = [
     "args",
@@ -1084,7 +1085,7 @@
     "types",
   ]
   pruneopts = "T"
-  revision = "e500ee069b5c8469a9e278b53cb41bd65404bfd9"
+  revision = "d8ecbaa43afd0cfa7a3370d5642b814840456eca"
 
 [[projects]]
   digest = "1:2c76089e62b6a1c8a48e87f47f7ac3069962a520e553db28d458d3e75d5fed3f"
@@ -1189,10 +1190,12 @@
     "k8s.io/apimachinery/pkg/api/errors",
     "k8s.io/apimachinery/pkg/api/resource",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
+    "k8s.io/apimachinery/pkg/apis/meta/v1/validation",
     "k8s.io/apimachinery/pkg/runtime",
     "k8s.io/apimachinery/pkg/runtime/schema",
     "k8s.io/apimachinery/pkg/types",
     "k8s.io/apimachinery/pkg/util/intstr",
+    "k8s.io/apimachinery/pkg/util/validation/field",
     "k8s.io/client-go/kubernetes",
     "k8s.io/client-go/kubernetes/scheme",
     "k8s.io/client-go/kubernetes/typed/core/v1",

--- a/deploy/example_catalog/cr-app-cdh5142cm.json
+++ b/deploy/example_catalog/cr-app-cdh5142cm.json
@@ -112,10 +112,7 @@
                     "port": 8088,
                     "path": "/cluster"
                 },
-                "id": "yarn-rm",
-                "qualifiers": [
-                    "yarn"
-                ]
+                "id": "yarn-rm"
             },
             {
                 "endpoint": {

--- a/deploy/example_configs/eks-gp2-for-kd.yaml
+++ b/deploy/example_configs/eks-gp2-for-kd.yaml
@@ -1,8 +1,18 @@
-# This is an example of one solution for the default StorageClass on EKS
-# not setting its volumeBindingMode to WaitForFirstConsumer. It creates
-# another storage class, which is identical to the "gp2" class except with
-# the necessary setting for volumeBindingMode, and then configures KD to use
-# that storage class (even though it is not the K8s default storage class).
+# This config was previously used as one possible solution for the default
+# StorageClass on EKS not setting its volumeBindingMode to WaitForFirstConsumer.
+#
+# It appears that the default StorageClass for KD-supported versions of
+# Kubernetes on EKS now WILL have the necessary setting for volumeBindingMode.
+# Until we're sure that this is a stable situation, we will leave this
+# config CR in the repo (and also leave the related processing of the
+# kubedirector-support label in the Makefile).
+
+# Here's the original description of this CR:
+
+# This creates another storage class, which is identical to the "gp2" class
+# except with the necessary setting for volumeBindingMode, and then configures
+# KD to use that storage class (even though it is not the K8s default storage
+# class).
 
 # The kubedirector-support label ensures that this storage class will be
 # removed by "make teardown". This is purely a behavior of the Makefile in

--- a/deploy/kubedirector/kubedirector_v1alpha1_kubedirectorapp_crd.yaml
+++ b/deploy/kubedirector/kubedirector_v1alpha1_kubedirectorapp_crd.yaml
@@ -13,6 +13,7 @@ spec:
   scope: Namespaced
   validation:
     openAPIV3Schema:
+      type: object
       required: [apiVersion, kind, metadata, spec]
       properties:
         apiVersion:
@@ -22,9 +23,11 @@ spec:
         metadata:
           type: object
         spec:
+          type: object
           required: [label, distroID, version, roles, config, configSchemaVersion]
           properties:
             label:
+              type: object
               required: [name]
               properties:
                 name:
@@ -45,6 +48,8 @@ spec:
               type: string
               minLength: 1
             defaultConfigPackage:
+              type: object
+              nullable: true
               required: [packageURL]
               properties:
                 packageURL:
@@ -53,6 +58,7 @@ spec:
             services:
               type: array
               items:
+                type: object
                 required: [id]
                 properties:
                   id:
@@ -61,6 +67,8 @@ spec:
                     maxLength: 15
                     pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
                   label:
+                    type: object
+                    nullable: true
                     required: [name]
                     properties:
                       name:
@@ -69,6 +77,8 @@ spec:
                       description:
                         type: string
                   endpoint:
+                    type: object
+                    nullable: true
                     required: [port]
                     properties:
                       port:
@@ -85,11 +95,14 @@ spec:
             roles:
               type: array
               items:
+                type: object
                 required: [id, cardinality]
                 properties:
                   id:
                     type: string
                     minLength: 1
+                    maxLength: 63
+                    pattern: '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?'
                   cardinality:
                     type: string
                     pattern: '^\d+\+?$'
@@ -97,6 +110,9 @@ spec:
                     type: string
                     minLength: 1
                   configPackage:
+                    type: object
+                    nullable: true
+                    required: [packageURL]
                     properties:
                       packageURL:
                         type: string
@@ -107,6 +123,8 @@ spec:
                       type: string
                       pattern: '^/.*[^/]$'
                   minResources:
+                    type: object
+                    nullable: true
                     properties:
                       memory:
                         type: string
@@ -122,10 +140,12 @@ spec:
                       amd.com/gpu:
                         type: integer
             config:
+              type: object
               required: [selectedRoles, roleServices]
               properties:
                 configMeta:
                   type: object
+                  nullable: true
                 selectedRoles:
                   type: array
                   items:
@@ -134,6 +154,7 @@ spec:
                 roleServices:
                   type: array
                   items:
+                    type: object
                     required: [roleID, serviceIDs]
                     properties:
                       roleID:
@@ -158,4 +179,3 @@ spec:
                 minLength: 1
             systemdRequired:
               type: boolean
-

--- a/deploy/kubedirector/kubedirector_v1alpha1_kubedirectorcluster_crd.yaml
+++ b/deploy/kubedirector/kubedirector_v1alpha1_kubedirectorcluster_crd.yaml
@@ -15,6 +15,7 @@ spec:
     status: {}
   validation:
     openAPIV3Schema:
+      type: object
       required: [apiVersion, kind, metadata, spec]
       properties:
         apiVersion:
@@ -24,6 +25,7 @@ spec:
         metadata:
           type: object
         spec:
+          type: object
           required: [app, roles]
           properties:
             app:
@@ -36,6 +38,8 @@ spec:
               type: string
               pattern: '^ClusterIP$|^NodePort$|^LoadBalancer$'
             defaultSecret:
+              type: object
+              nullable: true
               required: [name, mountPath]
               properties:
                 name:
@@ -53,15 +57,23 @@ spec:
             roles:
               type: array
               items:
+                type: object
                 required: [id, resources]
                 properties:
                   id:
                     type: string
                     minLength: 1
+                    maxLength: 63
+                    pattern: '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?'
+                  labels:
+                    type: object
+                    nullable: true
                   members:
                     type: integer
                     minimum: 0
                   secret:
+                    type: object
+                    nullable: true
                     required: [name, mountPath]
                     properties:
                       name:
@@ -77,9 +89,11 @@ spec:
                       readOnly:
                         type: boolean
                   resources:
+                    type: object
                     required: [limits]
                     properties:
                       limits:
+                        type: object
                         required: [memory, cpu]
                         properties:
                           memory:
@@ -96,6 +110,8 @@ spec:
                             type: string
                             pattern: '^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'
                       requests:
+                        type: object
+                        nullable: true
                         properties:
                           memory:
                             type: string
@@ -109,6 +125,7 @@ spec:
                   env:
                     type: array
                     items:
+                      type: object
                       required: [name, value]
                       properties:
                         name:
@@ -117,6 +134,8 @@ spec:
                         value:
                           type: string
                   storage:
+                    type: object
+                    nullable: true
                     required: [size]
                     properties:
                       size:
@@ -128,6 +147,7 @@ spec:
                   fileInjections:
                     type: array
                     items:
+                      type: object
                       required: [srcURL, destDir]
                       properties:
                         srcURL:
@@ -138,6 +158,8 @@ spec:
                           pattern: '^/.*$'
                           minLength: 1
                         permissions:
+                          type: object
+                          nullable: true
                           properties:
                             fileMode:
                               type: integer
@@ -146,6 +168,8 @@ spec:
                             fileGroup:
                               type: string
         status:
+          type: object
+          nullable: true
           properties:
             state:
               type: string
@@ -158,6 +182,7 @@ spec:
             roles:
               type: array
               items:
+                type: object
                 properties:
                   id:
                     type: string
@@ -166,6 +191,7 @@ spec:
                   members:
                     type: array
                     items:
+                      type: object
                       properties:
                         pod:
                           type: string

--- a/deploy/kubedirector/kubedirector_v1alpha1_kubedirectorconfig_crd.yaml
+++ b/deploy/kubedirector/kubedirector_v1alpha1_kubedirectorconfig_crd.yaml
@@ -15,6 +15,7 @@ spec:
     status: {}
   validation:
     openAPIV3Schema:
+      type: object
       required: [apiVersion, kind, metadata]
       properties:
         apiVersion:
@@ -22,11 +23,14 @@ spec:
         kind:
           type: string
         metadata:
+          type: object
           properties:
             name:
               type: string
               pattern: '^kd-global-config$'
         spec:
+          type: object
+          nullable: true
           properties:
             defaultStorageClassName:
               type: string
@@ -41,6 +45,8 @@ spec:
             clusterSvcDomainBase:
               type: string
         status:
+          type: object
+          nullable: true
           properties:
             generationUID:
               type: string

--- a/deploy/kubedirector/rbac-default.yaml
+++ b/deploy/kubedirector/rbac-default.yaml
@@ -1,5 +1,5 @@
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: kubedirector
 rules:
@@ -63,7 +63,7 @@ metadata:
 ---
 
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: kubedirector
 subjects:

--- a/doc/eks-notes.md
+++ b/doc/eks-notes.md
@@ -5,7 +5,7 @@ If you intend to deploy KubeDirector on EKS, you will need to have AWS credentia
 The [Getting Started with Amazon EKS](https://docs.aws.amazon.com/eks/latest/userguide/getting-started.html) guide will walk you through all first-time setup as well as the process of creating a cluster. Both the AWS Management Console (web UI) process as well as the eksctl (command-line) process will work fine, but we recommend becoming familiar with the eksctl process if you will be repeatedly deploying EKS clusters.
 
 Two important notes to be aware of when creating an EKS cluster:
-* Be sure to specify Kubernetes version 1.12 or later.
+* Be sure to specify Kubernetes version 1.14 or later.
 * Choose a worker [instance type](https://aws.amazon.com/ec2/instance-types/) with enough resources to host at least one virtual cluster member. The example type t3.medium is probably too small; consider using t3.xlarge or an m5 instance type.
 
 Use of eksctl and the AWS Management Console can be somewhat intermixed, because in the end they are just manipulating standard AWS resources, but this doc will assume you're just using one process or the other.
@@ -36,8 +36,6 @@ A YAML file is available in the "deploy/example_configs" subdirectory to address
 ```
 
 If you teardown and then re-deploy KubeDirector, you will need to repeat this step before using persistent storage.
-
-Note: if that command fails by rejecting the storage class creation, it may be the case that you are not using Kubernetes version 1.12 or later (as required) in your EKS cluster.
 
 #### WORKING WITH KUBEDIRECTOR
 

--- a/doc/eks-notes.md
+++ b/doc/eks-notes.md
@@ -4,7 +4,9 @@ If you intend to deploy KubeDirector on EKS, you will need to have AWS credentia
 
 The [Getting Started with Amazon EKS](https://docs.aws.amazon.com/eks/latest/userguide/getting-started.html) guide will walk you through all first-time setup as well as the process of creating a cluster. Both the AWS Management Console (web UI) process as well as the eksctl (command-line) process will work fine, but we recommend becoming familiar with the eksctl process if you will be repeatedly deploying EKS clusters.
 
-Two important notes to be aware of when creating an EKS cluster:
+As part of this process you will have a choice whether or not to use "AWS Fargate". For example, in the eksctl docs the cluster creation section has two tabs "AWS Fargate-only cluster" and "Cluster with Linux-only workloads". You may wish to follow the available links to read more about Fargate. FWIW we do *not* yet use Fargate when testing KubeDirector deployment and any EKS-related docs in this repo are currently written in the context of a non-Fargate deployment.
+
+Two other important notes to be aware of when creating an EKS cluster:
 * Be sure to specify Kubernetes version 1.14 or later.
 * Choose a worker [instance type](https://aws.amazon.com/ec2/instance-types/) with enough resources to host at least one virtual cluster member. The example type t3.medium is probably too small; consider using t3.xlarge or an m5 instance type.
 
@@ -24,18 +26,7 @@ From here you can proceed to deploy KubeDirector as described in [quickstart.md]
 
 #### CONFIGURING KUBEDIRECTOR
 
-After deploying KubeDirector but before creating virtual clusters, you may wish to create a KubeDirectorConfig object as described in [quickstart.md](quickstart.md).
-
-This is particularly useful to address [an issue with storage classes](https://github.com/kubernetes/kubernetes/issues/34583) that is peculiar to EKS. In EKS, a storage class that will be used for container persistent storage must have its volumeBindingMode property set to the value "WaitForFirstConsumer". However, the "gp2" storage class that is the default in EKS clusters is not currently configured this way.
-
-The volumeBindingMode property of an existing storage class cannot be modified, so to deal with this issue you must create another storage class and then either set it as the K8s default or else explicitly configure KubeDirector to use it.
-
-A YAML file is available in the "deploy/example_configs" subdirectory to address this issue. It creates a storage class with the necessary property, and also creates a KubeDirectorConfig to direct KubeDirector to use that storage class. You can use kubectl to apply this solution:
-```
-    kubectl create -f deploy/example_configs/eks-gp2-for-kd.yaml
-```
-
-If you teardown and then re-deploy KubeDirector, you will need to repeat this step before using persistent storage.
+In older versions of EKS it was necessary to create a particular KubeDirector config object if you intended to use persistent storage. That seems to no longer be necessary, but if you are experiencing issues with persistent volumes then you may want to refer to the content of this section in an [older version of this doc](https://github.com/bluek8s/kubedirector/blob/v0.3.0/doc/eks-notes.md).
 
 #### WORKING WITH KUBEDIRECTOR
 
@@ -52,7 +43,7 @@ If you now want to completely delete your EKS cluster, you can.
 
 If are using the AWS Management Console process, you should delete the cluster in the Amazon EKS console UI and delete the CloudFormation stack used to create the worker nodes. You can also delete the CloudFormation stack used to create the cluster VPC, or you can leave it for re-use with future clusters.
 
-If you are using the eksctl process, the "eksctl delete cluster" command should clean up all resources it created.
+If you are using the eksctl process, the "eksctl delete cluster" command should clean up all resources it created. Note that doing this immediately after deleting LoadBalancer-type services may fail with an error about "cannot delete orphan ELB Security Groups"; wait a few minutes and try again.
 
 The "eksctl delete cluster" command will also delete the related context from your kubectl config, but if you are using the AWS Management Console process you will need to do this cleanup yourself. You can use "kubectl config get-contexts" to see which contexts exist, and then use "kubectl config delete-context" to remove the context associated with the deleted cluster.
 

--- a/doc/gke-notes.md
+++ b/doc/gke-notes.md
@@ -4,11 +4,21 @@ If you intend to deploy KubeDirector on GKE, you will need to have a Google Clou
 
 If you're starting from scratch with GKE, the first few sections of [Google's GKE Quickstart guide](https://cloud.google.com/kubernetes-engine/docs/quickstart) may be useful, but you should probably stop after the "Configuring default settings for gcloud" section in that page and return here.
 
-With gcloud configured to use the appropriate project, you can then launch a GKE cluster. For example, this gcloud command will create a 3-node GKE cluster named "my-gke":
+With gcloud configured to use the appropriate project, you can then launch a GKE cluster.
+
+Two important notes to be aware of when creating a GKE cluster:
+* Be sure to specify Kubernetes version 1.14 or later.
+* Choose a [machine type](https://cloud.google.com/compute/docs/machine-types) with enough resources to host at least one virtual cluster member.
+
+For a list of available GKE Kubernetes versions you can run the following query. For simplest cluster launching syntax, you would want to find a version that is in both the validMasterVersions list and the validNodeVersions list.
 ```bash
-    gcloud container clusters create my-gke --machine-type n1-highmem-4
+    gcloud container get-server-config
 ```
-(See [the Machine Types list](https://cloud.google.com/compute/docs/machine-types) for the details of the available GKE node resources.)
+
+So for example, this gcloud command will create a 3-node GKE cluster named "my-gke" using Kubernetes version 1.15.7 and the n1-highmem-4 machine type:
+```bash
+    gcloud container clusters create my-gke --cluster-version=1.15.7-gke.2 --machine-type=n1-highmem-4
+```
 
 If you need to grow your GKE cluster you can use gcloud to do that as well; for example, growing to 5 nodes:
 ```bash

--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -1,6 +1,6 @@
 #### KUBERNETES SETUP
 
-You will need a K8s (Kubernetes) cluster for deploying KubeDirector and KubeDirector-managed virtual clusters. Currently we require using K8s version 1.12 or later. Especially if you are using a cloud service to spin up K8s clusters, take care that you are getting the necessary K8s version.
+You will need a K8s (Kubernetes) cluster for deploying KubeDirector and KubeDirector-managed virtual clusters. Currently we require using K8s version 1.14 or later. Especially if you are using a cloud service to spin up K8s clusters, take care that you are getting the necessary K8s version.
 
 We usually run KubeDirector on Google Kubernetes Engine; see [gke-notes.md](gke-notes.md) for GKE-specific elaborations on the various steps in this document. Or if you would rather use Amazon Elastic Container Service for Kubernetes, see [eks-notes.md](eks-notes.md). We have also run it on DigitalOcean Kubernetes without issues.
 

--- a/pkg/apis/kubedirector.bluedata.io/v1alpha1/kubedirectorapp_types.go
+++ b/pkg/apis/kubedirector.bluedata.io/v1alpha1/kubedirectorapp_types.go
@@ -31,7 +31,7 @@ type KubeDirectorAppSpec struct {
 	Services            []Service       `json:"services"`
 	NodeRoles           []NodeRole      `json:"roles"`
 	Config              NodeGroupConfig `json:"config"`
-	DefaultPersistDirs  *[]string       `json:"defaultPersistDirs"`
+	DefaultPersistDirs  *[]string       `json:"defaultPersistDirs,omitempty"`
 	Capabilities        []v1.Capability `json:"capabilities"`
 	SystemdRequired     bool            `json:"systemdRequired"`
 }
@@ -43,9 +43,8 @@ type KubeDirectorAppSpec struct {
 // +kubebuilder:subresource:status
 type KubeDirectorApp struct {
 	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata,omitempty"`
-
-	Spec KubeDirectorAppSpec `json:"spec,omitempty"`
+	metav1.ObjectMeta `json:"metadata"`
+	Spec              KubeDirectorAppSpec `json:"spec"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -53,7 +52,7 @@ type KubeDirectorApp struct {
 // KubeDirectorAppList contains a list of KubeDirectorApp
 type KubeDirectorAppList struct {
 	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata,omitempty"`
+	metav1.ListMeta `json:"metadata"`
 	Items           []KubeDirectorApp `json:"items"`
 }
 
@@ -103,8 +102,8 @@ type NodeRole struct {
 	Cardinality  string           `json:"cardinality"`
 	ImageRepoTag *string          `json:"imageRepoTag,omitempty"`
 	SetupPackage SetupPackage     `json:"configPackage,omitempty"`
-	PersistDirs  *[]string        `json:"persistDirs"`
-	MinResources *v1.ResourceList `json:"minResources"`
+	PersistDirs  *[]string        `json:"persistDirs,omitempty"`
+	MinResources *v1.ResourceList `json:"minResources,omitempty"`
 }
 
 // NodeGroupConfig identifies a set of roles, and the services on those roles.
@@ -114,7 +113,7 @@ type NodeRole struct {
 type NodeGroupConfig struct {
 	RoleServices   []RoleService     `json:"roleServices"`
 	SelectedRoles  []string          `json:"selectedRoles"`
-	ConfigMetadata map[string]string `json:"configMeta"`
+	ConfigMetadata map[string]string `json:"configMeta,omitempty"`
 }
 
 // RoleService associates a service with a role.

--- a/pkg/apis/kubedirector.bluedata.io/v1alpha1/kubedirectorcluster_types.go
+++ b/pkg/apis/kubedirector.bluedata.io/v1alpha1/kubedirectorcluster_types.go
@@ -27,10 +27,10 @@ import (
 // +k8s:openapi-gen=true
 type KubeDirectorClusterSpec struct {
 	AppID         string    `json:"app"`
-	AppCatalog    *string   `json:"appCatalog"`
-	ServiceType   *string   `json:"serviceType"`
+	AppCatalog    *string   `json:"appCatalog,omitempty"`
+	ServiceType   *string   `json:"serviceType,omitempty"`
 	Roles         []Role    `json:"roles"`
-	DefaultSecret *KDSecret `json:"defaultSecret"`
+	DefaultSecret *KDSecret `json:"defaultSecret,omitempty"`
 }
 
 // KubeDirectorClusterStatus defines the observed state of KubeDirectorCluster.
@@ -54,11 +54,10 @@ type KubeDirectorClusterStatus struct {
 // +k8s:openapi-gen=true
 type KubeDirectorCluster struct {
 	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata,omitempty"`
-
-	Spec    KubeDirectorClusterSpec    `json:"spec,omitempty"`
-	Status  *KubeDirectorClusterStatus `json:"status,omitempty"`
-	AppSpec *KubeDirectorApp           `json:"-"`
+	metav1.ObjectMeta `json:"metadata"`
+	Spec              KubeDirectorClusterSpec    `json:"spec"`
+	Status            *KubeDirectorClusterStatus `json:"status,omitempty"`
+	AppSpec           *KubeDirectorApp           `json:"-"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -66,7 +65,7 @@ type KubeDirectorCluster struct {
 // KubeDirectorClusterList is the top-level list type for virtual cluster CRs.
 type KubeDirectorClusterList struct {
 	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata,omitempty"`
+	metav1.ListMeta `json:"metadata"`
 	Items           []KubeDirectorCluster `json:"items"`
 }
 
@@ -105,19 +104,20 @@ type FileInjections struct {
 // defined by the cluster's KubeDirectorApp) set of service endpoints.
 type Role struct {
 	Name           string                      `json:"id"`
-	Members        *int32                      `json:"members"`
+	Labels         map[string]string           `json:"labels,omitempty"`
+	Members        *int32                      `json:"members,omitempty"`
 	Resources      corev1.ResourceRequirements `json:"resources"`
 	Storage        *ClusterStorage             `json:"storage,omitempty"`
 	EnvVars        []corev1.EnvVar             `json:"env,omitempty"`
 	FileInjections []FileInjections            `json:"fileInjections,omitempty"`
-	Secret         *KDSecret                   `json:"secret"`
+	Secret         *KDSecret                   `json:"secret,omitempty"`
 }
 
 // ClusterStorage defines the persistent storage size/type, if any, to be used
 // for certain specified directories of each container filesystem in a role.
 type ClusterStorage struct {
 	Size         string  `json:"size"`
-	StorageClass *string `json:"storageClassName"`
+	StorageClass *string `json:"storageClassName,omitempty"`
 }
 
 // RoleStatus describes the component objects of a virtual cluster role.

--- a/pkg/apis/kubedirector.bluedata.io/v1alpha1/kubedirectorconfig_types.go
+++ b/pkg/apis/kubedirector.bluedata.io/v1alpha1/kubedirectorconfig_types.go
@@ -23,9 +23,9 @@ import (
 type KubeDirectorConfigSpec struct {
 	StorageClass         *string `json:"defaultStorageClassName,omitempty"`
 	ServiceType          *string `json:"defaultServiceType,omitempty"`
-	NativeSystemdSupport *bool   `json:"nativeSystemdSupport"`
+	NativeSystemdSupport *bool   `json:"nativeSystemdSupport,omitempty"`
 	RequiredSecretPrefix *string `json:"requiredSecretPrefix,omitempty"`
-	ClusterSvcDomainBase *string `json:"clusterSvcDomainBase"`
+	ClusterSvcDomainBase *string `json:"clusterSvcDomainBase,omitempty"`
 }
 
 // KubeDirectorConfigStatus defines the observed state of KubeDirectorConfig.
@@ -42,7 +42,7 @@ type KubeDirectorConfigStatus struct {
 // +k8s:openapi-gen=true
 type KubeDirectorConfig struct {
 	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata,omitempty"`
+	metav1.ObjectMeta `json:"metadata"`
 	Spec              *KubeDirectorConfigSpec   `json:"spec,omitempty"`
 	Status            *KubeDirectorConfigStatus `json:"status,omitempty"`
 }
@@ -52,7 +52,7 @@ type KubeDirectorConfig struct {
 // KubeDirectorConfigList is the top-level list type for global config CRs
 type KubeDirectorConfigList struct {
 	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata,omitempty"`
+	metav1.ListMeta `json:"metadata"`
 	Items           []KubeDirectorConfig `json:"items"`
 }
 

--- a/pkg/controller/kubedirectorcluster/cluster.go
+++ b/pkg/controller/kubedirectorcluster/cluster.go
@@ -15,6 +15,7 @@
 package kubedirectorcluster
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"time"
@@ -42,6 +43,99 @@ func (r *ReconcileKubeDirectorCluster) syncCluster(
 	cr *kdv1.KubeDirectorCluster,
 ) error {
 
+	// Memoize state of the incoming object.
+	hadFinalizer := shared.HasFinalizer(cr)
+	oldStatus := cr.Status.DeepCopy()
+
+	// Make sure we have a Status object to work with.
+	if cr.Status == nil {
+		cr.Status = &kdv1.KubeDirectorClusterStatus{}
+		cr.Status.Roles = make([]kdv1.RoleStatus, 0)
+	}
+
+	// Set a defer func to write new status and/or finalizers if they change.
+	defer func() {
+		nowHasFinalizer := shared.HasFinalizer(cr)
+		// Bail out if nothing has changed.
+		statusChanged := !reflect.DeepEqual(cr.Status, oldStatus)
+		finalizersChanged := (hadFinalizer != nowHasFinalizer)
+		if !(statusChanged || finalizersChanged) {
+			return
+		}
+		// Write back the status. Don't exit this reconciler until we
+		// succeed (will block other reconcilers for this resource).
+		wait := time.Second
+		maxWait := 4096 * time.Second
+		for {
+			// If status has changed, write it back.
+			var updateErr error
+			if statusChanged {
+				cr.Status.GenerationUID = uuid.New().String()
+				ClusterStatusGens.WriteStatusGen(cr.UID, cr.Status.GenerationUID)
+				updateErr = executor.UpdateClusterStatus(cr)
+				// If this succeeded, no need to do it again on next iteration
+				// if we're just cycling because of a failure to update the
+				// finalizer.
+				if updateErr == nil {
+					statusChanged = false
+				}
+			}
+			// If any necessary status update worked, let's also update
+			// finalizers if necessary.
+			if (updateErr == nil) && finalizersChanged {
+				// See https://github.com/bluek8s/kubedirector/issues/194
+				// Migrate Client().Update() calls back to Patch() calls.
+				updateErr = shared.Client().Update(context.TODO(), cr)
+			}
+			// Bail out if we're done.
+			if updateErr == nil {
+				return
+			}
+			// Some necessary update failed. If the cluster has been deleted,
+			// that's ok... otherwise we'll try again.
+			currentCluster, currentClusterErr := observer.GetCluster(
+				cr.Namespace,
+				cr.Name,
+			)
+			if currentClusterErr != nil {
+				if errors.IsNotFound(currentClusterErr) {
+					return
+				}
+			} else {
+				// If we got a conflict error, update the CR with its current
+				// form, restore our desired status/finalizers, and try again
+				// immediately.
+				if errors.IsConflict(updateErr) {
+					currentCluster.Status = cr.Status
+					currentHasFinalizer := shared.HasFinalizer(currentCluster)
+					if currentHasFinalizer {
+						if !nowHasFinalizer {
+							shared.RemoveFinalizer(currentCluster)
+						}
+					} else {
+						if nowHasFinalizer {
+							shared.EnsureFinalizer(currentCluster)
+						}
+					}
+					*cr = *currentCluster
+					continue
+				}
+			}
+			if wait < maxWait {
+				wait = wait * 2
+			}
+			shared.LogErrorf(
+				reqLogger,
+				updateErr,
+				cr,
+				shared.EventReasonCluster,
+				"trying status update again in %v; failed",
+				wait,
+			)
+			time.Sleep(wait)
+		}
+	}()
+
 	// We use a finalizer to maintain KubeDirector state consistency;
 	// e.g. app references and ClusterStatusGens.
 	doExit, finalizerErr := r.handleFinalizers(reqLogger, cr)
@@ -52,68 +146,6 @@ func (r *ReconcileKubeDirectorCluster) syncCluster(
 		return nil
 	}
 
-	// Make sure we have a Status object to work with.
-	if cr.Status == nil {
-		cr.Status = &kdv1.KubeDirectorClusterStatus{}
-		cr.Status.Roles = make([]kdv1.RoleStatus, 0)
-	}
-
-	// Set up logic to update status as necessary when reconciler exits.
-	oldStatus := cr.Status.DeepCopy()
-	defer func() {
-		if !reflect.DeepEqual(cr.Status, oldStatus) {
-			// Write back the status. Don't exit this reconciler until we
-			// succeed (will block other reconcilers for this resource).
-			wait := time.Second
-			maxWait := 4096 * time.Second
-			for {
-				cr.Status.GenerationUID = uuid.New().String()
-				ClusterStatusGens.WriteStatusGen(cr.UID, cr.Status.GenerationUID)
-				updateErr := executor.UpdateClusterStatus(cr)
-				if updateErr == nil {
-					return
-				}
-				// Update failed. If the cluster has been or is being
-				// deleted, that's ok... otherwise wait and try again.
-				currentCluster, currentClusterErr := observer.GetCluster(
-					cr.Namespace,
-					cr.Name,
-				)
-				if currentClusterErr != nil {
-					if errors.IsNotFound(currentClusterErr) {
-						return
-					}
-				} else {
-					if currentCluster.DeletionTimestamp != nil {
-						return
-					}
-					if errors.IsConflict(updateErr) {
-						// If the update failed with a ResourceVersion
-						// conflict then we need to use the current
-						// version of the cluster. Otherwise, the status
-						// update will never succeed and this loop will
-						// never terminate.
-						currentCluster.Status = cr.Status
-						*cr = *currentCluster
-						continue
-					}
-				}
-				if wait < maxWait {
-					wait = wait * 2
-				}
-				shared.LogErrorf(
-					reqLogger,
-					updateErr,
-					cr,
-					shared.EventReasonCluster,
-					"trying status update again in %v; failed",
-					wait,
-				)
-				time.Sleep(wait)
-			}
-		}
-	}()
-
 	// For a new CR just update the status state/gen.
 	shouldProcessCR, processErr := r.handleNewCluster(reqLogger, cr)
 	if processErr != nil {
@@ -123,14 +155,16 @@ func (r *ReconcileKubeDirectorCluster) syncCluster(
 		return nil
 	}
 
+	// Define a common error function for sync problems.
 	errLog := func(domain string, err error) {
 		shared.LogErrorf(
 			reqLogger,
 			err,
 			cr,
 			shared.EventReasonCluster,
-			"failed to sync %s",
+			"failed to sync %s: %v",
 			domain,
+			err,
 		)
 	}
 
@@ -281,8 +315,10 @@ func (r *ReconcileKubeDirectorCluster) handleNewCluster(
 	return true, nil
 }
 
-// handleFinalizers will remove our finalizer if deletion has been requested.
-// Otherwise it will add our finalizer if it is absent.
+// handleFinalizers will, if deletion has been requested, try to do any
+// cleanup and then remove our finalizer from the in-memory CR. If deletion
+// has NOT been requested then it will add our finalizer to the in-memory CR
+// if it is absent.
 func (r *ReconcileKubeDirectorCluster) handleFinalizers(
 	reqLogger logr.Logger,
 	cr *kdv1.KubeDirectorCluster,
@@ -291,17 +327,14 @@ func (r *ReconcileKubeDirectorCluster) handleFinalizers(
 	if cr.DeletionTimestamp != nil {
 		// If a deletion has been requested, while ours (or other) finalizers
 		// existed on the CR, go ahead and remove our finalizer.
-		removeErr := shared.RemoveFinalizer(cr)
-		if removeErr == nil {
-			shared.LogInfo(
-				reqLogger,
-				cr,
-				shared.EventReasonCluster,
-				"greenlighting for deletion",
-			)
-		}
-		// Also clear the status gen from our cache, regardless of whether
-		// finalizer modification succeeded.
+		shared.RemoveFinalizer(cr)
+		shared.LogInfo(
+			reqLogger,
+			cr,
+			shared.EventReasonCluster,
+			"greenlighting for deletion",
+		)
+		// Also clear the status gen from our cache.
 		ClusterStatusGens.DeleteStatusGen(cr.UID)
 		shared.RemoveClusterAppReference(
 			cr.Namespace,
@@ -309,14 +342,11 @@ func (r *ReconcileKubeDirectorCluster) handleFinalizers(
 			*(cr.Spec.AppCatalog),
 			cr.Spec.AppID,
 		)
-		return true, removeErr
+		return true, nil
 	}
 
 	// If our finalizer doesn't exist on the CR, put it in there.
-	ensureErr := shared.EnsureFinalizer(cr)
-	if ensureErr != nil {
-		return true, ensureErr
-	}
+	shared.EnsureFinalizer(cr)
 
 	return false, nil
 }

--- a/pkg/executor/guest.go
+++ b/pkg/executor/guest.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"path/filepath"
+	"strings"
 
 	"github.com/bluek8s/kubedirector/pkg/observer"
 	"github.com/bluek8s/kubedirector/pkg/shared"
@@ -142,10 +143,12 @@ func RemoveDir(
 		ioStreams,
 	)
 	if err != nil {
-		err = fmt.Errorf("rmdir failed: %s\n%s",
-			stdErr.String(),
-			err.Error(),
-		)
+		errStr := stdErr.String()
+		if strings.Contains(errStr, "No such file or directory") {
+			err = nil
+		} else {
+			err = fmt.Errorf("rmdir failed: %s", errStr)
+		}
 	}
 	return err
 }

--- a/pkg/executor/statefulset.go
+++ b/pkg/executor/statefulset.go
@@ -468,7 +468,6 @@ func generateVolumeMounts(
 	nativeSystemdSupport bool,
 	persistDirs []string,
 ) ([]v1.VolumeMount, []v1.Volume, error) {
-
 	var volumeMounts []v1.VolumeMount
 	var volumes []v1.Volume
 

--- a/pkg/executor/types.go
+++ b/pkg/executor/types.go
@@ -16,10 +16,14 @@ package executor
 
 import (
 	"io"
+
+	"github.com/bluek8s/kubedirector/pkg/shared"
 )
 
 const (
-	headlessServiceLabel = "kubedirector.bluedata.io/headless"
+	clusterLabel         = "kubedirectorcluster"
+	clusterRoleLabel     = "role"
+	headlessServiceLabel = shared.KdDomainBase + "/" + "headless"
 	statefulSetPodLabel  = "statefulset.kubernetes.io/pod-name"
 	storageClassName     = "volume.beta.kubernetes.io/storage-class"
 	// AppContainerName is the name of kubedirector app containers

--- a/pkg/observer/doc.go
+++ b/pkg/observer/doc.go
@@ -12,13 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package executor manages objects within k8s that implement virtual clusters.
-//
-// For the most part, the exported functions in this package will create,
-// update, or delete individual native k8s objects that make up parts of the
-// virtual cluster. The exceptions are in guest.go, where the exported
-// functions handle operations within a cluster member's OS.
-
 // Package observer implements queries for k8s objects that compose a cluster.
 //
 // Each exported function will return the found object (if query succeeds).

--- a/pkg/shared/kubedirectorobject.go
+++ b/pkg/shared/kubedirectorobject.go
@@ -15,8 +15,7 @@
 package shared
 
 import (
-	"context"
-
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -30,56 +29,51 @@ const (
 // Currently it's used to add/remove the KubeDirector finalizer from
 // KubeDirector resources.
 type KubeDirectorObject interface {
-	GetFinalizers() []string
-	SetFinalizers(finalizers []string)
 	runtime.Object
+	metav1.Object
+}
+
+// HasFinalizer checks whether the KubeDirector finalizer is among the CR's
+// finalizers list.
+func HasFinalizer(
+	cr KubeDirectorObject,
+) bool {
+
+	finalizers := cr.GetFinalizers()
+	for _, f := range finalizers {
+		if f == KubeDirectorFinalizerID {
+			return true
+		}
+	}
+	return false
 }
 
 // RemoveFinalizer removes the KubeDirector finalizer from the CR's finalizers
 // list (if it is in there).
 func RemoveFinalizer(
 	cr KubeDirectorObject,
-) error {
+) {
 
-	found := false
 	finalizers := cr.GetFinalizers()
 	for i, f := range finalizers {
 		if f == KubeDirectorFinalizerID {
 			cr.SetFinalizers(append(finalizers[:i], finalizers[i+1:]...))
-			found = true
-			break
+			return
 		}
 	}
-	if !found {
-		return nil
-	}
-
-	// See https://github.com/bluek8s/kubedirector/issues/194
-	// Migrate Client().Update() calls back to Patch() calls.
-	return Client().Update(context.TODO(), cr)
 }
 
 // EnsureFinalizer adds the KubeDirector finalizer into the CR's finalizers
 // list (if it is not in there).
 func EnsureFinalizer(
 	cr KubeDirectorObject,
-) error {
+) {
 
-	found := false
 	finalizers := cr.GetFinalizers()
 	for _, f := range finalizers {
 		if f == KubeDirectorFinalizerID {
-			found = true
-			break
+			return
 		}
 	}
-	if found {
-		return nil
-	}
-
 	cr.SetFinalizers(append(finalizers, KubeDirectorFinalizerID))
-
-	// See https://github.com/bluek8s/kubedirector/issues/194
-	// Migrate Client().Update() calls back to Patch() calls.
-	return Client().Update(context.TODO(), cr)
 }

--- a/pkg/shared/types.go
+++ b/pkg/shared/types.go
@@ -26,6 +26,9 @@ const (
 	// KubeDirectorGlobalConfig is the name of the kubedirector config CR
 	KubeDirectorGlobalConfig = "kd-global-config"
 
+	//KdDomainBase - Annotation DNS subdomain prefix
+	KdDomainBase = "kubedirector.bluedata.io"
+
 	// DefaultServiceType - default service type if not specified in
 	// the configCR
 	DefaultServiceType = "LoadBalancer"


### PR DESCRIPTION
Significant improvements to the CRDs to make them check more stuff and to get rid of errors reported by K8s on the created CRD resources. These changes do require using the "nullable" attribute, which in turn requires using K8s 1.14 or later. Also we need to be more careful about when we specify "omitempty" for our type fields.

Use the API rbac.authorization.k8s.io/v1 instead of rbac.authorization.k8s.io/v1beta1. This non-beta version has been available for a long time and beta may go away.

Improvements to the GKE and EKS usage notes.

Some significant changes to how we handle finalizers in our CR reconciliation handlers. The previous logic relied on the first creation of the finalizer happening before any status stanza existed (so that status protection would not be triggered by the write). This is OK for now but it is kind of a time bomb; in some work on another operator we found instances where we might need to affect the status stanza during handleFinalizers. Best way to make this possible is to NOT to do an object write inside of RemoveFinalizer or EnsureFinalizer. Instead those functions can just modify the CR in memory, and finalizers can be written back in the deferfunc just like we do with status changes.

Misc log message and comment improvements.

Generic-izing executor.ownerReferences so that owner references can be created to any kind of object.

Adding the ability to specify labels to add to pods in your KubeDirectorCluster spec.