### PR TITLE
handle host/pod shutdown and reboot

### DIFF
--- a/deploy/kubedirector/kubedirector_v1beta1_kubedirectorcluster_crd.yaml
+++ b/deploy/kubedirector/kubedirector_v1beta1_kubedirectorcluster_crd.yaml
@@ -228,7 +228,9 @@ spec:
                           properties:
                             configErrorDetail:
                               type: string
-                            lastGenerationUpdate:
+                            lastConfigDataGeneration:
+                              type: integer
+                            initialConfigGeneration:
                               type: integer
                             pendingNotifyCmds:
                               type: array

--- a/deploy/kubedirector/kubedirector_v1beta1_kubedirectorcluster_crd.yaml
+++ b/deploy/kubedirector/kubedirector_v1beta1_kubedirectorcluster_crd.yaml
@@ -187,6 +187,8 @@ spec:
                   type: boolean
                 membersDown:
                   type: boolean
+                membersInitializing:
+                  type: boolean
                 membersWaiting:
                   type: boolean
                 membersRestarting:

--- a/deploy/kubedirector/kubedirector_v1beta1_kubedirectorcluster_crd.yaml
+++ b/deploy/kubedirector/kubedirector_v1beta1_kubedirectorcluster_crd.yaml
@@ -191,11 +191,7 @@ spec:
                   type: boolean
                 membersRestarting:
                   type: boolean
-                configCmdErrors:
-                  type: boolean
-                pendingConfigDataUpdates:
-                  type: boolean
-                pendingNotifyCmds:
+                configErrors:
                   type: boolean
             generationUID:
               type: string

--- a/deploy/kubedirector/kubedirector_v1beta1_kubedirectorcluster_crd.yaml
+++ b/deploy/kubedirector/kubedirector_v1beta1_kubedirectorcluster_crd.yaml
@@ -185,6 +185,8 @@ spec:
               properties:
                 membershipChanging:
                   type: boolean
+                membersDown:
+                  type: boolean
                 configCmdErrors:
                   type: boolean
                 pendingConfigDataUpdates:
@@ -233,6 +235,8 @@ spec:
                             initialConfigGeneration:
                               type: integer
                             lastConfiguredContainer:
+                              type: string
+                            lastKnownContainerState:
                               type: string
                             pendingNotifyCmds:
                               type: array

--- a/deploy/kubedirector/kubedirector_v1beta1_kubedirectorcluster_crd.yaml
+++ b/deploy/kubedirector/kubedirector_v1beta1_kubedirectorcluster_crd.yaml
@@ -215,3 +215,10 @@ spec:
                           type: string
                         state:
                           type: string
+                        stateDetail:
+                          type: object
+                          properties:
+                            configErrorDetail:
+                              type: string
+                            lastGenerationUpdate:
+                              type: integer

--- a/deploy/kubedirector/kubedirector_v1beta1_kubedirectorcluster_crd.yaml
+++ b/deploy/kubedirector/kubedirector_v1beta1_kubedirectorcluster_crd.yaml
@@ -232,7 +232,7 @@ spec:
                               type: string
                             lastConfigDataGeneration:
                               type: integer
-                            initialConfigGeneration:
+                            lastSetupGeneration:
                               type: integer
                             configuringContainer:
                               type: string

--- a/deploy/kubedirector/kubedirector_v1beta1_kubedirectorcluster_crd.yaml
+++ b/deploy/kubedirector/kubedirector_v1beta1_kubedirectorcluster_crd.yaml
@@ -180,6 +180,11 @@ spec:
           properties:
             state:
               type: string
+            memberStateRollup:
+              type: object
+              properties:
+                configErrors:
+                  type: boolean
             generationUID:
               type: string
             clusterService:

--- a/deploy/kubedirector/kubedirector_v1beta1_kubedirectorcluster_crd.yaml
+++ b/deploy/kubedirector/kubedirector_v1beta1_kubedirectorcluster_crd.yaml
@@ -183,10 +183,18 @@ spec:
             memberStateRollup:
               type: object
               properties:
-                configErrors:
+                membershipChanging:
+                  type: boolean
+                configCmdErrors:
+                  type: boolean
+                pendingConfigDataUpdates:
+                  type: boolean
+                pendingNotifyCmds:
                   type: boolean
             generationUID:
               type: string
+            specGenerationToProcess:
+              type: integer
             clusterService:
               type: string
             lastNodeID:
@@ -222,3 +230,12 @@ spec:
                               type: string
                             lastGenerationUpdate:
                               type: integer
+                            pendingNotifyCmds:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  arguments:
+                                    type: array
+                                    items:
+                                      type: string

--- a/deploy/kubedirector/kubedirector_v1beta1_kubedirectorcluster_crd.yaml
+++ b/deploy/kubedirector/kubedirector_v1beta1_kubedirectorcluster_crd.yaml
@@ -187,6 +187,10 @@ spec:
                   type: boolean
                 membersDown:
                   type: boolean
+                membersWaiting:
+                  type: boolean
+                membersRestarting:
+                  type: boolean
                 configCmdErrors:
                   type: boolean
                 pendingConfigDataUpdates:

--- a/deploy/kubedirector/kubedirector_v1beta1_kubedirectorcluster_crd.yaml
+++ b/deploy/kubedirector/kubedirector_v1beta1_kubedirectorcluster_crd.yaml
@@ -234,6 +234,8 @@ spec:
                               type: integer
                             initialConfigGeneration:
                               type: integer
+                            configuringContainer:
+                              type: string
                             lastConfiguredContainer:
                               type: string
                             lastKnownContainerState:

--- a/deploy/kubedirector/kubedirector_v1beta1_kubedirectorcluster_crd.yaml
+++ b/deploy/kubedirector/kubedirector_v1beta1_kubedirectorcluster_crd.yaml
@@ -232,6 +232,8 @@ spec:
                               type: integer
                             initialConfigGeneration:
                               type: integer
+                            lastConfiguredContainer:
+                              type: string
                             pendingNotifyCmds:
                               type: array
                               items:

--- a/doc/virtual-clusters.md
+++ b/doc/virtual-clusters.md
@@ -66,7 +66,7 @@ You can edit the resource YAML file to add or remove a role, or increase/decreas
 
 Depending on the app definition, some resize operations may not be allowed for some roles. For example you will not be allowed to remove a Spark controller or have fewer than two Cassandra seeds. In these cases the resize attempt will be immediately rejected with an explanation.
 
-If a resize that grows the virtual cluster is accepted, but the status shows that some members are staying in create_pending state indefinitely, you may have requested more resources than your K8s nodes can provide. Use kubectl to examine the associated pods, see if they are stuck in Pending status, and what Events they are experiencing. If they appear to be permanently blocked without available resources, you will want to downsize or remove virtual cluster roles so that they no longer request as many members.
+If a resize that grows the virtual cluster is accepted, but the status shows that some members are staying in create pending state indefinitely, you may have requested more resources than your K8s nodes can provide. Use kubectl to examine the associated pods, see if they are stuck in Pending status, and what Events they are experiencing. If they appear to be permanently blocked without available resources, you will want to downsize or remove virtual cluster roles so that they no longer request as many members.
 
 #### DELETING
 

--- a/pkg/apis/kubedirector.hpe.com/v1beta1/kubedirectorcluster_types.go
+++ b/pkg/apis/kubedirector.hpe.com/v1beta1/kubedirectorcluster_types.go
@@ -120,6 +120,7 @@ type Role struct {
 // should be investigated.
 type StateRollup struct {
 	MembershipChanging       bool `json:"membershipChanging"`
+	MembersDown              bool `json:"membersDown"`
 	ConfigCmdErrors          bool `json:"configCmdErrors"`
 	PendingConfigDataUpdates bool `json:"pendingConfigDataUpdates"`
 	PendingNotifyCmds        bool `json:"pendingNotifyCmds"`
@@ -156,6 +157,7 @@ type MemberStateDetail struct {
 	LastConfigDataGeneration *int64              `json:"lastConfigDataGeneration,omitempty"`
 	InitialConfigGeneration  *int64              `json:"initialConfigGeneration,omitempty"`
 	LastConfiguredContainer  string              `json:"lastConfiguredContainer,omitempty"`
+	LastKnownContainerState  string              `json:"lastKnownContainerState,omitempty"`
 	PendingNotifyCmds        []*NotificationDesc `json:"pendingNotifyCmds,omitempty"`
 }
 

--- a/pkg/apis/kubedirector.hpe.com/v1beta1/kubedirectorcluster_types.go
+++ b/pkg/apis/kubedirector.hpe.com/v1beta1/kubedirectorcluster_types.go
@@ -155,6 +155,7 @@ type MemberStateDetail struct {
 	ConfigErrorDetail        *string             `json:"configErrorDetail,omitempty"`
 	LastConfigDataGeneration *int64              `json:"lastConfigDataGeneration,omitempty"`
 	InitialConfigGeneration  *int64              `json:"initialConfigGeneration,omitempty"`
+	LastConfiguredContainer  string              `json:"lastConfiguredContainer,omitempty"`
 	PendingNotifyCmds        []*NotificationDesc `json:"pendingNotifyCmds,omitempty"`
 }
 

--- a/pkg/apis/kubedirector.hpe.com/v1beta1/kubedirectorcluster_types.go
+++ b/pkg/apis/kubedirector.hpe.com/v1beta1/kubedirectorcluster_types.go
@@ -121,6 +121,8 @@ type Role struct {
 type StateRollup struct {
 	MembershipChanging       bool `json:"membershipChanging"`
 	MembersDown              bool `json:"membersDown"`
+	MembersWaiting           bool `json:"membersWaiting"`
+	MembersRestarting        bool `json:"membersRestarting"`
 	ConfigCmdErrors          bool `json:"configCmdErrors"`
 	PendingConfigDataUpdates bool `json:"pendingConfigDataUpdates"`
 	PendingNotifyCmds        bool `json:"pendingNotifyCmds"`

--- a/pkg/apis/kubedirector.hpe.com/v1beta1/kubedirectorcluster_types.go
+++ b/pkg/apis/kubedirector.hpe.com/v1beta1/kubedirectorcluster_types.go
@@ -38,11 +38,12 @@ type KubeDirectorClusterSpec struct {
 // indicates ongoing operations of cluster creation or reconfiguration.
 // +k8s:openapi-gen=true
 type KubeDirectorClusterStatus struct {
-	State          string       `json:"state"`
-	GenerationUID  string       `json:"generationUID"`
-	ClusterService string       `json:"clusterService"`
-	LastNodeID     int64        `json:"lastNodeID"`
-	Roles          []RoleStatus `json:"roles"`
+	State             string       `json:"state"`
+	MemberStateRollup StateRollup  `json:"memberStateRollup"`
+	GenerationUID     string       `json:"generationUID"`
+	ClusterService    string       `json:"clusterService"`
+	LastNodeID        int64        `json:"lastNodeID"`
+	Roles             []RoleStatus `json:"roles"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -112,6 +113,12 @@ type Role struct {
 	EnvVars        []corev1.EnvVar             `json:"env,omitempty"`
 	FileInjections []FileInjections            `json:"fileInjections,omitempty"`
 	Secret         *KDSecret                   `json:"secret,omitempty"`
+}
+
+// StateRollup surfaces whether any per-member statuses have problems that
+// should be investigated.
+type StateRollup struct {
+	ConfigErrors bool `json:"configErrors"`
 }
 
 // ClusterStorage defines the persistent storage size/type, if any, to be used

--- a/pkg/apis/kubedirector.hpe.com/v1beta1/kubedirectorcluster_types.go
+++ b/pkg/apis/kubedirector.hpe.com/v1beta1/kubedirectorcluster_types.go
@@ -156,6 +156,7 @@ type MemberStateDetail struct {
 	ConfigErrorDetail        *string             `json:"configErrorDetail,omitempty"`
 	LastConfigDataGeneration *int64              `json:"lastConfigDataGeneration,omitempty"`
 	InitialConfigGeneration  *int64              `json:"initialConfigGeneration,omitempty"`
+	ConfiguringContainer     string              `json:"configuringContainer,omitempty"`
 	LastConfiguredContainer  string              `json:"lastConfiguredContainer,omitempty"`
 	LastKnownContainerState  string              `json:"lastKnownContainerState,omitempty"`
 	PendingNotifyCmds        []*NotificationDesc `json:"pendingNotifyCmds,omitempty"`

--- a/pkg/apis/kubedirector.hpe.com/v1beta1/kubedirectorcluster_types.go
+++ b/pkg/apis/kubedirector.hpe.com/v1beta1/kubedirectorcluster_types.go
@@ -119,11 +119,12 @@ type Role struct {
 // StateRollup surfaces whether any per-member statuses have problems that
 // should be investigated.
 type StateRollup struct {
-	MembershipChanging bool `json:"membershipChanging"`
-	MembersDown        bool `json:"membersDown"`
-	MembersWaiting     bool `json:"membersWaiting"`
-	MembersRestarting  bool `json:"membersRestarting"`
-	ConfigErrors       bool `json:"configErrors"`
+	MembershipChanging  bool `json:"membershipChanging"`
+	MembersDown         bool `json:"membersDown"`
+	MembersInitializing bool `json:"membersInitializing"`
+	MembersWaiting      bool `json:"membersWaiting"`
+	MembersRestarting   bool `json:"membersRestarting"`
+	ConfigErrors        bool `json:"configErrors"`
 }
 
 // ClusterStorage defines the persistent storage size/type, if any, to be used

--- a/pkg/apis/kubedirector.hpe.com/v1beta1/kubedirectorcluster_types.go
+++ b/pkg/apis/kubedirector.hpe.com/v1beta1/kubedirectorcluster_types.go
@@ -137,11 +137,19 @@ type RoleStatus struct {
 
 // MemberStatus describes the component objects of a virtual cluster member.
 type MemberStatus struct {
-	Pod     string `json:"pod"`
-	Service string `json:"service"`
-	PVC     string `json:"pvc,omitempty"`
-	State   string `json:"state"`
-	NodeID  int64  `json:"nodeID"`
+	Pod         string            `json:"pod"`
+	Service     string            `json:"service"`
+	PVC         string            `json:"pvc,omitempty"`
+	State       string            `json:"state"`
+	StateDetail MemberStateDetail `json:"stateDetail,omitempty"`
+	NodeID      int64             `json:"nodeID"`
+}
+
+// MemberStateDetail digs into detail about the management of configmeta and
+// app scripts in the member.
+type MemberStateDetail struct {
+	ConfigErrorDetail    *string `json:"configErrorDetail,omitempty"`
+	LastGenerationUpdate *int64  `json:"lastGenerationUpdate,omitempty"`
 }
 
 func init() {

--- a/pkg/apis/kubedirector.hpe.com/v1beta1/kubedirectorcluster_types.go
+++ b/pkg/apis/kubedirector.hpe.com/v1beta1/kubedirectorcluster_types.go
@@ -155,7 +155,7 @@ type MemberStatus struct {
 type MemberStateDetail struct {
 	ConfigErrorDetail        *string             `json:"configErrorDetail,omitempty"`
 	LastConfigDataGeneration *int64              `json:"lastConfigDataGeneration,omitempty"`
-	InitialConfigGeneration  *int64              `json:"initialConfigGeneration,omitempty"`
+	LastSetupGeneration      *int64              `json:"lastSetupGeneration,omitempty"`
 	ConfiguringContainer     string              `json:"configuringContainer,omitempty"`
 	LastConfiguredContainer  string              `json:"lastConfiguredContainer,omitempty"`
 	LastKnownContainerState  string              `json:"lastKnownContainerState,omitempty"`

--- a/pkg/apis/kubedirector.hpe.com/v1beta1/kubedirectorcluster_types.go
+++ b/pkg/apis/kubedirector.hpe.com/v1beta1/kubedirectorcluster_types.go
@@ -152,9 +152,10 @@ type MemberStatus struct {
 // MemberStateDetail digs into detail about the management of configmeta and
 // app scripts in the member.
 type MemberStateDetail struct {
-	ConfigErrorDetail    *string            `json:"configErrorDetail,omitempty"`
-	LastGenerationUpdate *int64             `json:"lastGenerationUpdate,omitempty"`
-	PendingNotifyCmds    []NotificationDesc `json:"PendingNotifyCmds,omitempty"`
+	ConfigErrorDetail        *string             `json:"configErrorDetail,omitempty"`
+	LastConfigDataGeneration *int64              `json:"lastConfigDataGeneration,omitempty"`
+	InitialConfigGeneration  *int64              `json:"initialConfigGeneration,omitempty"`
+	PendingNotifyCmds        []*NotificationDesc `json:"pendingNotifyCmds,omitempty"`
 }
 
 // NotificationDesc contains the info necessary to perform a notify command.

--- a/pkg/apis/kubedirector.hpe.com/v1beta1/kubedirectorcluster_types.go
+++ b/pkg/apis/kubedirector.hpe.com/v1beta1/kubedirectorcluster_types.go
@@ -119,13 +119,11 @@ type Role struct {
 // StateRollup surfaces whether any per-member statuses have problems that
 // should be investigated.
 type StateRollup struct {
-	MembershipChanging       bool `json:"membershipChanging"`
-	MembersDown              bool `json:"membersDown"`
-	MembersWaiting           bool `json:"membersWaiting"`
-	MembersRestarting        bool `json:"membersRestarting"`
-	ConfigCmdErrors          bool `json:"configCmdErrors"`
-	PendingConfigDataUpdates bool `json:"pendingConfigDataUpdates"`
-	PendingNotifyCmds        bool `json:"pendingNotifyCmds"`
+	MembershipChanging bool `json:"membershipChanging"`
+	MembersDown        bool `json:"membersDown"`
+	MembersWaiting     bool `json:"membersWaiting"`
+	MembersRestarting  bool `json:"membersRestarting"`
+	ConfigErrors       bool `json:"configErrors"`
 }
 
 // ClusterStorage defines the persistent storage size/type, if any, to be used

--- a/pkg/apis/kubedirector.hpe.com/v1beta1/kubedirectorcluster_types.go
+++ b/pkg/apis/kubedirector.hpe.com/v1beta1/kubedirectorcluster_types.go
@@ -38,12 +38,13 @@ type KubeDirectorClusterSpec struct {
 // indicates ongoing operations of cluster creation or reconfiguration.
 // +k8s:openapi-gen=true
 type KubeDirectorClusterStatus struct {
-	State             string       `json:"state"`
-	MemberStateRollup StateRollup  `json:"memberStateRollup"`
-	GenerationUID     string       `json:"generationUID"`
-	ClusterService    string       `json:"clusterService"`
-	LastNodeID        int64        `json:"lastNodeID"`
-	Roles             []RoleStatus `json:"roles"`
+	State                   string       `json:"state"`
+	MemberStateRollup       StateRollup  `json:"memberStateRollup"`
+	GenerationUID           string       `json:"generationUID"`
+	SpecGenerationToProcess *int64       `json:"specGenerationToProcess,omitempty"`
+	ClusterService          string       `json:"clusterService"`
+	LastNodeID              int64        `json:"lastNodeID"`
+	Roles                   []RoleStatus `json:"roles"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -118,7 +119,10 @@ type Role struct {
 // StateRollup surfaces whether any per-member statuses have problems that
 // should be investigated.
 type StateRollup struct {
-	ConfigErrors bool `json:"configErrors"`
+	MembershipChanging       bool `json:"membershipChanging"`
+	ConfigCmdErrors          bool `json:"configCmdErrors"`
+	PendingConfigDataUpdates bool `json:"pendingConfigDataUpdates"`
+	PendingNotifyCmds        bool `json:"pendingNotifyCmds"`
 }
 
 // ClusterStorage defines the persistent storage size/type, if any, to be used
@@ -148,8 +152,14 @@ type MemberStatus struct {
 // MemberStateDetail digs into detail about the management of configmeta and
 // app scripts in the member.
 type MemberStateDetail struct {
-	ConfigErrorDetail    *string `json:"configErrorDetail,omitempty"`
-	LastGenerationUpdate *int64  `json:"lastGenerationUpdate,omitempty"`
+	ConfigErrorDetail    *string            `json:"configErrorDetail,omitempty"`
+	LastGenerationUpdate *int64             `json:"lastGenerationUpdate,omitempty"`
+	PendingNotifyCmds    []NotificationDesc `json:"PendingNotifyCmds,omitempty"`
+}
+
+// NotificationDesc contains the info necessary to perform a notify command.
+type NotificationDesc struct {
+	Arguments []string `json:"arguments,omitempty"`
 }
 
 func init() {

--- a/pkg/controller/kubedirectorcluster/cluster.go
+++ b/pkg/controller/kubedirectorcluster/cluster.go
@@ -88,11 +88,14 @@ func (r *ReconcileKubeDirectorCluster) syncCluster(
 				}
 			}
 			// If any necessary status update worked, let's also update
-			// finalizers if necessary.
+			// finalizers if necessary. To be safe, don't include the status
+			// stanza in this write.
 			if (updateErr == nil) && finalizersChanged {
 				// See https://github.com/bluek8s/kubedirector/issues/194
 				// Migrate Client().Update() calls back to Patch() calls.
-				updateErr = shared.Update(context.TODO(), cr)
+				crWithoutStatus := cr.DeepCopy()
+				crWithoutStatus.Status = nil
+				updateErr = shared.Update(context.TODO(), crWithoutStatus)
 			}
 			// Bail out if we're done.
 			if updateErr == nil {

--- a/pkg/controller/kubedirectorcluster/cluster.go
+++ b/pkg/controller/kubedirectorcluster/cluster.go
@@ -55,6 +55,7 @@ func (r *ReconcileKubeDirectorCluster) syncCluster(
 
 	// Set a defer func to write new status and/or finalizers if they change.
 	defer func() {
+		syncMemberNotifies(reqLogger, cr)
 		updateStateRollup(cr)
 		nowHasFinalizer := shared.HasFinalizer(cr)
 		// Bail out if nothing has changed.
@@ -253,11 +254,11 @@ func updateStateRollup(
 				// SpecGenerationToProcess should always be non-nil if we have
 				// a ready member, but let's be paranoid.
 				if cr.Status.SpecGenerationToProcess != nil {
-					// Similarly the LastGenerationUpdate of a ready member
+					// Similarly the LastConfigDataGeneration of a ready member
 					// should always be non-nil but eh.
-					if memberStatus.StateDetail.LastGenerationUpdate == nil {
+					if memberStatus.StateDetail.LastConfigDataGeneration == nil {
 						cr.Status.MemberStateRollup.PendingConfigDataUpdates = true
-					} else if *cr.Status.SpecGenerationToProcess != *memberStatus.StateDetail.LastGenerationUpdate {
+					} else if *cr.Status.SpecGenerationToProcess != *memberStatus.StateDetail.LastConfigDataGeneration {
 						cr.Status.MemberStateRollup.PendingConfigDataUpdates = true
 					}
 				}

--- a/pkg/controller/kubedirectorcluster/cluster.go
+++ b/pkg/controller/kubedirectorcluster/cluster.go
@@ -323,7 +323,7 @@ func checkContainerStates(
 							// No persistent storage, so any previously uploaded
 							// stuff has been lost.
 							memberStatus.StateDetail.LastConfigDataGeneration = nil
-							memberStatus.StateDetail.InitialConfigGeneration = nil
+							memberStatus.StateDetail.LastSetupGeneration = nil
 							// We will completely rerun the config, so drop any
 							// pending notifies.
 							memberStatus.StateDetail.PendingNotifyCmds = []*kdv1.NotificationDesc{}

--- a/pkg/controller/kubedirectorcluster/cluster.go
+++ b/pkg/controller/kubedirectorcluster/cluster.go
@@ -58,8 +58,12 @@ func (r *ReconcileKubeDirectorCluster) syncCluster(
 		syncMemberNotifies(reqLogger, cr)
 		updateStateRollup(cr)
 		nowHasFinalizer := shared.HasFinalizer(cr)
-		// Bail out if nothing has changed.
-		statusChanged := !reflect.DeepEqual(cr.Status, oldStatus)
+		// Bail out if nothing has changed. Note that if we are deleting we
+		// don't care if status has changed.
+		statusChanged := false
+		if (cr.DeletionTimestamp == nil) || nowHasFinalizer {
+			statusChanged = !reflect.DeepEqual(cr.Status, oldStatus)
+		}
 		finalizersChanged := (hadFinalizer != nowHasFinalizer)
 		if !(statusChanged || finalizersChanged) {
 			return

--- a/pkg/controller/kubedirectorcluster/members.go
+++ b/pkg/controller/kubedirectorcluster/members.go
@@ -920,6 +920,13 @@ func appConfig(
 		stateDetail.ConfigErrorDetail = nil
 		stateDetail.InitialConfigGeneration = nil
 		stateDetail.PendingNotifyCmds = []*kdv1.NotificationDesc{}
+		shared.LogInfof(
+			reqLogger,
+			cr,
+			shared.EventReasonMember,
+			"member{%s} was previously in config error state; re-trying setup",
+			podName,
+		)
 	} else {
 		// For initial configuration, startscript will run asynchronously and we
 		// will check back periodically. So let's have a look at the existing
@@ -956,6 +963,13 @@ func appConfig(
 				if configContainerID == expectedContainerID {
 					return false, nil
 				}
+				shared.LogInfof(
+					reqLogger,
+					cr,
+					shared.EventReasonMember,
+					"previous setup for member{%s} interrupted; re-trying setup",
+					podName,
+				)
 			} else {
 				// All done, what status did we get?
 				status, convErr := strconv.Atoi(configStatus)

--- a/pkg/controller/kubedirectorcluster/members.go
+++ b/pkg/controller/kubedirectorcluster/members.go
@@ -175,10 +175,10 @@ func handleReadyMembers(
 }
 
 // handleCreatePendingMembers operates on all members in the role that are
-// currently in the create_pending state. It first adjusts the statefulset
+// currently in the create pending state. It first adjusts the statefulset
 // replicas count as necessary, then checks each new member to see if it is
 // running. If so, it moves it to the creating state. It is quite possible for
-// members to be left in the create_pending state across multiple reconciler
+// members to be left in the create pending state across multiple reconciler
 // passes.
 func handleCreatePendingMembers(
 	reqLogger logr.Logger,
@@ -489,9 +489,9 @@ func handleDeletingMembers(
 }
 
 // handleDeletePendingMembers operates on all members in the role that are
-// currently in the delete_pending state. It first notifies all ready members
+// currently in the delete pending state. It first notifies all ready members
 // in the cluster of the impending deletion; then it moves all of these
-// delete_pending members to the deleting state.
+// delete pending members to the deleting state.
 func handleDeletePendingMembers(
 	reqLogger logr.Logger,
 	cr *kdv1.KubeDirectorCluster,

--- a/pkg/controller/kubedirectorcluster/members.go
+++ b/pkg/controller/kubedirectorcluster/members.go
@@ -97,10 +97,12 @@ func syncMemberNotifies(
 ) {
 
 	var membersToProcess []*kdv1.MemberStatus
-	for _, roleStatus := range cr.Status.Roles {
+	numRoleStatuses := len(cr.Status.Roles)
+	for i := 0; i < numRoleStatuses; i++ {
+		roleStatus := &(cr.Status.Roles[i])
 		numMembers := len(roleStatus.Members)
-		for i := 0; i < numMembers; i++ {
-			memberStatus := &(roleStatus.Members[i])
+		for j := 0; j < numMembers; j++ {
+			memberStatus := &(roleStatus.Members[j])
 			if len(memberStatus.StateDetail.PendingNotifyCmds) != 0 {
 				if memberStatus.State == string(memberReady) {
 					membersToProcess = append(membersToProcess, memberStatus)

--- a/pkg/controller/kubedirectorcluster/roles.go
+++ b/pkg/controller/kubedirectorcluster/roles.go
@@ -245,7 +245,7 @@ func calcRoleMembersByState(
 
 // handleRoleCreate deals with a newly specified role. If the desired population
 // is nonzero then it will create an associated statefulset and create the
-// role status and its member statuses (initially as create_pending). Failure
+// role status and its member statuses (initially as create pending). Failure
 // to create a statefulset will be a reconciler-stopping error.
 func handleRoleCreate(
 	reqLogger logr.Logger,
@@ -341,7 +341,7 @@ func handleRoleReCreate(
 		*anyMembersChanged = true
 		// Need to clean up from the old status before we make a new
 		// statefulset. For any pods that had reached "ready" or "error" state,
-		// we should mark them first as "delete_pending" -- we know we have notified
+		// we should mark them first as "delete pending" -- we know we have notified
 		// other pods of these creations, so we should now notify of deletions.
 		// For other pods we can just move them straight into deleting state.
 		numMembers := len(role.roleStatus.Members)
@@ -435,7 +435,7 @@ func handleRoleResize(
 
 	// We won't even be attempting a resize if there are any creating-state
 	// members, so the current set of "requested members" is just ready plus
-	// create_pending.
+	// create pending.
 	prevDesiredPop :=
 		len(role.membersByState[memberReady]) +
 			len(role.membersByState[memberConfigError]) +
@@ -444,7 +444,7 @@ func handleRoleResize(
 		return
 	}
 	if role.desiredPop > prevDesiredPop {
-		// Only expand if no members are in delete_pending or deleting states;
+		// Only expand if no members are in delete pending or deleting states;
 		// we can't use expand to "rescue" a member that is currently being
 		// deleted. (The way statefulsets reuse FQDNs, we might be able to get
 		// away with that actually, but let's not complicate things.)
@@ -474,7 +474,7 @@ func handleRoleResize(
 	}
 }
 
-// addMemberStatuses adds member statuses to a role, in create_pending state,
+// addMemberStatuses adds member statuses to a role, in create pending state,
 // to bring it up to the desired number of members. It also updates the
 // members-by-state map accordingly.
 func addMemberStatuses(
@@ -515,8 +515,8 @@ func addMemberStatuses(
 }
 
 // deleteMemberStatuses changes member statuses in a role by moving them from
-// to delete_pending state (if currently ready) or deleting state (if currently
-// create_pending or creating), to prepare to shrink the role to the desired
+// to delete pending state (if currently ready) or deleting state (if currently
+// create pending or creating), to prepare to shrink the role to the desired
 // number of members. It also updates the members-by-state map accordingly.
 func deleteMemberStatuses(
 	role *roleInfo,

--- a/pkg/controller/kubedirectorcluster/types.go
+++ b/pkg/controller/kubedirectorcluster/types.go
@@ -24,7 +24,7 @@ type clusterState string
 const (
 	clusterCreating clusterState = "creating"
 	clusterUpdating              = "updating"
-	clusterReady                 = "ready"
+	clusterReady                 = "configured"
 	// ClusterSpecModified is exported because it is actually only used by
 	// the validator; declaring it here just to keep all cluster states in
 	// one spot.

--- a/pkg/controller/kubedirectorcluster/types.go
+++ b/pkg/controller/kubedirectorcluster/types.go
@@ -60,6 +60,14 @@ var transitionalMemberStates = []string{
 }
 
 const (
+	containerRunning    = "running"
+	containerWaiting    = "waiting"
+	containerTerminated = "terminated"
+	containerMissing    = "missing"
+	containerUnknown    = "unknown"
+)
+
+const (
 	configMetaFile      = "/etc/guestconfig/configmeta.json"
 	configcliSrcFile    = "/home/kubedirector/configcli.tgz"
 	configcliDestFile   = "/tmp/configcli.tgz"

--- a/pkg/controller/kubedirectorcluster/types.go
+++ b/pkg/controller/kubedirectorcluster/types.go
@@ -62,11 +62,13 @@ var deletingMemberStates = []string{
 }
 
 const (
-	containerRunning    = "running"
-	containerWaiting    = "waiting"
-	containerTerminated = "terminated"
-	containerMissing    = "absent"
-	containerUnknown    = "unknown"
+	containerRunning      = "running"
+	containerWaiting      = "waiting"
+	containerInitializing = "initializing"
+	containerUnresponsive = "unresponsive"
+	containerTerminated   = "terminated"
+	containerMissing      = "absent"
+	containerUnknown      = "unknown"
 )
 
 const (

--- a/pkg/controller/kubedirectorcluster/types.go
+++ b/pkg/controller/kubedirectorcluster/types.go
@@ -45,7 +45,6 @@ type memberState string
 const (
 	memberCreatePending memberState = "create pending"
 	memberCreating                  = "creating"
-	memberConfigured                = "configured-internal" // not externally visible
 	memberReady                     = "configured"
 	memberDeletePending             = "delete pending"
 	memberDeleting                  = "deleting"

--- a/pkg/controller/kubedirectorcluster/types.go
+++ b/pkg/controller/kubedirectorcluster/types.go
@@ -52,6 +52,13 @@ const (
 	memberConfigError               = "config error"
 )
 
+var transitionalMemberStates = []string{
+	string(memberCreatePending),
+	string(memberCreating),
+	string(memberDeletePending),
+	string(memberDeleting),
+}
+
 const (
 	configMetaFile      = "/etc/guestconfig/configmeta.json"
 	configcliSrcFile    = "/home/kubedirector/configcli.tgz"

--- a/pkg/controller/kubedirectorcluster/types.go
+++ b/pkg/controller/kubedirectorcluster/types.go
@@ -45,8 +45,8 @@ type memberState string
 const (
 	memberCreatePending memberState = "create pending"
 	memberCreating                  = "creating"
-	memberConfigured                = "configured" // not externally visible
-	memberReady                     = "ready"
+	memberConfigured                = "configured-internal" // not externally visible
+	memberReady                     = "configured"
 	memberDeletePending             = "delete pending"
 	memberDeleting                  = "deleting"
 	memberConfigError               = "config error"
@@ -63,7 +63,7 @@ const (
 	containerRunning    = "running"
 	containerWaiting    = "waiting"
 	containerTerminated = "terminated"
-	containerMissing    = "missing"
+	containerMissing    = "absent"
 	containerUnknown    = "unknown"
 )
 

--- a/pkg/controller/kubedirectorcluster/types.go
+++ b/pkg/controller/kubedirectorcluster/types.go
@@ -52,9 +52,11 @@ const (
 	memberConfigError               = "config error"
 )
 
-var transitionalMemberStates = []string{
+var creatingMemberStates = []string{
 	string(memberCreatePending),
 	string(memberCreating),
+}
+var deletingMemberStates = []string{
 	string(memberDeletePending),
 	string(memberDeleting),
 }

--- a/pkg/controller/kubedirectorcluster/types.go
+++ b/pkg/controller/kubedirectorcluster/types.go
@@ -88,11 +88,11 @@ const (
 	rm -rf /opt/guestconfig/appconfig.tgz`
 	appPrepConfigStatus = "/opt/guestconfig/configure.status"
 	appPrepConfigRunCmd = `rm -f /opt/guestconfig/configure.* &&
-	touch ` + appPrepConfigStatus + ` &&
+	echo -n %s= > ` + appPrepConfigStatus + ` &&
 	nohup sh -c "` + appPrepStartscript + ` --configure
 	2> /opt/guestconfig/configure.stderr
 	1> /opt/guestconfig/configure.stdout;
-	echo -n $? > ` + appPrepConfigStatus + `" &`
+	echo -n $? >> ` + appPrepConfigStatus + `" &`
 	fileInjectionCommand = `mkdir -p %s && cd %s &&
 	curl -L %s -o %s`
 )

--- a/pkg/controller/kubedirectorcluster/types.go
+++ b/pkg/controller/kubedirectorcluster/types.go
@@ -25,6 +25,10 @@ const (
 	clusterCreating clusterState = "creating"
 	clusterUpdating              = "updating"
 	clusterReady                 = "ready"
+	// ClusterSpecModified is exported because it is actually only used by
+	// the validator; declaring it here just to keep all cluster states in
+	// one spot.
+	ClusterSpecModified = "spec modified"
 )
 
 type clusterStateInternal int

--- a/pkg/controller/kubedirectorcluster/types.go
+++ b/pkg/controller/kubedirectorcluster/types.go
@@ -43,13 +43,13 @@ const (
 type memberState string
 
 const (
-	memberCreatePending memberState = "create_pending"
+	memberCreatePending memberState = "create pending"
 	memberCreating                  = "creating"
-	memberConfigured                = "configured_internal" // not externally visible
+	memberConfigured                = "configured" // not externally visible
 	memberReady                     = "ready"
-	memberDeletePending             = "delete_pending"
+	memberDeletePending             = "delete pending"
 	memberDeleting                  = "deleting"
-	memberConfigError               = "config_error"
+	memberConfigError               = "config error"
 )
 
 const (

--- a/pkg/controller/kubedirectorconfig/config.go
+++ b/pkg/controller/kubedirectorconfig/config.go
@@ -61,8 +61,12 @@ func (r *ReconcileKubeDirectorConfig) syncConfig(
 	// Set a defer func to write new status and/or finalizers if they change.
 	defer func() {
 		nowHasFinalizer := shared.HasFinalizer(cr)
-		// Bail out if nothing has changed.
-		statusChanged := !reflect.DeepEqual(cr.Status, oldStatus)
+		// Bail out if nothing has changed. Note that if we are deleting we
+		// don't care if status has changed.
+		statusChanged := false
+		if (cr.DeletionTimestamp == nil) || nowHasFinalizer {
+			statusChanged = !reflect.DeepEqual(cr.Status, oldStatus)
+		}
 		finalizersChanged := (hadFinalizer != nowHasFinalizer)
 		if !(statusChanged || finalizersChanged) {
 			return

--- a/pkg/controller/kubedirectorconfig/config.go
+++ b/pkg/controller/kubedirectorconfig/config.go
@@ -90,11 +90,14 @@ func (r *ReconcileKubeDirectorConfig) syncConfig(
 				}
 			}
 			// If any necessary status update worked, let's also update
-			// finalizers if necessary.
+			// finalizers if necessary. To be safe, don't include the status
+			// stanza in this write.
 			if (updateErr == nil) && finalizersChanged {
 				// See https://github.com/bluek8s/kubedirector/issues/194
 				// Migrate Client().Update() calls back to Patch() calls.
-				updateErr = shared.Update(context.TODO(), cr)
+				crWithoutStatus := cr.DeepCopy()
+				crWithoutStatus.Status = nil
+				updateErr = shared.Update(context.TODO(), crWithoutStatus)
 			}
 			// Bail out if we're done.
 			if updateErr == nil {

--- a/pkg/validator/cluster.go
+++ b/pkg/validator/cluster.go
@@ -71,6 +71,56 @@ func (obj clusterPatchValue) MarshalJSON() ([]byte, error) {
 	return json.Marshal(obj.ValueStr)
 }
 
+// validateSpecChange is only called when an update is changing the spec. It
+// enforces that the cluster spec may not be modified if the previous spec
+// change has not been seen by the reconciler. (This invariant is required
+// for some error-handling cases.) If the spec is being modified & that's ok,
+// will return a patch to change the cluster overall status to "spec modified".
+func validateSpecChange(
+	cr *kdv1.KubeDirectorCluster,
+	prevCr *kdv1.KubeDirectorCluster,
+	valErrors []string,
+	patches []clusterPatchSpec,
+) ([]string, []clusterPatchSpec) {
+
+	// If this is an update and the reconciler has not yet created the status
+	// stanza, that's a problem.
+	if cr.Status == nil {
+		valErrors = append(
+			valErrors,
+			multipleSpecChange,
+		)
+		return valErrors, patches
+	}
+
+	stringStateModified := string(kubedirectorcluster.ClusterSpecModified)
+
+	// Spec change not allowed if the overall cluster state is still
+	// "spec modified".
+	if cr.Status.State == stringStateModified {
+		valErrors = append(
+			valErrors,
+			multipleSpecChange,
+		)
+		return valErrors, patches
+	}
+
+	// Spec is changing and that's OK. Update state to indicate a modify is
+	// waiting for the reconciler to pick it up.
+	newState := stringStateModified
+	patches = append(
+		patches,
+		clusterPatchSpec{
+			Op:   "replace",
+			Path: "/status/state",
+			Value: clusterPatchValue{
+				ValueStr: &newState,
+			},
+		},
+	)
+	return valErrors, patches
+}
+
 // validateCardinality checks the member count specified for a role in the
 // cluster CR against the cardinality value from the app CR. Any generated
 // error messages will be added to the input list and returned. If there were
@@ -781,7 +831,9 @@ func admitClusterCR(
 
 	// Shortcut out of here if the spec is not being changed. Among other
 	// things this allows KD to update status or metadata even if the
-	// referenced app is bad/gone.
+	// referenced app is bad/gone. Note that we can't just check the
+	// metadata generation number here because that is incremented after this
+	// validator sees the request.
 	if ar.Request.Operation == v1beta1.Update {
 		if reflect.DeepEqual(clusterCR.Spec, prevClusterCR.Spec) {
 			admitResponse.Allowed = true
@@ -800,6 +852,12 @@ func admitClusterCR(
 		return &admitResponse
 	}
 
+	// Validate that it's OK to change the spec. Note that this check assumes
+	// that the above "shortcut" is in place, i.e. we are only calling this
+	// if the spec is changing.
+	if ar.Request.Operation == v1beta1.Update {
+		valErrors, patches = validateSpecChange(&clusterCR, &prevClusterCR, valErrors, patches)
+	}
 	// Validate cardinality and generate patches for defaults members values.
 	valErrors, patches = validateCardinality(&clusterCR, appCR, valErrors, patches)
 

--- a/pkg/validator/cluster.go
+++ b/pkg/validator/cluster.go
@@ -95,12 +95,16 @@ func validateSpecChange(
 	}
 
 	// Spec change not allowed if pending notifies.
-	if cr.Status.MemberStateRollup.PendingNotifyCmds {
-		valErrors = append(
-			valErrors,
-			pendingNotifies,
-		)
-		return valErrors, patches
+	for _, roleStatus := range cr.Status.Roles {
+		for _, memberStatus := range roleStatus.Members {
+			if len(memberStatus.StateDetail.PendingNotifyCmds) != 0 {
+				valErrors = append(
+					valErrors,
+					pendingNotifies,
+				)
+				return valErrors, patches
+			}
+		}
 	}
 
 	stringStateModified := string(kubedirectorcluster.ClusterSpecModified)

--- a/pkg/validator/types.go
+++ b/pkg/validator/types.go
@@ -37,6 +37,8 @@ const (
 	appKey  = "app.pem"
 	rootCrt = "ca.crt"
 
+	multipleSpecChange = "Change to spec not allowed before previous spec change has been processed."
+
 	invalidAppMessage  = "Invalid app(%s). This app resource ID has not been registered."
 	invalidCardinality = "Invalid member count for role(%s). Specified member count:%d Role cardinality:%s"
 	invalidRole        = "Invalid role(%s) in app(%s) specified. Valid roles: \"%s\""

--- a/pkg/validator/types.go
+++ b/pkg/validator/types.go
@@ -38,6 +38,7 @@ const (
 	rootCrt = "ca.crt"
 
 	multipleSpecChange = "Change to spec not allowed before previous spec change has been processed."
+	pendingNotifies    = "Change to spec not allowed because some members have not processed notifications of previous change."
 
 	invalidAppMessage  = "Invalid app(%s). This app resource ID has not been registered."
 	invalidCardinality = "Invalid member count for role(%s). Specified member count:%d Role cardinality:%s"


### PR DESCRIPTION
This PR addresses (at least partially) issue #18 and issue #66.

We want to add more status useful for analyzing when cluster members are in bad or transitional states, and add more smarts to reconciliation to help cluster members survive those states.

Note that this change does NOT include automatic recovery if the host for some member is permanently down. Someone with the right privileges will still need to explicitly delete that pod so that the statefulset controller will reschedule/recreate it. There is room for us to add value there in the future.

If a member is stuck in config-error state, you can also delete its pod to trigger another attempt at getting that member set up. (If there's a bug in your app image/setup it will probably just end up in config-error state again though.)

There's a couple more things I want to add after this in terms of dev/debug "trigger labels" that can be applied to a KD cluster to forcibly move members out of bad states. Not in this PR though.

----------

The general ideas for handling pod death and/or restart better:

* Be stricter in the validator about whether we can send additional changes to a cluster that has not finished digesting previous changes yet (because of dead pods). Once we start propagating spec changes to the app containers, we don't track enough state history to continue to allow more spec changes while the previous changes have not been fully propagated.

* Be persistent -- if configmeta updates or add/delete notifies fail on one handler pass, try again later.

* Notice if the container ID changes for a member, indicating that the pod has restarted. If so, pop the member back into create-pending state so we can send them back through the process of making sure they have their app configuration set up. This will cause any file injections to happen again, and one of four things to happen with app setup:
  * If the role has no setup package, do nothing.
  * Or if the previous setup had ended in a config error, re-run setup from scratch.
  * Or if the member has no persistent storage, re-run setup from scratch.
  * Or just run through the normal appConfig code paying attention to any existing status file. If it shows that the previous config completed successfully then no need to do initial setup again. (If stuff has happened while the pod was down, it may immediately then need to get add/delete notifies.)

----------

Specific changes in status:

* A memberStateRollup block at the top level of the status stanza. This is to just help advertise when things are "going on" with some individual members; it has no functional impact. The properties in this block are:
  * membershipChanging: This is true if members are in the process of being added to or removed from the cluster. Specifically these are members in the creating or create-pending state that have not previously been successfully brought to a configured state (i.e. are not just restarting), or members in the deleting or delete-pending state.
  * membersDown: This is true if member containers (our "app" container in each pod) are in a terminated or unresponsive state or just plain missing. Members in deleting or create-pending state are not included here.
  * membersInitializing: This is true if members are waiting on persistent storage setup. This may take a while if large quantities of data must be initially copied to a PV.
  * membersWaiting: This is true if member containers are waiting for some condition (other than persistent storage setup) before they can start running. Investigate the member status and pod resource status/events for details if this persists. May require admin intervention; e.g. a Docker image pull will resolve itself if the image is indeed available in the repo, but lack of resources might not.
  * membersRestarting: This is true if members are in the process of coming back up and possibly getting their app config/setup refreshed. Specifically these are members in the creating or create-pending state that have previously been successfully brought to a configured state.
  * configErrors: This is true if any members are in the config-error state.

* A specGenerationToProcess property also in the top level. This reflects the generation of the KD cluster (from the resource's metadata) that the operator desires to reflect in the app setup. It's quite possible to make changes to the KD cluster resource, e.g. by just editing labels, that don't affect this number. This number is not useful for most clients but is used by reconciliation logic in KD.

* A stateDetail block within each member status. This is used by reconciliation logic, and some of the properties can also be useful for other clients to help determine exactly what is up with an individual member. The properties in this block are:
  * configErrorDetail: A string that is populated if and only if the member is in config-error state, and then also persisted after restarting from config-error state until config is attempted again. Describes the error encountered.
  * lastConfigDataGeneration: An integer populated when the member has configmeta injected (note that for no-setup-package roles this will not happen). Advertises the KD cluster resource generation number for which configmeta was generated and pushed into the member. Updated each time that configmeta is refreshed for this member.
  * lastSetupGeneration: An integer set equal to lastConfigDataGeneration when the member runs a setup script to process that config data. This can be at initial setup time, at reboot time if setup needs to be re-run, or when processing an add/delete notify.
  * configuringContainer: While going through initial configuration, this is the Docker container ID corresponding to our app container inside the member's pod. Functionally this is just an opaque UUID that we trust will change if the container gets restarted.
  * lastConfiguredContainer: The Docker container ID at the time that the member successfully reached configured state. Again all we care about is that this is a UUID that changes if the container gets restarted.
  * lastKnownContainerState: Just advertised FYI. Can be one of:
    * running: Container is in the K8s running state, and neither KD nor K8s are having trouble contacting it.
    * unresponsive: Container is in the K8s running state. But KD can't execute necessary commands in it, and/or K8s has its Ready condition set false.
    * initializing: An init container is running (to set up persistent storage).
    * waiting: Container is in the K8s waiting state but an init container is NOT what it is waiting on. The most likely candidate for time spent in this state is a docker image pull.
    * terminated: Container is in the K8s terminated state.
    * absent: Container does not exist. Not a problem if member state is create pending, but probably bad news otherwise. If this persists while in create pending, it's usually a case of insufficient resources to schedule.
    * unknown: Couldn't determine a result based on the rules above. "Shouldn't happen."
  * pendingNotifyCmds: A list of objects describing the add or delete notifies to be sent to a member. Each object just has one property "arguments" whose value is a list of the appropriate startscript arguments. It's fine for objects to come and go in this list, but if they remain here then that will block future spec changes to the KD cluster.

----------

There's a couple of interesting situations that can affect these properties:
* appConfig is run on a restarted member that was previously in the config-error state. In this case we will try to re-run initial configuration from scratch. We will intentionally forget any status that stores previous config results or pending add/delete notifications. We'll call this the "error retry restart" situation.
* A container gets restarted and it doesn't have persistent storage. In this case we will definitely need to re-run appConfig even if it was previously successful. We need to forget not only previous config results but also any idea of the configmeta version sent to the member. We'll call this the "clean slate restart" situation. checkContainerState will detect this case at the beginning of our cluster handler. appConfig should naturally do setup from scratch since any configure.status file will have been lost.

So that being said, here's how these properties are populated:

* memberStateRollup is calculated in syncCluster at the end of every handler. The updateStateRollup is called from the same deferred func that writes back any CR status changes. It's a pretty straightforward examination of each member status.

* specGenerationToProcess is also populated in syncCluster; it's set to the current resource generation if syncClusterRoles returned clusterMembersChangedUnready, i.e. when something in the spec has changed that we need to propagate into the members.

* The bits of the member stateDetail block are calculated at various points:
  * configErrorDetail is set whenever configuration succeeds/fails in handleCreatingMembers. It is cleared on success and set to some message on failure.
  * lastConfigDataGeneration is normally set either in appConfig (during handleCreatingMembers) when first configuring a member or in handleReadyMembers when updating the configmeta. It will be cleared in a "clean slate restart".
  * lastSetupGeneration set equal to lastConfigDataGeneration whenever that data is processed by the member. It is initially set when initial setup completes, and is then updated when any notify to the member succeeds. It will be cleared in "error retry restart" as well as "clean slate restart".
  * configuringContainer is set in handleCreatePendingMembers when moving members to creating state, and then cleared in handleCreatingMembers when setup is complete.
  * lastConfiguredContainer is set in handleCreatingMembers when setup is complete.
  * lastKnownContainerState is set in checkContainerStates.
  * pendingNotifyCmds is normally set/modified in queueNotify (during handleCreatingMembers and handleDeletePendingMembers) and then processed/cleared in syncMemberNotifies, called at the end of each cluster handler in the deferred func. It is cleared at the end of setup, because setup will have captured the same info that a notify would bring. It will also be cleared in "error retry restart" as well as "clean slate restart".

----------

Here's how our validation has changed:

Our KD cluster validation webhook has to be a little more strict about when it can accept changes. Partly this is to support the reconciliation changes described below, and partly to close some existing holes. There are two new things we enforce:
* A change to the spec is not allowed if the reconciler has not yet taken at least one pass through the previous change. (Changes to metadata like labels are fine though.) It's possible that a quick race between multiple client requests to change a given KD cluster could hit this restriction, but in practice this shouldn't happen unless a reconciler handler for a specific cluster is permanently stuck without returning because of some bug.
* A change to the spec is not allowed if there are pending notifies. (Because we only persist the need for notifies, and not their content, we can't change the source info that will be used to generate that content.) For a healthy cluster the pending notifies list should be generated and cleared inside the same handler pass and the validator won't see them. But if some of the configured-state members are down and not able to process their notifies, you'll be blocked from making further spec changes.

Note: a good and important KD improvement would be to have the KD app spec explicitly state which roles need which notifies. So if for example the workers don't need to receive add/delete notifies, we know that we don't need to update their config or send them notifies on add/delete events... and so we won't get blocked from processing KD cluster changes if some of those workers are down.

----------

Finally here's a walkthrough of how the reconciliation has changed, aside from all the status-updating already described above.

One broad thing to notice is any time we run some function from guest.go we check to see that the container ID we're accessing is still the lastConfiguredContainer. (So you'll see "container ID" arguments passed down through a lot of functions.) If not, that is treated as an error, same as if we had just completely failed to execute the operation. Next handler will detect the container ID change and trigger the whole member recovery process.

OK, so first the high-level view of the handler processing as seen in syncCluster:

* Before doing any sync-ing we will invoke checkContainerStates. Along with populating status as described above, this function's job is to handle any restart case i.e. we notice that the container ID has changed. The most basic thing to do here is to kick the member back to create-pending state so it can get reconfigured if necessary. If the member doesn't have persistent storage then we'll also handle the "clean slate restart" described above.

* We haven't made any changes to syncClusterRoles. But notice that if checkContainerStates put any members into create-pending, syncClusterRoles will never return clusterMembersStableReady, and therefore we will proceed to do member syncing.

* Member processing happens in syncMembers; we'll get to the changes to that below in the next part. We no longer pass a boolean flag to syncMembers indicating whether membership has changed in this handler. Instead, we'll make decisions about where to update configmeta based on the per-member status we're tracking.

* When syncCluster exits, the defer func runs. This is where syncMemberNotifies is invoked, and that'll be the final part described below.

The next part to mention is syncMembers, and the processing functions it invokes for the different member states:

* In the loop that calls handleReadyMembers we now attempt sending notifies to each role, even if some role along the way encounters issues.

* handleReadyMembers will skip updating a configured member's configmeta if that role doesn't have a setup package or if the member's lastConfigDataGeneration indicates that it already has the configmeta.

* We now bail out before any further processing if ANY previously-configured member is stuck on an old configmeta (not just ready members). This catches members that were previously configured but are currently "rebooting"... we need to wait for them to come back & give them the update. This maintains a previously-established invariant that to get past this step of the reconciliation, no member can have a stale version of the configmeta.

* handleCreatePendingMembers no longer uses an "internal" configured state to help decide where to send notifies; our other state we're tracking can better cover that. (Cf. the code and comments at the end of this function.) And instead of immediately sending out notifies, handleCreatePendingMembers calls generateNotifies which adds to the pending-notifies lists of the target members.

* handleDeletePendingMembers also queues up notifies rather than sending them right away.

The last part is syncMemberNotifies. This always happens at the end of each handler, regardless of whether we had to handle any membership changes.

syncMemberNotifies walks through all configured-state members and tries to send them any add/delete notifies stored in their pending-notifies lists. On success a notify is removed from the list. Ideally all these notifies will succeed, but if some of them don't, then they'll stay on the list and we'll try them again next handler. Meanwhile the KD cluster status will be advertising that there are pending notifies (which block further cluster spec changes) and that maybe something needs to get fixed.
