### PR TITLE
Added App yaml and Cluster yaml file for Confluent Kafka 5.5 cluster creation

### DIFF
--- a/deploy/example_catalog/cr-app-kafka55.json
+++ b/deploy/example_catalog/cr-app-kafka55.json
@@ -1,0 +1,215 @@
+{
+    "apiVersion": "kubedirector.hpe.com/v1beta1",
+    "kind": "KubeDirectorApp",
+    "metadata": {
+        "name" : "confluentkafka55"
+    },
+    "spec" : {
+        "systemdRequired" : true,
+        "defaultPersistDirs" : ["/var/log", "/opt/configscripts"],
+        "capabilities" : [
+            "SYS_PACCT",
+            "SYS_RESOURCE",
+            "CHOWN",
+            "FSETID",
+            "KILL",
+            "SETGID",
+            "SETUID",
+            "NET_BIND_SERVICE",
+            "NET_BROADCAST",
+            "SYS_PTRACE",
+            "SETFCAP"
+        ],
+
+    "config": {
+        "roleServices": [
+            {
+                "serviceIDs": [
+                    "control-center"
+                ],
+                "roleID": "control-center"
+            },
+            {
+                "serviceIDs": [
+                    "zookeeper"
+                ],
+                "roleID": "zookeeper"
+            },
+            {
+                "serviceIDs": [
+                    "broker"
+                ],
+                "roleID": "broker"
+            },
+            {
+                "serviceIDs": [
+                    "schema-registry"
+                ],
+                "roleID": "schema-registry"
+            },
+            {
+                "serviceIDs": [
+                    "rest-proxy"
+                ],
+                "roleID": "rest-proxy"
+            },
+            {
+                "serviceIDs": [
+                    "kafka-connect"
+                ],
+                "roleID": "kafka-connect"
+            },
+            {
+                "serviceIDs": [
+                    "ksqldb"
+                ],
+                "roleID": "ksqldb"
+            },
+            {
+                "serviceIDs": [
+                    "kafka-client"
+                ],
+                "roleID": "kafka-client"
+            }
+        ],
+        "selectedRoles": [
+            "control-center",
+            "zookeeper",
+            "broker",
+            "schema-registry",
+            "rest-proxy",
+            "kafka-connect",
+            "ksqldb",
+            "kafka-client"
+        ]
+    },
+    "defaultImageRepoTag": "docker.io/bluedata/kafka:1.0",
+    "label": {
+        "name": "ConfluentKafka5.5",
+        "description": "Confluent Kafka Platform, with Control Center, KSQL, Kafka Broker, Zookeeper, Kafka Connect, REST Proxy, Schema Registry and optional Kafka Client"
+    },
+    "distroID": "bluedata/confluentkafka5",
+    "version": "1.0",
+    "configSchemaVersion": 7,
+    "services": [
+        {
+            "endpoint": {
+                "urlScheme": "http",
+                "path": "/",
+                "isDashboard": true,
+                "port": 9021
+            },
+            "id": "control-center",
+            "label": {
+                "name": "Confluent Control Center"
+            }
+        },
+        {
+            "endpoint": {
+		"path": "/",
+                "isDashboard": false,
+                "port": 2181
+            },
+            "id": "zookeeper",
+            "label": {
+                "name": "Kafka Zookeeper service"
+            }
+        },
+        {
+            "endpoint": {
+                "isDashboard": false,
+                "port": 9092
+            },
+            "id": "broker",
+            "label": {
+                "name": "Kafka Broker service"
+            }
+        },
+        {
+            "endpoint": {
+                "isDashboard": false,
+                "port": 8081
+            },
+            "id": "schema-registry",
+            "label": {
+                "name": "Kafka Schema Registry service"
+            }
+        },
+        {
+            "endpoint": {
+                "isDashboard": false,
+                "port": 8082
+            },
+            "id": "rest-proxy",
+            "label": {
+                "name": "Kafka REST Proxy service"
+            }
+        },
+        {
+            "endpoint": {
+                "isDashboard": false,
+                "port": 8083
+            },
+            "id": "kafka-connect",
+            "label": {
+                "name": "Kafka Connect REST API"
+            }
+        },
+        {
+            "endpoint": {
+                "isDashboard": false,
+                "port": 8088
+            },
+            "id": "ksqldb",
+            "label": {
+                "name": "Kafka SQL Server"
+            }
+        },
+        {
+            "id": "kafka-client",
+            "label": {
+                "name": "Kafka_Client"
+            }
+        }
+    ],
+    "defaultConfigPackage":  {
+            "packageURL": "file:///opt/configscripts/appconfig.tgz"
+        },
+    "roles": [
+        {
+            "cardinality": "1",
+            "id": "control-center"
+        },
+        {
+            "cardinality": "3",
+            "persistDirs": ["/var/lib/zookeeper"],
+            "id": "zookeeper"
+        },
+        {
+            "cardinality": "3+",
+            "id": "broker"
+        },
+        {
+            "cardinality": "1",
+            "id": "schema-registry"
+        },
+        {
+            "cardinality": "1",
+            "id": "rest-proxy"
+        },
+        {
+            "cardinality": "1",
+            "id": "kafka-connect"
+        },
+        {
+            "cardinality": "1",
+            "persistDirs": ["/usr/share/ksql","/var/lib/kafka-streams"],
+            "id": "ksqldb"
+        },
+        {
+            "cardinality": "0+",
+            "id": "kafka-client"
+        }
+    ]
+    }
+}

--- a/deploy/example_clusters/cr-cluster-kafka55-stor.yaml
+++ b/deploy/example_clusters/cr-cluster-kafka55-stor.yaml
@@ -1,0 +1,87 @@
+apiVersion: "kubedirector.hpe.com/v1beta1"
+kind: "KubeDirectorCluster"
+metadata:
+  name: "kafka55-persistent"
+spec:
+  app: confluentkafka55
+  roles:
+  - id: control-center
+    members: 1
+    resources:
+      requests:
+        memory: "2Gi"
+        cpu: "2"
+      limits:
+        memory: "2Gi"
+        cpu: "2"
+    storage:
+      size: "50Gi"
+  - id: zookeeper
+    members: 3
+    resources:
+      requests:
+        memory: "2Gi"
+        cpu: "2"
+      limits:
+        memory: "2Gi"
+        cpu: "2"
+    storage:
+      size: "50Gi"
+  - id: broker
+    members: 3
+    resources:
+      requests:
+        memory: "2Gi"
+        cpu: "2"
+      limits:
+        memory: "2Gi"
+        cpu: "2"
+    storage:
+      size: "50Gi"
+  - id: schema-registry
+    members: 1
+    resources:
+      requests:
+        memory: "2Gi"
+        cpu: "2"
+      limits:
+        memory: "2Gi"
+        cpu: "2"
+  - id: rest-proxy
+    members: 1
+    resources:
+      requests:
+        memory: "2Gi"
+        cpu: "2"
+      limits:
+        memory: "2Gi"
+        cpu: "2"
+  - id: kafka-connect
+    members: 1
+    resources:
+      requests:
+        memory: "4Gi"
+        cpu: "4"
+      limits:
+        memory: "4Gi"
+        cpu: "4"
+  - id: ksqldb
+    members: 1
+    resources:
+      requests:
+        memory: "2Gi"
+        cpu: "2"
+      limits:
+        memory: "2Gi"
+        cpu: "2"
+    storage:
+     size: "50Gi"
+  - id: kafka-client
+    members: 1
+    resources:
+      requests:
+        memory: "1Gi"
+        cpu: "1"
+      limits:
+        memory: "1Gi"
+        cpu: "1"


### PR DESCRIPTION
Application Json and cluster yaml file for Confluent Kafka 2.12. Includes following roles:
Kafka Broker version 5.5.0 
Zookeeper 3.5.7
Kafka Connect 5.5.0
REST Proxy 5.5.0
KSQL 5.5.0
Schema Registry 5.5.0
Control Center 5.5.0
An optional client pod for running test loads is also provided in the yaml file. The client pod role is kafka-client.