### PR TITLE
Fix appconfig logging to log to configure.* files

### DIFF
--- a/pkg/controller/kubedirectorcluster/types.go
+++ b/pkg/controller/kubedirectorcluster/types.go
@@ -92,8 +92,8 @@ const (
 	echo -n %s= > ` + appPrepConfigStatus + ` &&
 	nohup sh -c "` + appPrepStartscript + ` --configure;
 	echo -n $? >> ` + appPrepConfigStatus +
-		`" > /opt/guestconfig/configure.stdout  
-    2> /opt/guestconfig/configure.stderr  &`
+	`" > /opt/guestconfig/configure.stdout  
+	2> /opt/guestconfig/configure.stderr  &`
 	fileInjectionCommand = `mkdir -p %s && cd %s &&
 	curl -L %s -o %s`
 )

--- a/pkg/controller/kubedirectorcluster/types.go
+++ b/pkg/controller/kubedirectorcluster/types.go
@@ -90,7 +90,7 @@ const (
 	appPrepConfigStatus = "/opt/guestconfig/configure.status"
 	appPrepConfigRunCmd = `rm -f /opt/guestconfig/configure.* &&
 	echo -n %s= > ` + appPrepConfigStatus + ` &&
-	nohup sh -c "` + appPrepStartscript + ` --configure
+	nohup "` + appPrepStartscript + ` --configure
 	2> /opt/guestconfig/configure.stderr
 	1> /opt/guestconfig/configure.stdout;
 	echo -n $? >> ` + appPrepConfigStatus + `" &`

--- a/pkg/controller/kubedirectorcluster/types.go
+++ b/pkg/controller/kubedirectorcluster/types.go
@@ -90,10 +90,10 @@ const (
 	appPrepConfigStatus = "/opt/guestconfig/configure.status"
 	appPrepConfigRunCmd = `rm -f /opt/guestconfig/configure.* &&
 	echo -n %s= > ` + appPrepConfigStatus + ` &&
-	nohup "` + appPrepStartscript + ` --configure
-	2> /opt/guestconfig/configure.stderr
-	1> /opt/guestconfig/configure.stdout;
-	echo -n $? >> ` + appPrepConfigStatus + `" &`
+	nohup sh -c "` + appPrepStartscript + ` --configure;
+	echo -n $? >> ` + appPrepConfigStatus +
+		`" > /opt/guestconfig/configure.stdout  
+    2> /opt/guestconfig/configure.stderr  &`
 	fileInjectionCommand = `mkdir -p %s && cd %s &&
 	curl -L %s -o %s`
 )

--- a/pkg/controller/kubedirectorcluster/types.go
+++ b/pkg/controller/kubedirectorcluster/types.go
@@ -91,8 +91,7 @@ const (
 	appPrepConfigRunCmd = `rm -f /opt/guestconfig/configure.* &&
 	echo -n %s= > ` + appPrepConfigStatus + ` &&
 	nohup sh -c "` + appPrepStartscript + ` --configure;
-	echo -n $? >> ` + appPrepConfigStatus +
-	`" > /opt/guestconfig/configure.stdout  
+	echo -n $? >> ` + appPrepConfigStatus + `" > /opt/guestconfig/configure.stdout  
 	2> /opt/guestconfig/configure.stderr  &`
 	fileInjectionCommand = `mkdir -p %s && cd %s &&
 	curl -L %s -o %s`


### PR DESCRIPTION
If nothing is specified, nohup redirects it's stdout to a file named nohup.out. We were trying to redirect the stdout and stderr of the _command_ running with nohup, but not of nohup _itself_ . As a result, starscripts writing to stdout/stderr in the pods was not getting redirected to configure.* files as originally intended and app developers have to take care of writing logs in their own custom files. 

Testing done on a simple [Helloworld KD APP](https://github.com/bluedatainc/bluedata-catalog/tree/ritesh-kd-helloworld/helloworld).    