### PR TITLE
Kishore test

### DIFF
--- a/pkg/catalog/interrogate.go
+++ b/pkg/catalog/interrogate.go
@@ -113,7 +113,6 @@ func GetRoleCardinality(
 
 // GetRoleMinResources is a utility function that fetching the minimum resources
 // for a given app role
-// Test comment XXX
 func GetRoleMinResources(
 	appRole *kdv1.NodeRole,
 ) *v1.ResourceList {

--- a/pkg/catalog/interrogate.go
+++ b/pkg/catalog/interrogate.go
@@ -113,6 +113,7 @@ func GetRoleCardinality(
 
 // GetRoleMinResources is a utility function that fetching the minimum resources
 // for a given app role
+// Test comment XXX
 func GetRoleMinResources(
 	appRole *kdv1.NodeRole,
 ) *v1.ResourceList {

--- a/pkg/executor/types.go
+++ b/pkg/executor/types.go
@@ -59,6 +59,17 @@ const (
 	systemdFSVolume       = "/sys/fs/cgroup/systemd"
 	tmpFSVolSize          = "20Gi"
 	kubedirectorInit      = "/etc/kubedirector.init"
+
+	// nvidiaGpuResourceName is the name of a GPU resource, schedulable for a container -
+	// specifically, a GPU by the vendor, NVIDIA
+	nvidiaGpuResourceName = "nvidia.com/gpu"
+	// nvidiaGpuVisWorkaroundEnvVarName is the name of an environment variable, which is to be
+	// injected in a scheduled container), as an NVIDIA-suggested work-around that
+	// avoids an NVIDIA GPU resource surfacing in a container for which it was not requested
+	nvidiaGpuVisWorkaroundEnvVarName = "NVIDIA_VISIBLE_DEVICE"
+	// nvidiaGpuVisWorkaroundEnvVarValue is the value to be set for the environment variable
+	// named nvidiaGpuVisWorkaroundEnvVarName, in the above work-around
+	nvidiaGpuVisWorkaroundEnvVarValue = "VOID"
 )
 
 // Streams for stdin, stdout, stderr of executed commands


### PR DESCRIPTION
This change is intended as at least a partial fix for the issue, https://github.com/bluek8s/kubedirector/issues/263.

The NVIDIA-suggested workaround (https://github.com/NVIDIA/k8s-device-plugin/issues/87), referred to by the issue's description, is implemented:
For each container pertaining to a Role that has NOT requested a GPU resource, an "NVIDIA_VISIBLE_DEVICES=VOID" environment variable is added.

We may have to watch for future updates to NVIDIA's Docker plug-in, to see if the need for this workaround is removed.