### PR TITLE
App tweaks

### DIFF
--- a/deploy/example_catalog/cr-app-cdh5142cm.json
+++ b/deploy/example_catalog/cr-app-cdh5142cm.json
@@ -71,11 +71,11 @@
         },
         "defaultImageRepoTag": "docker.io/bluedata/cdh5142cm:3.0",
         "label": {
-            "name": "CDH 5.14.2 on 7x with Cloudera Manager",
+            "name": "CDH 5.14.2",
             "description": "CDH 5.14.2 with YARN support. Includes Pig, Hive, and Hue."
         },
         "distroID": "bluedata/cdh51427x",
-        "version": "1.4",
+        "version": "1.5",
         "configSchemaVersion": 7,
         "services": [
             {

--- a/deploy/example_catalog/cr-app-centos7.json
+++ b/deploy/example_catalog/cr-app-centos7.json
@@ -22,11 +22,11 @@
             ]
         },
         "label": {
-            "name": "CentOS 7.x utility.",
-            "description": "CentOS 7x utility with no preinstalled apps"
+            "name": "CentOS 7.5",
+            "description": "CentOS 7.5.1804 with no preinstalled apps"
         },
         "distroID": "bluedata/centos7x",
-        "version": "1.0",
+        "version": "1.1",
         "configSchemaVersion": 7,
         "services": [
             {

--- a/deploy/example_catalog/cr-app-spark221e2.json
+++ b/deploy/example_catalog/cr-app-spark221e2.json
@@ -41,11 +41,11 @@
             ]
         },
         "label": {
-            "name": "Spark 2.2.1 on centos7x with Jupyter",
-            "description": "Spark 2.2.1 with Jupyter"
+            "name": "Spark 2.2.1 + Jupyter",
+            "description": "Spark 2.2.1 with Jupyter notebook"
         },
         "distroID": "bluedata/spark221e2",
-        "version": "2.6",
+        "version": "2.7",
         "configSchemaVersion": 7,
         "services": [
             {

--- a/deploy/example_catalog/cr-app-tensorflow-notebook.json
+++ b/deploy/example_catalog/cr-app-tensorflow-notebook.json
@@ -24,12 +24,12 @@
             ]
         },
         "label": {
-            "name": "Tensorflow GPU with jupyter notebook",
-            "description": "TensorFlow GPU with jupyter notebook"
+            "name": "TensorFlow + Jupyter",
+            "description": "TensorFlow GPU with Jupyter notebook"
         },
         "defaultImageRepoTag": "tensorflow/tensorflow:latest-gpu-py3-jupyter",
-        "distroID": "tensorflow/tensorflow:latest-gpu-py3-jupyter",
-        "version": "latest-gpu-py3-jupyter",
+        "distroID": "bluedata/tensorflow",
+        "version": "2.0",
         "configSchemaVersion": 7,
         "services": [
             {

--- a/deploy/example_catalog/cr-app-tensorflow-notebook.json
+++ b/deploy/example_catalog/cr-app-tensorflow-notebook.json
@@ -4,7 +4,7 @@
     "metadata": {
         "name": "ml-jupyter-notebook",
         "annotations": {
-            "token":"execute this command to get the authentication token 'kubectl exec <pod-name> jupyter notebook list and use this token in Jupyter notebook.'"
+            "token":"execute this command to get the authentication token 'kubectl exec <pod-name> jupyter notebook list' and use this token in Jupyter notebook."
         }
     },
 

--- a/doc/gke-notes.md
+++ b/doc/gke-notes.md
@@ -15,10 +15,11 @@ For a list of available GKE Kubernetes versions you can run the following query.
     gcloud container get-server-config
 ```
 
-So for example, this gcloud command will create a 3-node GKE cluster named "my-gke" using Kubernetes version 1.14.10 and the n1-highmem-4 machine type:
+So for example, at the time this doc was written, the following gcloud command would create a 3-node GKE cluster named "my-gke" using Kubernetes version 1.15.7 and the n1-highmem-4 machine type:
 ```bash
-    gcloud container clusters create my-gke --cluster-version=1.14.10-gke.17 --machine-type=n1-highmem-4
+    gcloud container clusters create my-gke --cluster-version=1.15.7-gke.23 --machine-type=n1-highmem-4
 ```
+At the current time when you're reading this, you may need or want to use some different value for cluster-version.
 
 If you need to grow your GKE cluster you can use gcloud to do that as well; for example, growing to 5 nodes:
 ```bash


### PR DESCRIPTION
Addresses HAATHI-15046:
* The "short names" really should be short.
* In the CentOS app, say exactly what OS version it is.
* Fix some capitalizations for identifiers like Jupyter and TensorFlow.
* In the TensorFlow app, the distroID should be some unique ID that is namespaced with the name of the "packager", which in this case is us. Still using the "bluedata" packager identity for now.
* Also in the TensorFlow app, the version needs to be a semantic version string tracking the evolution of this particular CR.

Also taking this opportunity to massage the GKE notes a bit. Still fiddling with the way to describe cluster version selection.