### PR TITLE
Datatap support for Spark KD app

### DIFF
--- a/deploy/example_catalog/cr-app-spark221e2.json
+++ b/deploy/example_catalog/cr-app-spark221e2.json
@@ -7,7 +7,6 @@
 
     "spec" : {
         "systemdRequired": true,
-        "defaultPersistDirs" : ["/usr", "/opt", "/var", "/data"],
         "config": {
             "roleServices": [
                 {

--- a/deploy/example_catalog/cr-app-spark221e2.json
+++ b/deploy/example_catalog/cr-app-spark221e2.json
@@ -106,7 +106,7 @@
                 }
             }
         ],
-        "defaultImageRepoTag": "docker.io/bluedata/sparkbase:2.2",
+        "defaultImageRepoTag": "docker.io/bluedata/sparkbase:2.3",
         "defaultConfigPackage":  {
             "packageURL": "file:///opt/configscripts/appconfig-2.6.tgz"
         },
@@ -120,7 +120,7 @@
                 "id": "worker"
             },
             {
-                "imageRepoTag": "docker.io/bluedata/jupyter:2.3",
+                "imageRepoTag": "docker.io/bluedata/jupyter:2.4",
                 "cardinality": "0+",
                 "id": "jupyter"
             }


### PR DESCRIPTION
To support dtap in spark kubedirector app - kd-Spark221-appconfig, following changes have been made.

1. updated start script file to create /opt/bdfs/ folder and copy related jar files to the created folder.
2. updated java, spark and dtap paths in hadoop, macros.sh and spark-defaults.conf files to above created folder.
3. .tgz files of sparkbase and Jupyter has been udpated and uploaded to Docker repository with versions changed from bluedata/sparkbase:2.2 to bluedata/sparkbase:2.3 and from bluedata/jupyter:2.3 to bluedata/jupyter:2.4 respectively.
4. Updated related app json file with updated version for sparkbase and Jupyter (cr-app-spark221e2.json in Everest)