### PR TITLE
ensure systemd is up before service enable/start

### DIFF
--- a/pkg/controller/kubedirectorcluster/cluster.go
+++ b/pkg/controller/kubedirectorcluster/cluster.go
@@ -152,7 +152,7 @@ func (r *ReconcileKubeDirectorCluster) syncCluster(
 		}
 	}()
 	// Calculate md5check sum to generate unique hash for connection object
-	var currentHash string = calcConnectionsHash(&cr.Spec.Connections, cr.Namespace)
+	currentHash := calcConnectionsHash(&cr.Spec.Connections, cr.Namespace)
 
 	// We use a finalizer to maintain KubeDirector state consistency;
 	// e.g. app references and ClusterStatusGens.


### PR DESCRIPTION
fixes #315 

Seems that there can be a startup race before systemd services can be properly started inside nodes. Noticing this on K8s nodes that use docker-ce. So let's be cautious and not run startscripts until systemd is working (for apps that require it).

Also a fix in cluster.go here for something that golint was complaining about.

Should backport this to 0.4.2.