### PR TITLE
user-specified labels feature tweaks

### DIFF
--- a/deploy/kubedirector/kubedirector_v1alpha1_kubedirectorcluster_crd.yaml
+++ b/deploy/kubedirector/kubedirector_v1alpha1_kubedirectorcluster_crd.yaml
@@ -65,7 +65,7 @@ spec:
                     minLength: 1
                     maxLength: 63
                     pattern: '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?'
-                  labels:
+                  podLabels:
                     type: object
                     nullable: true
                   serviceLabels:

--- a/deploy/kubedirector/kubedirector_v1alpha1_kubedirectorcluster_crd.yaml
+++ b/deploy/kubedirector/kubedirector_v1alpha1_kubedirectorcluster_crd.yaml
@@ -68,6 +68,9 @@ spec:
                   labels:
                     type: object
                     nullable: true
+                  serviceLabels:
+                    type: object
+                    nullable: true
                   members:
                     type: integer
                     minimum: 0

--- a/pkg/apis/kubedirector.bluedata.io/v1alpha1/kubedirectorcluster_types.go
+++ b/pkg/apis/kubedirector.bluedata.io/v1alpha1/kubedirectorcluster_types.go
@@ -104,7 +104,7 @@ type FileInjections struct {
 // defined by the cluster's KubeDirectorApp) set of service endpoints.
 type Role struct {
 	Name           string                      `json:"id"`
-	Labels         map[string]string           `json:"labels,omitempty"`
+	PodLabels      map[string]string           `json:"podLabels,omitempty"`
 	ServiceLabels  map[string]string           `json:"serviceLabels,omitempty"`
 	Members        *int32                      `json:"members,omitempty"`
 	Resources      corev1.ResourceRequirements `json:"resources"`

--- a/pkg/apis/kubedirector.bluedata.io/v1alpha1/kubedirectorcluster_types.go
+++ b/pkg/apis/kubedirector.bluedata.io/v1alpha1/kubedirectorcluster_types.go
@@ -105,6 +105,7 @@ type FileInjections struct {
 type Role struct {
 	Name           string                      `json:"id"`
 	Labels         map[string]string           `json:"labels,omitempty"`
+	ServiceLabels  map[string]string           `json:"serviceLabels,omitempty"`
 	Members        *int32                      `json:"members,omitempty"`
 	Resources      corev1.ResourceRequirements `json:"resources"`
 	Storage        *ClusterStorage             `json:"storage,omitempty"`

--- a/pkg/executor/service.go
+++ b/pkg/executor/service.go
@@ -46,7 +46,7 @@ func CreateHeadlessService(
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:       cr.Namespace,
 			OwnerReferences: ownerReferences(cr),
-			Labels:          labelsForService(cr),
+			Labels:          labelsForService(cr, nil),
 		},
 		Spec: corev1.ServiceSpec{
 			ClusterIP: "None",
@@ -116,10 +116,10 @@ func CreatePodService(
 			Name:            serviceName(podName),
 			Namespace:       cr.Namespace,
 			OwnerReferences: ownerReferences(cr),
-			Labels:          labelsForService(cr),
+			Labels:          labelsForService(cr, role),
 		},
 		Spec: corev1.ServiceSpec{
-			Selector:                 labelsForPod(cr, role, podName),
+			Selector:                 map[string]string{statefulSetPodLabel: podName},
 			Type:                     serviceType,
 			PublishNotReadyAddresses: true,
 		},

--- a/pkg/executor/statefulset.go
+++ b/pkg/executor/statefulset.go
@@ -166,7 +166,8 @@ func getStatefulset(
 	replicas int32,
 ) (*appsv1.StatefulSet, error) {
 
-	labels := labelsForRole(cr, role)
+	labels := labelsForStatefulSet(cr, role)
+	podLabels := labelsForPod(cr, role)
 	startupScript := getStartupScript(cr)
 
 	portInfoList, portsErr := catalog.PortsForRole(cr, role.Name)
@@ -269,11 +270,11 @@ func getStatefulset(
 			Replicas:            &replicas,
 			ServiceName:         cr.Status.ClusterService,
 			Selector: &metav1.LabelSelector{
-				MatchLabels: labels,
+				MatchLabels: podLabels,
 			},
 			Template: v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: labels,
+					Labels: podLabels,
 				},
 				Spec: v1.PodSpec{
 					AutomountServiceAccountToken: &useServiceAccount,

--- a/pkg/executor/types.go
+++ b/pkg/executor/types.go
@@ -21,7 +21,11 @@ import (
 )
 
 const (
-	ClusterLabel         = "kubedirectorcluster"
+	// ClusterLabel is a label placed on every created statefulset, pod, and
+	// service, with a value of the KubeDirectorCluster CR name.
+	ClusterLabel = "kubedirectorcluster"
+	// ClusterRoleLabel is a label placed on every created pod, and
+	// (non-headless) service, with a value of the relevant role ID.
 	ClusterRoleLabel     = "role"
 	headlessServiceLabel = shared.KdDomainBase + "/" + "headless"
 	statefulSetPodLabel  = "statefulset.kubernetes.io/pod-name"

--- a/pkg/executor/types.go
+++ b/pkg/executor/types.go
@@ -21,8 +21,8 @@ import (
 )
 
 const (
-	clusterLabel         = "kubedirectorcluster"
-	clusterRoleLabel     = "role"
+	ClusterLabel         = "kubedirectorcluster"
+	ClusterRoleLabel     = "role"
 	headlessServiceLabel = shared.KdDomainBase + "/" + "headless"
 	statefulSetPodLabel  = "statefulset.kubernetes.io/pod-name"
 	storageClassName     = "volume.beta.kubernetes.io/storage-class"

--- a/pkg/executor/util.go
+++ b/pkg/executor/util.go
@@ -40,17 +40,40 @@ func ownerReferences(
 }
 
 // labelsForRole generates a set of resource labels appropriate for the
-// given role.
+// given role. These will be propagated to the statefulset, pods, and
+// services related to that role.
 func labelsForRole(
 	cr *kdv1.KubeDirectorCluster,
 	role *kdv1.Role,
 ) map[string]string {
 
 	result := map[string]string{
-		clusterLabel:         cr.Name,
-		clusterRoleLabel:     role.Name,
-		headlessServiceLabel: headlessServiceName + "-" + cr.Name,
+		clusterLabel:     cr.Name,
+		clusterRoleLabel: role.Name,
 	}
+	return result
+}
+
+// labelsForStatefulSet generates a set of resource labels appropriate for a
+// statefulset in the given role.
+func labelsForStatefulSet(
+	cr *kdv1.KubeDirectorCluster,
+	role *kdv1.Role,
+) map[string]string {
+
+	result := labelsForRole(cr, role)
+	result[headlessServiceLabel] = headlessServiceName + "-" + cr.Name
+	return result
+}
+
+// labelsForPod generates a set of resource labels appropriate for a pod in
+// the given role. This includes any user-requested labels.
+func labelsForPod(
+	cr *kdv1.KubeDirectorCluster,
+	role *kdv1.Role,
+) map[string]string {
+
+	result := labelsForStatefulSet(cr, role)
 	for name, value := range role.Labels {
 		result[name] = value
 	}
@@ -58,28 +81,23 @@ func labelsForRole(
 }
 
 // labelsForService generates a set of resource labels appropriate for the
-// services created for a cluster
+// services created for a cluster. This includes any user-requested labels.
+// role may be nil if this is the headless service.
 func labelsForService(
 	cr *kdv1.KubeDirectorCluster,
-) map[string]string {
-
-	return map[string]string{
-		clusterLabel: cr.Name,
-	}
-}
-
-// labelsForPod generates a set of resource labels appropriate for a pod in
-// the given role.
-func labelsForPod(
-	cr *kdv1.KubeDirectorCluster,
 	role *kdv1.Role,
-	podName string,
 ) map[string]string {
 
-	podLabels := labelsForRole(cr, role)
-	podLabels[statefulSetPodLabel] = podName
-
-	return podLabels
+	var result map[string]string
+	if role == nil {
+		result = map[string]string{clusterLabel: cr.Name}
+	} else {
+		result = labelsForRole(cr, role)
+		for name, value := range role.ServiceLabels {
+			result[name] = value
+		}
+	}
+	return result
 }
 
 // createPortNameForService creates the port name for a service endpoint.

--- a/pkg/executor/util.go
+++ b/pkg/executor/util.go
@@ -74,7 +74,7 @@ func labelsForPod(
 ) map[string]string {
 
 	result := labelsForStatefulSet(cr, role)
-	for name, value := range role.Labels {
+	for name, value := range role.PodLabels {
 		result[name] = value
 	}
 	return result

--- a/pkg/executor/util.go
+++ b/pkg/executor/util.go
@@ -48,8 +48,8 @@ func labelsForRole(
 ) map[string]string {
 
 	result := map[string]string{
-		clusterLabel:     cr.Name,
-		clusterRoleLabel: role.Name,
+		ClusterLabel:     cr.Name,
+		ClusterRoleLabel: role.Name,
 	}
 	return result
 }
@@ -90,7 +90,7 @@ func labelsForService(
 
 	var result map[string]string
 	if role == nil {
-		result = map[string]string{clusterLabel: cr.Name}
+		result = map[string]string{ClusterLabel: cr.Name}
 	} else {
 		result = labelsForRole(cr, role)
 		for name, value := range role.ServiceLabels {

--- a/pkg/validator/cluster.go
+++ b/pkg/validator/cluster.go
@@ -134,8 +134,8 @@ func validateCardinality(
 		// validate user-specified labels
 		rolePath := rolesPath.Index(i)
 		labelErrors := appsvalidation.ValidateLabels(
-			role.Labels,
-			rolePath.Child("labels"),
+			role.PodLabels,
+			rolePath.Child("podLabels"),
 		)
 		serviceLabelErrors := appsvalidation.ValidateLabels(
 			role.ServiceLabels,

--- a/pkg/validator/cluster.go
+++ b/pkg/validator/cluster.go
@@ -131,14 +131,23 @@ func validateCardinality(
 				},
 			)
 		}
-		// validate role[i].labels
+		// validate user-specified labels
 		rolePath := rolesPath.Index(i)
-		fieldsPath := rolePath.Child("labels")
-		labelErrors := appsvalidation.ValidateLabels(role.Labels, fieldsPath)
-		if len(labelErrors) != 0 {
+		labelErrors := appsvalidation.ValidateLabels(
+			role.Labels,
+			rolePath.Child("labels"),
+		)
+		serviceLabelErrors := appsvalidation.ValidateLabels(
+			role.ServiceLabels,
+			rolePath.Child("serviceLabels"),
+		)
+		if (len(labelErrors) != 0) || (len(serviceLabelErrors) != 0) {
 			anyError = true
-			for _, err := range labelErrors {
-				valErrors = append(valErrors, err.Error())
+			for _, labelErr := range labelErrors {
+				valErrors = append(valErrors, labelErr.Error())
+			}
+			for _, serviceLabelErr := range serviceLabelErrors {
+				valErrors = append(valErrors, serviceLabelErr.Error())
 			}
 		}
 	}


### PR DESCRIPTION
Add serviceLabels to the role config too, to allow specifying labels for services related to the role.

Also a couple of slight tweaks to existing label behavior:

- Don't put the user-specified pod member labels on the statefulset; only on the pods.
- Go easier on the labels in the pod selector in a member service; just reference the pod name.