### PR TITLE
InitContainer should not rely on configmeta.json

### DIFF
--- a/pkg/executor/statefulset.go
+++ b/pkg/executor/statefulset.go
@@ -421,9 +421,9 @@ func getStartupScript(
 func generateInitContainerLaunch(persistDirs []string) string {
 
 	// To be safe in the case that this container is restarted by someone,
-	// don't do this copy if the configmeta file already exists in /etc.
-	launchCmd := "! [ -f /mnt" + configMetaFile + " ]" + " && " +
-		"cp --parent -ax " + strings.Join(persistDirs, " ") + " /mnt || exit 0"
+	// don't do this copy if the kubedirector.init file already exists in /etc.
+	launchCmd := "! [ -f /mnt" + kubedirectorInit + " ]" + " && " +
+		"cp --parent -ax " + strings.Join(persistDirs, " ") + " /mnt || exit 0; touch " + kubedirectorInit
 
 	return launchCmd
 }

--- a/pkg/executor/types.go
+++ b/pkg/executor/types.go
@@ -40,6 +40,7 @@ const (
 	cgroupFSVolume      = "/sys/fs/cgroup"
 	systemdFSVolume     = "/sys/fs/cgroup/systemd"
 	tmpFSVolSize        = "20Gi"
+	kubedirectorInit    = "/etc/kubedirector.init"
 )
 
 // Streams for stdin, stdout, stderr of executed commands


### PR DESCRIPTION
We don't inject config meta in the container if app config is not required. So drop in a file (kubedirector.init) for initContainer check. 
