### PR TITLE
prepend urlScheme to port names in created member services

### DIFF
--- a/deploy/kubedirector/kubedirector_v1alpha1_kubedirectorapp_crd.yaml
+++ b/deploy/kubedirector/kubedirector_v1alpha1_kubedirectorapp_crd.yaml
@@ -88,6 +88,8 @@ spec:
                       urlScheme:
                         type: string
                         minLength: 1
+                        maxLength: 15
+                        pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
                       path:
                         type: string
                       isDashboard:
@@ -102,7 +104,7 @@ spec:
                     type: string
                     minLength: 1
                     maxLength: 63
-                    pattern: '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?'
+                    pattern: '^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$'
                   cardinality:
                     type: string
                     pattern: '^\d+\+?$'
@@ -160,6 +162,8 @@ spec:
                       roleID:
                         type: string
                         minLength: 1
+                        maxLength: 63
+                        pattern: '^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$'
                       serviceIDs:
                         type: array
                         items:

--- a/pkg/catalog/interrogate.go
+++ b/pkg/catalog/interrogate.go
@@ -146,8 +146,9 @@ func PortsForRole(
 				if shared.StringInList(service.ID, roleService.ServiceIDs) {
 					if service.Endpoint.Port != nil {
 						servicePortInfo := ServicePortInfo{
-							ID:   service.ID,
-							Port: *(service.Endpoint.Port),
+							ID:        service.ID,
+							Port:      *(service.Endpoint.Port),
+							URLScheme: service.Endpoint.URLScheme,
 						}
 						result = append(result, servicePortInfo)
 					}

--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -90,6 +90,7 @@ type flavor struct {
 
 // ServicePortInfo - A mapping between a Service Port ID and the port number
 type ServicePortInfo struct {
-	ID   string
-	Port int32
+	ID        string
+	Port      int32
+	URLScheme string
 }

--- a/pkg/executor/service.go
+++ b/pkg/executor/service.go
@@ -127,7 +127,7 @@ func CreatePodService(
 	for _, portInfo := range portInfoList {
 		servicePort := corev1.ServicePort{
 			Port: portInfo.Port,
-			Name: portInfo.ID,
+			Name: createPortNameForService(portInfo),
 		}
 		service.Spec.Ports = append(service.Spec.Ports, servicePort)
 	}

--- a/pkg/executor/util.go
+++ b/pkg/executor/util.go
@@ -15,7 +15,10 @@
 package executor
 
 import (
+	"strings"
+
 	kdv1 "github.com/bluek8s/kubedirector/pkg/apis/kubedirector.bluedata.io/v1alpha1"
+	"github.com/bluek8s/kubedirector/pkg/catalog"
 	"github.com/bluek8s/kubedirector/pkg/shared"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -77,4 +80,17 @@ func labelsForPod(
 	podLabels[statefulSetPodLabel] = podName
 
 	return podLabels
+}
+
+// createPortNameForService creates the port name for a service endpoint.
+// It prefixes the ID with the lowercased URL scheme if given; otherwise
+// prefixing with "generic-".
+func createPortNameForService(
+	portInfo catalog.ServicePortInfo,
+) string {
+
+	if portInfo.URLScheme == "" {
+		return "generic-" + portInfo.ID
+	}
+	return strings.ToLower(portInfo.URLScheme) + "-" + portInfo.ID
 }


### PR DESCRIPTION
We don't make use of urlScheme much in the example apps yet, but this will be handy for clients.

If urlScheme is unspecified just prepend "generic-".