### PR TITLE
robustification

### DIFF
--- a/deploy/kubedirector/deployment-prebuilt.yaml
+++ b/deploy/kubedirector/deployment-prebuilt.yaml
@@ -17,7 +17,7 @@ spec:
           image: bluek8s/kubedirector:unstable
           livenessProbe:
             httpGet:
-              path: /health
+              path: /healthz
               port: 8443
               scheme: HTTPS
             initialDelaySeconds: 10

--- a/deploy/kubedirector/deployment-prebuilt.yaml
+++ b/deploy/kubedirector/deployment-prebuilt.yaml
@@ -15,6 +15,16 @@ spec:
       containers:
         - name: kubedirector
           image: bluek8s/kubedirector:unstable
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8443
+              scheme: HTTPS
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
           ports:
           - containerPort: 60000
             name: metrics

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -17,6 +17,16 @@ spec:
         - name: kubedirector
           # Replace this with the built image name
           image: REPLACE_IMAGE
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8443
+              scheme: HTTPS
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
           ports:
           - containerPort: 60000
             name: metrics

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -19,7 +19,7 @@ spec:
           image: REPLACE_IMAGE
           livenessProbe:
             httpGet:
-              path: /health
+              path: /healthz
               port: 8443
               scheme: HTTPS
             initialDelaySeconds: 10

--- a/doc/gke-notes.md
+++ b/doc/gke-notes.md
@@ -15,9 +15,9 @@ For a list of available GKE Kubernetes versions you can run the following query.
     gcloud container get-server-config
 ```
 
-So for example, this gcloud command will create a 3-node GKE cluster named "my-gke" using Kubernetes version 1.15.7 and the n1-highmem-4 machine type:
+So for example, this gcloud command will create a 3-node GKE cluster named "my-gke" using Kubernetes version 1.14.10 and the n1-highmem-4 machine type:
 ```bash
-    gcloud container clusters create my-gke --cluster-version=1.15.7-gke.2 --machine-type=n1-highmem-4
+    gcloud container clusters create my-gke --cluster-version=1.14.10-gke.17 --machine-type=n1-highmem-4
 ```
 
 If you need to grow your GKE cluster you can use gcloud to do that as well; for example, growing to 5 nodes:

--- a/pkg/validator/server.go
+++ b/pkg/validator/server.go
@@ -187,6 +187,14 @@ func StartValidationServer() error {
 		},
 	)
 
+	http.HandleFunc(
+		healthPath,
+		func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+			w.Write([]byte("ok"))
+		},
+	)
+
 	err = server.ListenAndServeTLS("", "")
 
 	return err

--- a/pkg/validator/types.go
+++ b/pkg/validator/types.go
@@ -30,6 +30,7 @@ const (
 	webhookHandlerName   = "validate-cr.kubedirector.bluedata.io"
 	validationPort       = 8443
 	validationPath       = "/validate"
+	healthPath           = "/health"
 	defaultNativeSystemd = false
 
 	appCrt  = "app.crt"

--- a/pkg/validator/types.go
+++ b/pkg/validator/types.go
@@ -30,7 +30,7 @@ const (
 	webhookHandlerName   = "validate-cr.kubedirector.bluedata.io"
 	validationPort       = 8443
 	validationPath       = "/validate"
-	healthPath           = "/health"
+	healthPath           = "/healthz"
 	defaultNativeSystemd = false
 
 	appCrt  = "app.crt"

--- a/pkg/validator/util.go
+++ b/pkg/validator/util.go
@@ -128,6 +128,13 @@ func createAdmissionService(
 			CABundle: signingCert,
 		},
 		Rules: []v1beta1.RuleWithOperations{
+			// For kubedirectorclusters and kubedirectorconfigs, we don't
+			// actually do any delete validation, but if our whole operator is
+			// down (most likely failure case) the object won't go away
+			// because the reconciler won't remove its finalizer. And you
+			// can't manually remove the finalizer without doing an update. So
+			// let's head all of that off by just registering for Delete
+			// (with Fail failure policy) for those resources too.
 			{
 				Operations: []v1beta1.OperationType{
 					v1beta1.Create,
@@ -137,18 +144,11 @@ func createAdmissionService(
 				Rule: v1beta1.Rule{
 					APIGroups:   []string{"kubedirector.bluedata.io"},
 					APIVersions: []string{"v1alpha1"},
-					Resources:   []string{"kubedirectorapps"},
-				},
-			},
-			{
-				Operations: []v1beta1.OperationType{
-					v1beta1.Create,
-					v1beta1.Update,
-				},
-				Rule: v1beta1.Rule{
-					APIGroups:   []string{"kubedirector.bluedata.io"},
-					APIVersions: []string{"v1alpha1"},
-					Resources:   []string{"kubedirectorclusters", "kubedirectorconfigs"},
+					Resources: []string{
+						"kubedirectorconfigs",
+						"kubedirectorapps",
+						"kubedirectorclusters",
+					},
 				},
 			},
 		},


### PR DESCRIPTION
We should never let an invalid CR into etcd. This will totally screw up any further reconciliation attempts. So, K8s should reject an attempt to create/modify (or in some cases even an attempt to delete) one of our CRs if our admission control hook is down. To ensure this, I've changed the failure policy to "Fail" for our webhooks. (issue #204)

In the event that someone really needs to delete a CR and KD is down and can't be resurrected, then they will have to edit or remove the webhook.

I've also added a liveness probe. If our validation server is down (probably because the entire operator process is dead), K8s will restart the container after 30 seconds of dead-ness. This should also help to solve the issue where the operator binary isn't running inside the container after a host reboot -- I would still like to be able to root-cause that, but I haven't made progress on that.

(Unrelated docs tweak in here too.)