### PR TITLE
notifications fixes

### DIFF
--- a/deploy/example_catalog/cr-app-cdh632cm.json
+++ b/deploy/example_catalog/cr-app-cdh632cm.json
@@ -382,7 +382,7 @@
             {
                 "id": "cmserver",
                 "cardinality": "1",
-                "EventList": ["configure", "addnodes", "delnodes"]
+                "eventList": ["configure", "addnodes", "delnodes"]
             },
             {
                 "id": "primary",

--- a/pkg/apis/kubedirector/v1beta1/kubedirectorapp_types.go
+++ b/pkg/apis/kubedirector/v1beta1/kubedirectorapp_types.go
@@ -31,7 +31,7 @@ type KubeDirectorAppSpec struct {
 	NodeRoles           []NodeRole          `json:"roles"`
 	Config              NodeGroupConfig     `json:"config"`
 	DefaultPersistDirs  *[]string           `json:"defaultPersistDirs,omitempty"`
-	DefaultEventList    *[]string           `json:"defaultEventList.omitempty"`
+	DefaultEventList    *[]string           `json:"defaultEventList,omitempty"`
 	Capabilities        []corev1.Capability `json:"capabilities,omitempty"`
 	SystemdRequired     bool                `json:"systemdRequired,omitempty"`
 }

--- a/pkg/controller/kubedirectorcluster/members.go
+++ b/pkg/controller/kubedirectorcluster/members.go
@@ -936,6 +936,7 @@ func generateNotifies(
 					cr,
 					member.Pod,
 					&member.StateDetail,
+					otherRole.roleStatus.Name,
 					role,
 				)
 			}
@@ -1118,6 +1119,7 @@ func queueNotify(
 	cr *kdv1.KubeDirectorCluster,
 	podName string,
 	stateDetail *kdv1.MemberStateDetail,
+	roleName string,
 	modifiedRole *roleInfo,
 ) {
 
@@ -1156,7 +1158,7 @@ func queueNotify(
 			shared.EventReasonCluster,
 			"app referenced by cluster does not exist")
 	}
-	role := catalog.GetRoleFromID(appCr, modifiedRole.roleStatus.Name)
+	role := catalog.GetRoleFromID(appCr, roleName)
 	if role.EventList != nil && !shared.StringInList(op, *role.EventList) {
 		return
 	}


### PR DESCRIPTION
* **Don't update LastSetupGeneration too early.** If there are any members currently in transitional state, they might be on the way to generate additional notifies related to this gen on future handler passes. So don't update LastSetupGeneration until all members have exited transitional state. Fixes #308 . Should be backported to 0.4.2.

* **Update spec gen for member add/remove.** It was incrementing only for connections changes and not for other changes. (Also, we don't need to do atomic int operations to increment it.)

* **Fix defaultEventList.** A typo in the JSON tag for defaultEventList meant that our internal DefaultEventList field was never populated, always nil.

* **Correctly honor eventList.** When queuing notifies, the code was checking the event list for the role of the added/deleted member, rather than the event list of the member that was receiving the notify.

Also a cosmetic fix for one of the app JSON files.