### PR TITLE
Cluster connections refactoring and addition of secret as connectable resource

### DIFF
--- a/deploy/kubedirector/kubedirector.hpe.com_kubedirectorclusters_crd.yaml
+++ b/deploy/kubedirector/kubedirector.hpe.com_kubedirectorclusters_crd.yaml
@@ -46,7 +46,11 @@ spec:
                 configmaps:
                   type: array
                   items:
-                    type: string  
+                    type: string
+                secrets:
+                  type: array
+                  items:
+                    type: string      
             serviceType:
               type: string
               pattern: '^ClusterIP$|^NodePort$|^LoadBalancer$'
@@ -66,9 +70,7 @@ spec:
                   type: integer
                   maximum: 511
                 readOnly:
-                  type: boolean
-            connectionsGenerationToProcess:
-              type: integer      
+                  type: boolean      
             roles:
               type: array
               items:
@@ -210,8 +212,8 @@ spec:
                   type: boolean
             generationUID:
               type: string
-            lastConnectionsGeneration:
-              type: integer  
+            lastConnectionHash:
+              type: string  
             specGenerationToProcess:
               type: integer
             clusterService:

--- a/pkg/apis/kubedirector/v1beta1/kubedirectorcluster_types.go
+++ b/pkg/apis/kubedirector/v1beta1/kubedirectorcluster_types.go
@@ -25,13 +25,12 @@ import (
 // requested cluster roles, each of which will be implemented (by KubeDirector)
 // using a StatefulSet.
 type KubeDirectorClusterSpec struct {
-	AppID                   string      `json:"app"`
-	AppCatalog              *string     `json:"appCatalog,omitempty"`
-	ServiceType             *string     `json:"serviceType,omitempty"`
-	Roles                   []Role      `json:"roles"`
-	DefaultSecret           *KDSecret   `json:"defaultSecret,omitempty"`
-	ConnectionsGenToProcess int64       `json:"connectionsGenerationToProcess"`
-	Connections             Connections `json:"connections"`
+	AppID         string      `json:"app"`
+	AppCatalog    *string     `json:"appCatalog,omitempty"`
+	ServiceType   *string     `json:"serviceType,omitempty"`
+	Roles         []Role      `json:"roles"`
+	DefaultSecret *KDSecret   `json:"defaultSecret,omitempty"`
+	Connections   Connections `json:"connections"`
 }
 
 // Connections specifies list of cluster objects and configmaps objects that has
@@ -39,6 +38,7 @@ type KubeDirectorClusterSpec struct {
 type Connections struct {
 	Clusters   []string `json:"clusters,omitempty"`
 	ConfigMaps []string `json:"configmaps,omitempty"`
+	Secrets    []string `json:"secrets,omitempty"`
 }
 
 // KubeDirectorClusterStatus defines the observed state of KubeDirectorCluster.
@@ -52,7 +52,7 @@ type KubeDirectorClusterStatus struct {
 	ClusterService          string       `json:"clusterService"`
 	LastNodeID              int64        `json:"lastNodeID"`
 	Roles                   []RoleStatus `json:"roles"`
-	LastConnectionGen       int64        `json:"lastConnectionsGeneration"`
+	LastConnectionHash      string       `json:"lastConnectionHash"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -46,6 +46,7 @@ type nodegroup struct {
 type connections struct {
 	Clusters   map[string]configmeta                   `json:"clusters"`
 	ConfigMaps map[string]map[string]map[string]string `json:"configmaps"`
+	Secrets    map[string]map[string]map[string][]byte `json:"secrets"`
 }
 
 type cluster struct {

--- a/pkg/controller/configmap/configmap.go
+++ b/pkg/controller/configmap/configmap.go
@@ -17,6 +17,7 @@ package configmap
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"time"
 
 	kdv1 "github.com/bluek8s/kubedirector/pkg/apis/kubedirector/v1beta1"
@@ -83,7 +84,13 @@ func (r *ReconcileConfigMap) syncConfigMap(
 			for {
 				updateMetaGenerator := &kubecluster
 				annotations := updateMetaGenerator.Annotations
-				annotations["kdreconfig"] = "true"
+				if v, ok := annotations["connUpdateCounter"]; ok {
+					newV, _ := strconv.Atoi(v)
+					annotations["connUpdateCounter"] = strconv.Itoa(newV + 1)
+				} else {
+					annotations["connUpdateCounter"] = "1"
+				}
+				fmt.Println("DEBUG: connected configmap changed, setting connUpdateCounter")
 				updateMetaGenerator.Annotations = annotations
 				if shared.Update(context.TODO(), updateMetaGenerator) == nil {
 					break

--- a/pkg/controller/configmap/configmap.go
+++ b/pkg/controller/configmap/configmap.go
@@ -31,8 +31,7 @@ import (
 const (
 	// ConfigMapType is a label placed on desired comfig maps that
 	// we want to watch and propogate inside containers
-	configMapType          = shared.KdDomainBase + "/cmType"
-	connectionsIncrementor = shared.KdDomainBase + "/connUpdateCounter"
+	configMapType = shared.KdDomainBase + "/cmType"
 )
 
 // syncConfigMap runs the reconciliation logic. It is invoked because of a
@@ -85,11 +84,11 @@ func (r *ReconcileConfigMap) syncConfigMap(
 			for {
 				updateMetaGenerator := &kubecluster
 				annotations := updateMetaGenerator.Annotations
-				if v, ok := annotations[connectionsIncrementor]; ok {
+				if v, ok := annotations[shared.ConnectionsIncrementor]; ok {
 					newV, _ := strconv.Atoi(v)
-					annotations[connectionsIncrementor] = strconv.Itoa(newV + 1)
+					annotations[shared.ConnectionsIncrementor] = strconv.Itoa(newV + 1)
 				} else {
-					annotations[connectionsIncrementor] = "1"
+					annotations[shared.ConnectionsIncrementor] = "1"
 				}
 				updateMetaGenerator.Annotations = annotations
 				if shared.Update(context.TODO(), updateMetaGenerator) == nil {

--- a/pkg/controller/configmap/configmap.go
+++ b/pkg/controller/configmap/configmap.go
@@ -82,7 +82,9 @@ func (r *ReconcileConfigMap) syncConfigMap(
 			maxWait := 4096 * time.Second
 			for {
 				updateMetaGenerator := &kubecluster
-				updateMetaGenerator.Spec.ConnectionsGenToProcess = updateMetaGenerator.Spec.ConnectionsGenToProcess + 1
+				annotations := updateMetaGenerator.Annotations
+				annotations["kdreconfig"] = "true"
+				updateMetaGenerator.Annotations = annotations
 				if shared.Update(context.TODO(), updateMetaGenerator) == nil {
 					break
 				}

--- a/pkg/controller/configmap/configmap.go
+++ b/pkg/controller/configmap/configmap.go
@@ -90,7 +90,6 @@ func (r *ReconcileConfigMap) syncConfigMap(
 				} else {
 					annotations["connUpdateCounter"] = "1"
 				}
-				fmt.Println("DEBUG: connected configmap changed, setting connUpdateCounter")
 				updateMetaGenerator.Annotations = annotations
 				if shared.Update(context.TODO(), updateMetaGenerator) == nil {
 					break

--- a/pkg/controller/configmap/configmap.go
+++ b/pkg/controller/configmap/configmap.go
@@ -37,7 +37,7 @@ const (
 // syncConfigMap runs the reconciliation logic. It is invoked because of a
 // change in or addition of configmap instance, currently there is no
 // polling for this resource. If the configmap is not labeled
-// with key ConfigMapType then no op
+// with key "kubedirector.hpe.com/cmType" then no op
 func (r *ReconcileConfigMap) syncConfigMap(
 	reqLogger logr.Logger,
 	configmap *corev1.ConfigMap,

--- a/pkg/controller/configmap/configmap.go
+++ b/pkg/controller/configmap/configmap.go
@@ -31,7 +31,8 @@ import (
 const (
 	// ConfigMapType is a label placed on desired comfig maps that
 	// we want to watch and propogate inside containers
-	configMapType = shared.KdDomainBase + "/cmType"
+	configMapType          = shared.KdDomainBase + "/cmType"
+	connectionsIncrementor = shared.KdDomainBase + "/connUpdateCounter"
 )
 
 // syncConfigMap runs the reconciliation logic. It is invoked because of a
@@ -84,11 +85,11 @@ func (r *ReconcileConfigMap) syncConfigMap(
 			for {
 				updateMetaGenerator := &kubecluster
 				annotations := updateMetaGenerator.Annotations
-				if v, ok := annotations["connUpdateCounter"]; ok {
+				if v, ok := annotations[connectionsIncrementor]; ok {
 					newV, _ := strconv.Atoi(v)
-					annotations["connUpdateCounter"] = strconv.Itoa(newV + 1)
+					annotations[connectionsIncrementor] = strconv.Itoa(newV + 1)
 				} else {
-					annotations["connUpdateCounter"] = "1"
+					annotations[connectionsIncrementor] = "1"
 				}
 				updateMetaGenerator.Annotations = annotations
 				if shared.Update(context.TODO(), updateMetaGenerator) == nil {

--- a/pkg/controller/kubedirectorcluster/cluster.go
+++ b/pkg/controller/kubedirectorcluster/cluster.go
@@ -311,7 +311,6 @@ func (r *ReconcileKubeDirectorCluster) syncCluster(
 		return configMetaErr
 	}
 	newHash := calcConnectionsHash(&cr.Spec.Connections, cr.Namespace)
-	//fmt.Println("DEBUG: new hash: ", newHash)
 	if state == clusterMembersChangedUnready || (newHash != cr.Status.LastConnectionHash) {
 		if cr.Status.SpecGenerationToProcess == nil {
 			cr.Status.SpecGenerationToProcess = &cr.Generation

--- a/pkg/controller/kubedirectorcluster/cluster.go
+++ b/pkg/controller/kubedirectorcluster/cluster.go
@@ -334,10 +334,10 @@ func (r *ReconcileKubeDirectorCluster) syncCluster(
 	return nil
 }
 
+// Calculates md5sum of resource-versions of all resources
+// connected to this cluster
 func calcConnectionsHash(con *kdv1.Connections, ns string) string {
-	//sliceToSha(buff bytes.Buffer)
 	clusterNames := con.Clusters
-	//clusterRvs := make([]string, len(clusterNames))
 	var buffer bytes.Buffer
 	for _, c := range clusterNames {
 		clusterObj, _ := observer.GetCluster(ns, c)
@@ -356,6 +356,7 @@ func calcConnectionsHash(con *kdv1.Connections, ns string) string {
 		rv := secretObj.ResourceVersion
 		buffer.WriteString(rv)
 	}
+	// md5 is very cheap for small strings
 	md5Sum := md5.Sum([]byte(buffer.String()))
 	return hex.EncodeToString(md5Sum[:])
 }

--- a/pkg/controller/kubedirectorcluster/cluster.go
+++ b/pkg/controller/kubedirectorcluster/cluster.go
@@ -288,8 +288,8 @@ func (r *ReconcileKubeDirectorCluster) syncCluster(
 				}
 			}
 			cr.Status.State = string(clusterReady)
-			return nil
 		}
+		return nil
 	}
 
 	if cr.Status.State != string(clusterCreating) {

--- a/pkg/controller/kubedirectorcluster/cluster.go
+++ b/pkg/controller/kubedirectorcluster/cluster.go
@@ -248,11 +248,11 @@ func (r *ReconcileKubeDirectorCluster) syncCluster(
 					updateMetaGenerator := &kubecluster
 					//updateMetaGenerator.Spec.ConnectionsGenToProcess = kubecluster.Spec.ConnectionsGenToProcess + 1
 					annotations := updateMetaGenerator.Annotations
-					if v, ok := annotations["connUpdateCounter"]; ok {
+					if v, ok := annotations[connectionsIncrementor]; ok {
 						newV, _ := strconv.Atoi(v)
-						annotations["connUpdateCounter"] = strconv.Itoa(newV + 1)
+						annotations[connectionsIncrementor] = strconv.Itoa(newV + 1)
 					} else {
-						annotations["connUpdateCounter"] = "1"
+						annotations[connectionsIncrementor] = "1"
 					}
 					updateMetaGenerator.Annotations = annotations
 					//Notify cluster by incrementing configmetaGenerator
@@ -261,11 +261,11 @@ func (r *ReconcileKubeDirectorCluster) syncCluster(
 					for {
 						updateMetaGenerator := &kubecluster
 						annotations := updateMetaGenerator.Annotations
-						if v, ok := annotations["connUpdateCounter"]; ok {
+						if v, ok := annotations[connectionsIncrementor]; ok {
 							newV, _ := strconv.Atoi(v)
-							annotations["connUpdateCounter"] = strconv.Itoa(newV + 1)
+							annotations[connectionsIncrementor] = strconv.Itoa(newV + 1)
 						} else {
-							annotations["connUpdateCounter"] = "1"
+							annotations[connectionsIncrementor] = "1"
 						}
 						updateMetaGenerator.Annotations = annotations
 						if shared.Update(context.TODO(), updateMetaGenerator) == nil {
@@ -315,7 +315,6 @@ func (r *ReconcileKubeDirectorCluster) syncCluster(
 		return configMetaErr
 	}
 	newHash := calcConnectionsHash(&cr.Spec.Connections, cr.Namespace)
-	fmt.Println("new hash is:  ", newHash)
 	if state == clusterMembersChangedUnready || (newHash != cr.Status.LastConnectionHash) {
 		if cr.Status.SpecGenerationToProcess == nil {
 			cr.Status.SpecGenerationToProcess = &cr.Generation

--- a/pkg/controller/kubedirectorcluster/cluster.go
+++ b/pkg/controller/kubedirectorcluster/cluster.go
@@ -348,13 +348,13 @@ func calcConnectionsHash(con *kdv1.Connections, ns string) string {
 		buffer.WriteString(rv)
 		//sha256.Sum256([]byte(buffer.String()))
 	}
-	// secretNames := con.Secrets
-	// for _, c := range secretNames {
-	// 	secretObj, _ := observer.GetSecret(ns, c)
-	// 	rv := secretObj.ResourceVersion
-	// 	buffer.WriteString(rv)
-	// 	//sha256.Sum256([]byte(buffer.String()))
-	// }
+	secretNames := con.Secrets
+	for _, c := range secretNames {
+		secretObj, _ := observer.GetSecret(ns, c)
+		rv := secretObj.ResourceVersion
+		buffer.WriteString(rv)
+		//sha256.Sum256([]byte(buffer.String()))
+	}
 	//shaSum := sha256.Sum256([]byte(buffer.String()))
 	return buffer.String()
 }

--- a/pkg/controller/kubedirectorcluster/cluster.go
+++ b/pkg/controller/kubedirectorcluster/cluster.go
@@ -336,6 +336,10 @@ func (r *ReconcileKubeDirectorCluster) syncCluster(
 // Calculates md5sum of resource-versions of all resources
 // connected to this cluster
 func calcConnectionsHash(con *kdv1.Connections, ns string) string {
+	if con == nil {
+		return ""
+	}
+
 	clusterNames := con.Clusters
 	var buffer bytes.Buffer
 	for _, c := range clusterNames {

--- a/pkg/controller/kubedirectorcluster/cluster.go
+++ b/pkg/controller/kubedirectorcluster/cluster.go
@@ -339,7 +339,7 @@ func calcConnectionsHash(
 		clusterObj, _ := observer.GetCluster(ns, c)
 		buffer.WriteString(c)
 		var specNum string
-		// extra careful while deferencing
+		// extra careful while dereferencing
 		if clusterObj.Status.SpecGenerationToProcess == nil {
 			specNum = "nil"
 		} else {

--- a/pkg/controller/kubedirectorcluster/types.go
+++ b/pkg/controller/kubedirectorcluster/types.go
@@ -16,6 +16,7 @@ package kubedirectorcluster
 
 import (
 	kdv1 "github.com/bluek8s/kubedirector/pkg/apis/kubedirector/v1beta1"
+	"github.com/bluek8s/kubedirector/pkg/shared"
 	appsv1 "k8s.io/api/apps/v1"
 )
 
@@ -99,6 +100,10 @@ const (
 
 const (
 	zeroPortsService = "n/a"
+)
+
+const (
+	connectionsIncrementor = shared.KdDomainBase + "/connUpdateCounter"
 )
 
 type roleInfo struct {

--- a/pkg/controller/kubedirectorcluster/types.go
+++ b/pkg/controller/kubedirectorcluster/types.go
@@ -16,7 +16,6 @@ package kubedirectorcluster
 
 import (
 	kdv1 "github.com/bluek8s/kubedirector/pkg/apis/kubedirector/v1beta1"
-	"github.com/bluek8s/kubedirector/pkg/shared"
 	appsv1 "k8s.io/api/apps/v1"
 )
 
@@ -100,10 +99,6 @@ const (
 
 const (
 	zeroPortsService = "n/a"
-)
-
-const (
-	connectionsIncrementor = shared.KdDomainBase + "/connUpdateCounter"
 )
 
 type roleInfo struct {

--- a/pkg/controller/secret/doc.go
+++ b/pkg/controller/secret/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2020 Hewlett Packard Enterprise Development LP
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package secret implements reconciliation for secret.
+package secret

--- a/pkg/controller/secret/secret.go
+++ b/pkg/controller/secret/secret.go
@@ -36,9 +36,9 @@ const (
 )
 
 // syncSecret runs the reconciliation logic. It is invoked because of a
-// change in or addition of configmap instance, currently there is no
-// polling for this resource. If the configmap is not labeled
-// with key ConfigMapType then no op
+// change in or addition of secret instance, currently there is no
+// polling for this resource. If the secret is not labeled
+// with key "kubedirector.hpe.com/secretType" then no op
 func (r *ReconcileSecret) syncSecret(
 	reqLogger logr.Logger,
 	secret *corev1.Secret,
@@ -108,7 +108,7 @@ func (r *ReconcileSecret) syncSecret(
 						reqLogger,
 						fmt.Errorf("failed to update cluster"),
 						secret,
-						shared.EventReasonConfigMap,
+						shared.EventReasonSecret,
 						"Unable to notify cluster {%s} of configmeta change",
 						updateMetaGenerator.Name)
 					break

--- a/pkg/controller/secret/secret.go
+++ b/pkg/controller/secret/secret.go
@@ -90,7 +90,6 @@ func (r *ReconcileSecret) syncSecret(
 				} else {
 					annotations["connUpdateCounter"] = "1"
 				}
-				fmt.Println("DEBUG: connected secret changed, setting connUpdateCounter")
 				updateMetaGenerator.Annotations = annotations
 				if shared.Update(context.TODO(), updateMetaGenerator) == nil {
 					break

--- a/pkg/controller/secret/secret.go
+++ b/pkg/controller/secret/secret.go
@@ -31,7 +31,8 @@ import (
 const (
 	// secretType is a label placed on desired comfig maps that
 	// we want to watch and propogate inside containers
-	secretType = shared.KdDomainBase + "/secretType"
+	secretType             = shared.KdDomainBase + "/secretType"
+	connectionsIncrementor = shared.KdDomainBase + "/connUpdateCounter"
 )
 
 // syncSecret runs the reconciliation logic. It is invoked because of a
@@ -84,11 +85,11 @@ func (r *ReconcileSecret) syncSecret(
 			for {
 				updateMetaGenerator := &kubecluster
 				annotations := updateMetaGenerator.Annotations
-				if v, ok := annotations["connUpdateCounter"]; ok {
+				if v, ok := annotations[connectionsIncrementor]; ok {
 					newV, _ := strconv.Atoi(v)
-					annotations["connUpdateCounter"] = strconv.Itoa(newV + 1)
+					annotations[connectionsIncrementor] = strconv.Itoa(newV + 1)
 				} else {
-					annotations["connUpdateCounter"] = "1"
+					annotations[connectionsIncrementor] = "1"
 				}
 				updateMetaGenerator.Annotations = annotations
 				if shared.Update(context.TODO(), updateMetaGenerator) == nil {

--- a/pkg/controller/secret/secret.go
+++ b/pkg/controller/secret/secret.go
@@ -1,0 +1,123 @@
+// Copyright 2020 Hewlett Packard Enterprise Development LP
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package secret
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"time"
+
+	kdv1 "github.com/bluek8s/kubedirector/pkg/apis/kubedirector/v1beta1"
+	"github.com/bluek8s/kubedirector/pkg/observer"
+	"github.com/bluek8s/kubedirector/pkg/shared"
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+)
+
+const (
+	// secretType is a label placed on desired comfig maps that
+	// we want to watch and propogate inside containers
+	secretType = shared.KdDomainBase + "/secretType"
+)
+
+// syncSecret runs the reconciliation logic. It is invoked because of a
+// change in or addition of configmap instance, currently there is no
+// polling for this resource. If the configmap is not labeled
+// with key ConfigMapType then no op
+func (r *ReconcileSecret) syncSecret(
+	reqLogger logr.Logger,
+	secret *corev1.Secret,
+) error {
+
+	// Memoize state of the incoming object.
+	oldSecret, _ := observer.GetSecret(secret.Namespace, secret.Name)
+	if _, ok := oldSecret.Labels[secretType]; !ok {
+		return nil
+	}
+	/* anonymous fun to check if some cluster
+	   is using this config map as a connection */
+	isClusterUsingSecret := func(secretName string, cluster kdv1.KubeDirectorCluster) bool {
+		clusterSecrets := cluster.Spec.Connections.Secrets
+		for _, clusterSecret := range clusterSecrets {
+			if clusterSecret == secretName {
+				return true
+			}
+		}
+		return false
+	}
+	allClusters := &kdv1.KubeDirectorClusterList{}
+	shared.List(context.TODO(), allClusters)
+	for _, kubecluster := range allClusters.Items {
+		if isClusterUsingSecret(secret.Name, kubecluster) {
+			shared.LogInfof(
+				reqLogger,
+				&kubecluster,
+				shared.EventReasonSecret,
+				"connected secret {%s} has changed",
+				secret.Name,
+			)
+			shared.LogInfof(
+				reqLogger,
+				secret,
+				shared.EventReasonCluster,
+				"connected to cluster {%s}; updating it",
+				kubecluster.Name,
+			)
+
+			//Notify cluster by incrementing configmetaGenerator
+			wait := time.Second
+			maxWait := 4096 * time.Second
+			for {
+				updateMetaGenerator := &kubecluster
+				annotations := updateMetaGenerator.Annotations
+				if v, ok := annotations["connUpdateCounter"]; ok {
+					newV, _ := strconv.Atoi(v)
+					annotations["connUpdateCounter"] = strconv.Itoa(newV + 1)
+				} else {
+					annotations["connUpdateCounter"] = "1"
+				}
+				fmt.Println("DEBUG: connected secret changed, setting connUpdateCounter")
+				updateMetaGenerator.Annotations = annotations
+				if shared.Update(context.TODO(), updateMetaGenerator) == nil {
+					break
+				}
+				// Since update failed, get a fresh copy of this cluster to work with and
+				// try update
+				updateMetaGenerator, fetchErr := observer.GetCluster(kubecluster.Namespace, kubecluster.Name)
+				if fetchErr != nil {
+					if errors.IsNotFound(fetchErr) {
+						break
+					}
+				}
+				if wait > maxWait {
+					shared.LogErrorf(
+						reqLogger,
+						fmt.Errorf("failed to update cluster"),
+						secret,
+						shared.EventReasonConfigMap,
+						"Unable to notify cluster {%s} of configmeta change",
+						updateMetaGenerator.Name)
+					break
+				}
+				time.Sleep(wait)
+				wait = wait * 2
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/controller/secret/secret_controller.go
+++ b/pkg/controller/secret/secret_controller.go
@@ -73,7 +73,7 @@ func add(
 var _ reconcile.Reconciler = &ReconcileSecret{}
 
 const (
-	// We do not need polling for configmaps
+	// We do not need polling for secrets
 	reconcilePeriod = 0
 )
 

--- a/pkg/controller/secret/secret_controller.go
+++ b/pkg/controller/secret/secret_controller.go
@@ -1,0 +1,111 @@
+// Copyright 2020 Hewlett Packard Enterprise Development LP
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package secret
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/bluek8s/kubedirector/pkg/shared"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+var log = logf.Log.WithName("controller_secret")
+
+// Add creates a new secret Controller and adds it to the Manager.
+// The Manager will set fields on the Controller and Start it when the Manager
+// is Started.
+func Add(mgr manager.Manager) error {
+
+	return add(mgr, newReconciler(mgr))
+}
+
+// newReconciler returns a new reconcile.Reconciler.
+func newReconciler(mgr manager.Manager) reconcile.Reconciler {
+
+	return &ReconcileSecret{scheme: mgr.GetScheme()}
+}
+
+// add adds a new Controller to mgr with r as the reconcile.Reconciler.
+func add(
+	mgr manager.Manager,
+	r reconcile.Reconciler,
+) error {
+
+	// Create a new controller
+	c, err := controller.New("secret-controller", mgr, controller.Options{MaxConcurrentReconciles: 10, Reconciler: r})
+	if err != nil {
+		return err
+	}
+
+	// Watch for changes to primary resource secret.
+	err = c.Watch(&source.Kind{Type: &corev1.Secret{}}, &handler.EnqueueRequestForObject{})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// blank assignment to verify that ReconcileSecret implements
+// reconcile.Reconciler.
+var _ reconcile.Reconciler = &ReconcileSecret{}
+
+const (
+	// We do not need polling for configmaps
+	reconcilePeriod = 0
+)
+
+// ReconcileSecret reconciles a Secret object.
+type ReconcileSecret struct {
+	scheme *runtime.Scheme
+}
+
+// Reconcile reads that state of the cluster for a ConfigMap object
+// and makes changes based on the state read and what is in the
+// Secret.Spec.
+// Note:
+// The Controller will requeue the Request to be processed again if the
+// returned error is non-nil or Result.Requeue is true, otherwise upon
+// completion it will remove the work from the queue.
+func (r *ReconcileSecret) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+
+	reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
+	reconcileResult := reconcile.Result{RequeueAfter: reconcilePeriod}
+
+	// Fetch the Secret instance.
+	secret := &corev1.Secret{}
+	err := shared.Get(context.TODO(), request.NamespacedName, secret)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return reconcile.Result{}, nil
+		}
+		// Error reading the object - requeue the request.
+		return reconcileResult,
+			fmt.Errorf("could not fetch Secret instance: %s", err)
+	}
+
+	err = r.syncSecret(reqLogger, secret)
+	return reconcileResult, err
+}

--- a/pkg/controller/secret/secret_controller.go
+++ b/pkg/controller/secret/secret_controller.go
@@ -82,13 +82,9 @@ type ReconcileSecret struct {
 	scheme *runtime.Scheme
 }
 
-// Reconcile reads that state of the cluster for a ConfigMap object
-// and makes changes based on the state read and what is in the
-// Secret.Spec.
-// Note:
-// The Controller will requeue the Request to be processed again if the
-// returned error is non-nil or Result.Requeue is true, otherwise upon
-// completion it will remove the work from the queue.
+// Reconcile watches the resource of type corev1.Secret{} and
+// acts if the secret resource with a specific label
+// has been modified.
 func (r *ReconcileSecret) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 
 	reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)

--- a/pkg/observer/observer.go
+++ b/pkg/observer/observer.go
@@ -106,6 +106,21 @@ func GetConfigMap(
 	return result, err
 }
 
+// GetSecret finds the k8s Secret with the given name in the given namespace.
+func GetSecret(
+	namespace string,
+	secretName string,
+) (*corev1.Secret, error) {
+
+	result := &corev1.Secret{}
+	err := shared.Get(
+		context.TODO(),
+		types.NamespacedName{Namespace: namespace, Name: secretName},
+		result,
+	)
+	return result, err
+}
+
 // GetPVC finds the k8s PersistentVolumeClaim with the given name in the given
 // namespace.
 func GetPVC(
@@ -153,21 +168,6 @@ func GetValidatorWebhook(
 	err = shared.Get(
 		context.TODO(),
 		types.NamespacedName{Namespace: kdNamespace, Name: validator},
-		result,
-	)
-	return result, err
-}
-
-// GetSecret fetches the secret resource in the given namespace.
-func GetSecret(
-	namespace string,
-	secretName string,
-) (*corev1.Secret, error) {
-
-	result := &corev1.Secret{}
-	err := shared.Get(
-		context.TODO(),
-		types.NamespacedName{Namespace: namespace, Name: secretName},
 		result,
 	)
 	return result, err

--- a/pkg/shared/types.go
+++ b/pkg/shared/types.go
@@ -42,6 +42,7 @@ const (
 	EventReasonMember    = "Member"
 	EventReasonConfig    = "Config"
 	EventReasonConfigMap = "ConfigMap"
+	EventReasonSecret    = "Secret"
 )
 
 // Settings for appCatalog

--- a/pkg/shared/types.go
+++ b/pkg/shared/types.go
@@ -50,3 +50,9 @@ const (
 	AppCatalogLocal  = "local"
 	AppCatalogSystem = "system"
 )
+
+// Used by configmap and cluster reconciler to update connection
+// changes
+const (
+	ConnectionsIncrementor = KdDomainBase + "/connUpdateCounter"
+)

--- a/pkg/shared/types.go
+++ b/pkg/shared/types.go
@@ -51,7 +51,7 @@ const (
 	AppCatalogSystem = "system"
 )
 
-// Used by configmap and cluster reconciler to update connection
+// Used by configmap, secret and cluster reconciler to update connection
 // changes
 const (
 	ConnectionsIncrementor = KdDomainBase + "/connUpdateCounter"

--- a/pkg/validator/cluster.go
+++ b/pkg/validator/cluster.go
@@ -626,27 +626,27 @@ func validateFileInjections(
 // validateConnections checks if connections have
 // changed, if yes then it increments ConfigMetaGenerator
 // so that reconciler can re-generate confgimeta
-func validateConnections(
-	cr *kdv1.KubeDirectorCluster,
-	prevCr *kdv1.KubeDirectorCluster,
-	patches []clusterPatchSpec,
-) []clusterPatchSpec {
+// func validateConnections(
+// 	cr *kdv1.KubeDirectorCluster,
+// 	prevCr *kdv1.KubeDirectorCluster,
+// 	patches []clusterPatchSpec,
+// ) []clusterPatchSpec {
 
-	if !reflect.DeepEqual(cr.Spec.Connections, prevCr.Spec.Connections) {
-		newConfigGenrator := int32(cr.Spec.ConnectionsGenToProcess + 1)
-		patches = append(
-			patches,
-			clusterPatchSpec{
-				Op:   "add",
-				Path: "/spec/connectionsGenerationToProcess",
-				Value: clusterPatchValue{
-					ValueInt: &newConfigGenrator,
-				},
-			},
-		)
-	}
-	return patches
-}
+// 	if !reflect.DeepEqual(cr.Spec.Connections, prevCr.Spec.Connections) {
+// 		newConfigGenrator := int32(cr.Spec.ConnectionsGenToProcess + 1)
+// 		patches = append(
+// 			patches,
+// 			clusterPatchSpec{
+// 				Op:   "add",
+// 				Path: "/spec/connectionsGenerationToProcess",
+// 				Value: clusterPatchValue{
+// 					ValueInt: &newConfigGenrator,
+// 				},
+// 			},
+// 		)
+// 	}
+// 	return patches
+// }
 
 // validateSecrets validates defaultSecret and individual secret field for
 // each role. Validation is done to make sure secret object with the given
@@ -922,7 +922,7 @@ func admitClusterCR(
 	// Validate secret and generate patches for default values (if any)
 	valErrors, patches = validateSecrets(&clusterCR, valErrors, patches)
 
-	patches = validateConnections(&clusterCR, &prevClusterCR, patches)
+	//patches = validateConnections(&clusterCR, &prevClusterCR, patches)
 
 	// If cluster already exists, check for invalid property changes.
 	if ar.Request.Operation == v1beta1.Update {

--- a/pkg/validator/cluster.go
+++ b/pkg/validator/cluster.go
@@ -623,32 +623,6 @@ func validateFileInjections(
 	return valErrors, patches
 }
 
-// validateConnections checks if connections have
-// changed, if yes then it increments ConfigMetaGenerator
-// so that reconciler can re-generate confgimeta
-// func validateConnections(
-// 	cr *kdv1.KubeDirectorCluster,
-// 	prevCr *kdv1.KubeDirectorCluster,
-// 	patches []clusterPatchSpec,
-// ) []clusterPatchSpec {
-
-// 	//unset := "false"
-// 	if _, ok := cr.Annotations["kdreconfig"]; ok {
-// 		patches = append(
-// 			patches,
-// 			clusterPatchSpec{
-// 				Op:   "remove",
-// 				Path: "/metadata/annotations/kdreconfig",
-// 				// Value: clusterPatchValue{
-// 				// 	ValueStr: &unset,
-// 				// },
-// 			},
-// 		)
-// 	}
-
-// 	return patches
-// }
-
 // validateSecrets validates defaultSecret and individual secret field for
 // each role. Validation is done to make sure secret object with the given
 // name is present in the cluster CR's namespace, and that its name includes
@@ -922,8 +896,6 @@ func admitClusterCR(
 
 	// Validate secret and generate patches for default values (if any)
 	valErrors, patches = validateSecrets(&clusterCR, valErrors, patches)
-
-	//patches = validateConnections(&clusterCR, &prevClusterCR, patches)
 
 	// If cluster already exists, check for invalid property changes.
 	if ar.Request.Operation == v1beta1.Update {

--- a/pkg/validator/cluster.go
+++ b/pkg/validator/cluster.go
@@ -632,19 +632,20 @@ func validateFileInjections(
 // 	patches []clusterPatchSpec,
 // ) []clusterPatchSpec {
 
-// 	if !reflect.DeepEqual(cr.Spec.Connections, prevCr.Spec.Connections) {
-// 		newConfigGenrator := int32(cr.Spec.ConnectionsGenToProcess + 1)
+// 	//unset := "false"
+// 	if _, ok := cr.Annotations["kdreconfig"]; ok {
 // 		patches = append(
 // 			patches,
 // 			clusterPatchSpec{
-// 				Op:   "add",
-// 				Path: "/spec/connectionsGenerationToProcess",
-// 				Value: clusterPatchValue{
-// 					ValueInt: &newConfigGenrator,
-// 				},
+// 				Op:   "remove",
+// 				Path: "/metadata/annotations/kdreconfig",
+// 				// Value: clusterPatchValue{
+// 				// 	ValueStr: &unset,
+// 				// },
 // 			},
 // 		)
 // 	}
+
 // 	return patches
 // }
 


### PR DESCRIPTION
- Currently, cluster connections utilizes **connectionsGenerationToProcess** in spec to determine if connections have been updated or not. 
- It's not ideal to use a field in spec for implementation purpose and hence, removed from the spec.
- The decision of whether connection object or the actually connected resources were modified is now determined by the md5 checksum of resource versions of connected k8s resources. This checksum is stored in the cluster's status object.  
- Also added secret as one of the connectable resources similar to clusters and configmaps.
- Modified reconciler for configmap to not change the cluster's spec but to invoke the cluster's reconciler by updating annotation.
- Secret's reconciler is similar to configmap. 