### PR TITLE
MapR 6.1 MEP 6.3 KD app

### DIFF
--- a/deploy/example_catalog/cr-app-mapr610-secured.json
+++ b/deploy/example_catalog/cr-app-mapr610-secured.json
@@ -1,0 +1,256 @@
+{
+  "apiVersion": "kubedirector.hpe.com/v1beta1",
+  "kind": "KubeDirectorApp",
+  "metadata": {
+    "name" : "mapr610"
+  },
+
+  "spec" : {
+    "systemdRequired": true,
+    "defaultPersistDirs" : ["/opt/mapr"],
+    "config": {
+      "configMeta" : {
+               "storage" : "60",
+               "secure":"true"
+      },
+      "roleServices": [
+        {
+                "roleID": "control-system",
+                "serviceIDs": [ "warden", "mapr-cs", "ssh" ]
+        },
+          {
+                "roleID": "cldb",
+                "serviceIDs": [ "warden", "cldb", "ssh"]
+          },
+          {
+                "roleID": "zookeeper",
+                "serviceIDs": [ "warden", "zookeeper", "ssh"]
+            },
+          {
+                "roleID": "hive-server2",
+                "serviceIDs": [ "warden", "hive-server2","webhcat" ,"ssh"]
+            },
+        {
+                "roleID": "hive-meta",
+                "serviceIDs": [ "warden", "hive-meta", "mysql", "ssh"]
+            },
+            {
+                "roleID": "hue",
+                "serviceIDs": [ "warden", "hue","httpfs", "ssh"]
+            },
+          {
+                "roleID": "edge",
+                "serviceIDs": [ "mapr-client", "ssh"]
+            },
+          {
+                "roleID": "nodemanager",
+                "serviceIDs": [ "warden", "yarn-nm", "ssh"]
+            },
+
+          {
+              "roleID": "resource-manager",
+                "serviceIDs": [ "warden", "yarn-rm", "ssh"]
+          },
+
+          {
+              "roleID": "history-server",
+                "serviceIDs": [ "warden", "yarn-hs", "ssh"]
+          },
+          {
+              "roleID": "fileserver",
+                "serviceIDs": [ "warden", "fileserver", "ssh"]
+          }
+
+      ],
+      "selectedRoles": [ "control-system","resource-manager","history-server", "zookeeper","cldb", "nodemanager","fileserver"]
+    },
+    "label": {
+      "name": "MapR 610",
+      "description": "MapR 6.1 with MEP 6.3"
+    },
+    "distroID": "bluedata/mapr610",
+    "version": "1.0",
+    "configSchemaVersion": 7,
+    "services": [
+    {
+            "id": "mapr-cs",
+            "label": { "name": "MapR Control System" },
+            "endpoint" : {
+                "urlScheme" : "https",
+                "path": "/app/mcs",
+                "port" : 8443,
+                "isDashboard" : true
+            }
+        },
+        {
+            "id": "hue",
+            "label": { "name": "Hue Console" },
+            "endpoint" : {
+                "urlScheme" : "https",
+                "path": "/",
+                "port" : 8888,
+                "isDashboard" : true
+            }
+        },
+        {
+            "id": "yarn-rm",
+            "label": { "name": "ResourceManager" },
+            "endpoint" : {
+                "urlScheme" : "https",
+                "path": "/cluster",
+                "port" : 8090,
+                "isDashboard" : true
+            }
+        },
+        {
+            "id": "yarn-nm",
+            "label": { "name": "NodeManager" },
+            "endpoint" : {
+                "urlScheme" : "https",
+                "path" : "/node",
+                "port" : 8044,
+                "isDashboard" : true
+            }
+        },
+        {
+            "id": "yarn-hs",
+            "label": { "name": "YARN HistoryServer"},
+            "endpoint" : {
+                "urlScheme" : "https",
+                "path" : "/jobhistory",
+                "port" : 19890,
+                "isDashboard" : true
+            }
+        },
+        {
+            "id": "cldb",
+            "label": { "name": "CLDB Web Port" },
+            "endpoint": {
+                "port" : 7443,
+                "isDashboard" : false
+            }
+        },
+        {
+            "id": "mapr-client",
+            "label": { "name": "MapR Client." }
+        },
+        {
+            "id": "zookeeper",
+            "label": { "name": "Zookeeper Server" },
+            "endpoint" : {
+                "port" : 5181,
+                "isDashboard" : false
+            }
+        },
+        {
+            "id": "webhcat",
+            "label": { "name": "WebHcat" },
+            "endpoint" : {
+                "port" : 50111,
+                "isDashboard" : false
+            }
+        },
+        {
+            "id": "httpfs",
+            "label": { "name": "HTTPFS" },
+            "endpoint" : {
+              "urlScheme": "https",
+              "path": "/webhdfs/v1",
+              "port": 14000,
+              "isDashboard": true
+            }
+        },
+        {
+            "id": "hive-meta",
+            "label": { "name": "HIVE Metastore" }
+        },
+      {
+            "id": "mysql",
+            "label": { "name": "MySQL" }
+        },
+        {
+            "id": "hive-server2",
+            "label": { "name": "HIVE Server 2" },
+            "endpoint" : {
+                "urlScheme" : "http",
+                "path": "/",
+                "port" : 10002,
+                "isDashboard" : true
+            }
+        },
+        {
+            "id": "warden",
+            "label": { "name": "Warden" }
+        },
+        {
+            "id": "fileserver",
+            "label": { "name": "FileServer" }
+        },
+        {
+            "id": "ssh",
+            "label": {
+                "name": "ssh"
+            },
+            "endpoint": {
+                "port": 22,
+                "isDashboard": false
+            }
+        },
+        {
+            "id": "ticketserver",
+            "label": { "name": "Simple Http server to distribute MapR tickets" }
+        }
+    ],
+    "defaultImageRepoTag": "bluedata/mapr610:1.0",
+    "defaultConfigPackage": {
+      "packageURL": "file:///opt/configscripts/appconfig-1.0.tgz"
+    },
+    "roles": [
+        {
+            "id": "control-system",
+            "cardinality": "1"
+        },
+        {
+            "id": "cldb",
+            "cardinality": "1+"
+        },
+        {
+            "id": "zookeeper",
+            "cardinality": "3"
+        },
+        {
+            "id": "hive-meta",
+            "cardinality": "1+"
+        },
+      {
+            "id": "hive-server2",
+            "cardinality": "1+"
+        },
+        {
+            "id": "hue",
+            "cardinality": "0+"
+        },
+        {
+            "id": "edge",
+            "imageRepoTag": "bluedata/mapr610edge:1.0",
+            "cardinality": "0+"
+        },
+        {
+            "id": "nodemanager",
+            "cardinality": "1+"
+        },
+        {
+            "id": "resource-manager",
+            "cardinality": "1+"
+        },
+        {
+            "id": "history-server",
+            "cardinality": "1"
+        },
+        {
+            "id": "fileserver",
+            "cardinality": "1+"
+        }
+    ]
+  }
+}

--- a/deploy/example_catalog/cr-app-mapr610-secured.json
+++ b/deploy/example_catalog/cr-app-mapr610-secured.json
@@ -112,6 +112,10 @@
         "history-server",
         "zookeeper",
         "cldb",
+        "hive-meta",
+        "hive-server2",
+        "hue",
+        "edge",
         "nodemanager",
         "fileserver"
       ]

--- a/deploy/example_catalog/cr-app-mapr610-secured.json
+++ b/deploy/example_catalog/cr-app-mapr610-secured.json
@@ -2,67 +2,119 @@
   "apiVersion": "kubedirector.hpe.com/v1beta1",
   "kind": "KubeDirectorApp",
   "metadata": {
-    "name" : "mapr610"
+    "name": "mapr610"
   },
-
-  "spec" : {
+  "spec": {
     "systemdRequired": true,
-    "defaultPersistDirs" : ["/opt/mapr"],
+    "defaultPersistDirs": [
+      "/opt/mapr"
+    ],
     "config": {
-      "configMeta" : {
-               "storage" : "60",
-               "secure":"true"
+      "configMeta": {
+        "storage": "60",
+        "secure": "true"
       },
       "roleServices": [
         {
-                "roleID": "control-system",
-                "serviceIDs": [ "warden", "mapr-cs", "ssh" ]
+          "roleID": "control-system",
+          "serviceIDs": [
+            "warden",
+            "mapr-cs",
+            "ssh"
+          ]
         },
-          {
-                "roleID": "cldb",
-                "serviceIDs": [ "warden", "cldb", "ssh"]
-          },
-          {
-                "roleID": "zookeeper",
-                "serviceIDs": [ "warden", "zookeeper", "ssh"]
-            },
-          {
-                "roleID": "hive-server2",
-                "serviceIDs": [ "warden", "hive-server2","webhcat" ,"ssh"]
-            },
         {
-                "roleID": "hive-meta",
-                "serviceIDs": [ "warden", "hive-meta", "mysql", "ssh"]
-            },
-            {
-                "roleID": "hue",
-                "serviceIDs": [ "warden", "hue","httpfs", "ssh"]
-            },
-          {
-                "roleID": "edge",
-                "serviceIDs": [ "mapr-client", "ssh"]
-            },
-          {
-                "roleID": "nodemanager",
-                "serviceIDs": [ "warden", "yarn-nm", "ssh"]
-            },
-
-          {
-              "roleID": "resource-manager",
-                "serviceIDs": [ "warden", "yarn-rm", "ssh"]
-          },
-
-          {
-              "roleID": "history-server",
-                "serviceIDs": [ "warden", "yarn-hs", "ssh"]
-          },
-          {
-              "roleID": "fileserver",
-                "serviceIDs": [ "warden", "fileserver", "ssh"]
-          }
-
+          "roleID": "cldb",
+          "serviceIDs": [
+            "warden",
+            "cldb",
+            "ssh"
+          ]
+        },
+        {
+          "roleID": "zookeeper",
+          "serviceIDs": [
+            "warden",
+            "zookeeper",
+            "ssh"
+          ]
+        },
+        {
+          "roleID": "hive-server2",
+          "serviceIDs": [
+            "warden",
+            "hive-server2",
+            "webhcat",
+            "ssh"
+          ]
+        },
+        {
+          "roleID": "hive-meta",
+          "serviceIDs": [
+            "warden",
+            "hive-meta",
+            "mysql",
+            "ssh"
+          ]
+        },
+        {
+          "roleID": "hue",
+          "serviceIDs": [
+            "warden",
+            "hue",
+            "httpfs",
+            "ssh"
+          ]
+        },
+        {
+          "roleID": "edge",
+          "serviceIDs": [
+            "mapr-client",
+            "ssh"
+          ]
+        },
+        {
+          "roleID": "nodemanager",
+          "serviceIDs": [
+            "warden",
+            "yarn-nm",
+            "ssh"
+          ]
+        },
+        {
+          "roleID": "resource-manager",
+          "serviceIDs": [
+            "warden",
+            "yarn-rm",
+            "ssh"
+          ]
+        },
+        {
+          "roleID": "history-server",
+          "serviceIDs": [
+            "warden",
+            "yarn-hs",
+            "ssh"
+          ]
+        },
+        {
+          "roleID": "fileserver",
+          "serviceIDs": [
+            "warden",
+            "fileserver",
+            "ssh"
+          ]
+        }
       ],
-      "selectedRoles": [ "control-system","resource-manager","history-server", "zookeeper","cldb", "nodemanager","fileserver"]
+      "selectedRoles": [
+        "control-system",
+        "resource-manager",
+        "history-server",
+        "zookeeper",
+        "cldb",
+        "nodemanager",
+        "fileserver"
+      ]
     },
     "label": {
       "name": "MapR 610",
@@ -72,185 +124,217 @@
     "version": "1.0",
     "configSchemaVersion": 7,
     "services": [
-    {
-            "id": "mapr-cs",
-            "label": { "name": "MapR Control System" },
-            "endpoint" : {
-                "urlScheme" : "https",
-                "path": "/app/mcs",
-                "port" : 8443,
-                "isDashboard" : true
-            }
-        },
-        {
-            "id": "hue",
-            "label": { "name": "Hue Console" },
-            "endpoint" : {
-                "urlScheme" : "https",
-                "path": "/",
-                "port" : 8888,
-                "isDashboard" : true
-            }
-        },
-        {
-            "id": "yarn-rm",
-            "label": { "name": "ResourceManager" },
-            "endpoint" : {
-                "urlScheme" : "https",
-                "path": "/cluster",
-                "port" : 8090,
-                "isDashboard" : true
-            }
-        },
-        {
-            "id": "yarn-nm",
-            "label": { "name": "NodeManager" },
-            "endpoint" : {
-                "urlScheme" : "https",
-                "path" : "/node",
-                "port" : 8044,
-                "isDashboard" : true
-            }
-        },
-        {
-            "id": "yarn-hs",
-            "label": { "name": "YARN HistoryServer"},
-            "endpoint" : {
-                "urlScheme" : "https",
-                "path" : "/jobhistory",
-                "port" : 19890,
-                "isDashboard" : true
-            }
-        },
-        {
-            "id": "cldb",
-            "label": { "name": "CLDB Web Port" },
-            "endpoint": {
-                "port" : 7443,
-                "isDashboard" : false
-            }
-        },
-        {
-            "id": "mapr-client",
-            "label": { "name": "MapR Client." }
-        },
-        {
-            "id": "zookeeper",
-            "label": { "name": "Zookeeper Server" },
-            "endpoint" : {
-                "port" : 5181,
-                "isDashboard" : false
-            }
-        },
-        {
-            "id": "webhcat",
-            "label": { "name": "WebHcat" },
-            "endpoint" : {
-                "port" : 50111,
-                "isDashboard" : false
-            }
-        },
-        {
-            "id": "httpfs",
-            "label": { "name": "HTTPFS" },
-            "endpoint" : {
-              "urlScheme": "https",
-              "path": "/webhdfs/v1",
-              "port": 14000,
-              "isDashboard": true
-            }
-        },
-        {
-            "id": "hive-meta",
-            "label": { "name": "HIVE Metastore" }
-        },
       {
-            "id": "mysql",
-            "label": { "name": "MySQL" }
+        "id": "mapr-cs",
+        "label": {
+          "name": "MapR Control System"
         },
-        {
-            "id": "hive-server2",
-            "label": { "name": "HIVE Server 2" },
-            "endpoint" : {
-                "urlScheme" : "http",
-                "path": "/",
-                "port" : 10002,
-                "isDashboard" : true
-            }
-        },
-        {
-            "id": "warden",
-            "label": { "name": "Warden" }
-        },
-        {
-            "id": "fileserver",
-            "label": { "name": "FileServer" }
-        },
-        {
-            "id": "ssh",
-            "label": {
-                "name": "ssh"
-            },
-            "endpoint": {
-                "port": 22,
-                "isDashboard": false
-            }
-        },
-        {
-            "id": "ticketserver",
-            "label": { "name": "Simple Http server to distribute MapR tickets" }
+        "endpoint": {
+          "urlScheme": "https",
+          "path": "/app/mcs",
+          "port": 8443,
+          "isDashboard": true
         }
+      },
+      {
+        "id": "hue",
+        "label": {
+          "name": "Hue Console"
+        },
+        "endpoint": {
+          "urlScheme": "https",
+          "path": "/",
+          "port": 8888,
+          "isDashboard": true
+        }
+      },
+      {
+        "id": "yarn-rm",
+        "label": {
+          "name": "ResourceManager"
+        },
+        "endpoint": {
+          "urlScheme": "https",
+          "path": "/cluster",
+          "port": 8090,
+          "isDashboard": true
+        }
+      },
+      {
+        "id": "yarn-nm",
+        "label": {
+          "name": "NodeManager"
+        },
+        "endpoint": {
+          "urlScheme": "https",
+          "path": "/node",
+          "port": 8044,
+          "isDashboard": true
+        }
+      },
+      {
+        "id": "yarn-hs",
+        "label": {
+          "name": "YARN HistoryServer"
+        },
+        "endpoint": {
+          "urlScheme": "https",
+          "path": "/jobhistory",
+          "port": 19890,
+          "isDashboard": true
+        }
+      },
+      {
+        "id": "cldb",
+        "label": {
+          "name": "CLDB Web Port"
+        },
+        "endpoint": {
+          "port": 7443,
+          "isDashboard": false
+        }
+      },
+      {
+        "id": "mapr-client",
+        "label": {
+          "name": "MapR Client."
+        }
+      },
+      {
+        "id": "zookeeper",
+        "label": {
+          "name": "Zookeeper Server"
+        },
+        "endpoint": {
+          "port": 5181,
+          "isDashboard": false
+        }
+      },
+      {
+        "id": "webhcat",
+        "label": {
+          "name": "WebHcat"
+        },
+        "endpoint": {
+          "port": 50111,
+          "isDashboard": false
+        }
+      },
+      {
+        "id": "httpfs",
+        "label": {
+          "name": "HTTPFS"
+        },
+        "endpoint": {
+          "urlScheme": "https",
+          "path": "/webhdfs/v1",
+          "port": 14000,
+          "isDashboard": true
+        }
+      },
+      {
+        "id": "hive-meta",
+        "label": {
+          "name": "HIVE Metastore"
+        }
+      },
+      {
+        "id": "mysql",
+        "label": {
+          "name": "MySQL"
+        }
+      },
+      {
+        "id": "hive-server2",
+        "label": {
+          "name": "HIVE Server 2"
+        },
+        "endpoint": {
+          "urlScheme": "http",
+          "path": "/",
+          "port": 10002,
+          "isDashboard": true
+        }
+      },
+      {
+        "id": "warden",
+        "label": {
+          "name": "Warden"
+        }
+      },
+      {
+        "id": "fileserver",
+        "label": {
+          "name": "FileServer"
+        }
+      },
+      {
+        "id": "ssh",
+        "label": {
+          "name": "ssh"
+        },
+        "endpoint": {
+          "port": 22,
+          "isDashboard": false
+        }
+      },
+      {
+        "id": "ticketserver",
+        "label": {
+          "name": "Simple Http server to distribute MapR tickets"
+        }
+      }
     ],
     "defaultImageRepoTag": "bluedata/mapr610:1.0",
     "defaultConfigPackage": {
       "packageURL": "file:///opt/configscripts/appconfig-1.0.tgz"
     },
     "roles": [
-        {
-            "id": "control-system",
-            "cardinality": "1"
-        },
-        {
-            "id": "cldb",
-            "cardinality": "1+"
-        },
-        {
-            "id": "zookeeper",
-            "cardinality": "3"
-        },
-        {
-            "id": "hive-meta",
-            "cardinality": "1+"
-        },
       {
-            "id": "hive-server2",
-            "cardinality": "1+"
-        },
-        {
-            "id": "hue",
-            "cardinality": "0+"
-        },
-        {
-            "id": "edge",
-            "imageRepoTag": "bluedata/mapr610edge:1.0",
-            "cardinality": "0+"
-        },
-        {
-            "id": "nodemanager",
-            "cardinality": "1+"
-        },
-        {
-            "id": "resource-manager",
-            "cardinality": "1+"
-        },
-        {
-            "id": "history-server",
-            "cardinality": "1"
-        },
-        {
-            "id": "fileserver",
-            "cardinality": "1+"
-        }
+        "id": "control-system",
+        "cardinality": "1"
+      },
+      {
+        "id": "cldb",
+        "cardinality": "1+"
+      },
+      {
+        "id": "zookeeper",
+        "cardinality": "3"
+      },
+      {
+        "id": "hive-meta",
+        "cardinality": "1+"
+      },
+      {
+        "id": "hive-server2",
+        "cardinality": "1+"
+      },
+      {
+        "id": "hue",
+        "cardinality": "0+"
+      },
+      {
+        "id": "edge",
+        "imageRepoTag": "bluedata/mapr610edge:1.0",
+        "cardinality": "0+"
+      },
+      {
+        "id": "nodemanager",
+        "cardinality": "1+"
+      },
+      {
+        "id": "resource-manager",
+        "cardinality": "1+"
+      },
+      {
+        "id": "history-server",
+        "cardinality": "1"
+      },
+      {
+        "id": "fileserver",
+        "cardinality": "1+"
+      }
     ]
   }
 }

--- a/deploy/example_catalog/cr-app-mapr610-unsecured.json
+++ b/deploy/example_catalog/cr-app-mapr610-unsecured.json
@@ -2,67 +2,119 @@
   "apiVersion": "kubedirector.hpe.com/v1beta1",
   "kind": "KubeDirectorApp",
   "metadata": {
-    "name" : "mapr610"
+    "name": "mapr610"
   },
-
-  "spec" : {
+  "spec": {
     "systemdRequired": true,
-    "defaultPersistDirs" : ["/opt/mapr"],
+    "defaultPersistDirs": [
+      "/opt/mapr"
+    ],
     "config": {
-      "configMeta" : {
-               "storage" : "60",
-               "secure":"false"
+      "configMeta": {
+        "storage": "60",
+        "secure": "false"
       },
       "roleServices": [
         {
-                "roleID": "control-system",
-                "serviceIDs": [ "warden", "mapr-cs", "ssh" ]
+          "roleID": "control-system",
+          "serviceIDs": [
+            "warden",
+            "mapr-cs",
+            "ssh"
+          ]
         },
-          {
-                "roleID": "cldb",
-                "serviceIDs": [ "warden", "cldb", "ssh"]
-          },
-          {
-                "roleID": "zookeeper",
-                "serviceIDs": [ "warden", "zookeeper", "ssh"]
-            },
-          {
-                "roleID": "hive-server2",
-                "serviceIDs": [ "warden", "hive-server2","webhcat" ,"ssh"]
-            },
         {
-                "roleID": "hive-meta",
-                "serviceIDs": [ "warden", "hive-meta", "mysql", "ssh"]
-            },
-            {
-                "roleID": "hue",
-                "serviceIDs": [ "warden", "hue","httpfs", "ssh"]
-            },
-          {
-                "roleID": "edge",
-                "serviceIDs": [ "mapr-client", "ssh"]
-            },
-          {
-                "roleID": "nodemanager",
-                "serviceIDs": [ "warden", "yarn-nm", "ssh"]
-            },
-
-          {
-              "roleID": "resource-manager",
-                "serviceIDs": [ "warden", "yarn-rm", "ssh"]
-          },
-
-          {
-              "roleID": "history-server",
-                "serviceIDs": [ "warden", "yarn-hs", "ssh"]
-          },
-          {
-              "roleID": "fileserver",
-                "serviceIDs": [ "warden", "fileserver", "ssh"]
-          }
-
+          "roleID": "cldb",
+          "serviceIDs": [
+            "warden",
+            "cldb",
+            "ssh"
+          ]
+        },
+        {
+          "roleID": "zookeeper",
+          "serviceIDs": [
+            "warden",
+            "zookeeper",
+            "ssh"
+          ]
+        },
+        {
+          "roleID": "hive-server2",
+          "serviceIDs": [
+            "warden",
+            "hive-server2",
+            "webhcat",
+            "ssh"
+          ]
+        },
+        {
+          "roleID": "hive-meta",
+          "serviceIDs": [
+            "warden",
+            "hive-meta",
+            "mysql",
+            "ssh"
+          ]
+        },
+        {
+          "roleID": "hue",
+          "serviceIDs": [
+            "warden",
+            "hue",
+            "httpfs",
+            "ssh"
+          ]
+        },
+        {
+          "roleID": "edge",
+          "serviceIDs": [
+            "mapr-client",
+            "ssh"
+          ]
+        },
+        {
+          "roleID": "nodemanager",
+          "serviceIDs": [
+            "warden",
+            "yarn-nm",
+            "ssh"
+          ]
+        },
+        {
+          "roleID": "resource-manager",
+          "serviceIDs": [
+            "warden",
+            "yarn-rm",
+            "ssh"
+          ]
+        },
+        {
+          "roleID": "history-server",
+          "serviceIDs": [
+            "warden",
+            "yarn-hs",
+            "ssh"
+          ]
+        },
+        {
+          "roleID": "fileserver",
+          "serviceIDs": [
+            "warden",
+            "fileserver",
+            "ssh"
+          ]
+        }
       ],
-      "selectedRoles": [ "control-system","resource-manager","history-server", "zookeeper","cldb", "nodemanager","fileserver"]
+      "selectedRoles": [
+        "control-system",
+        "resource-manager",
+        "history-server",
+        "zookeeper",
+        "cldb",
+        "nodemanager",
+        "fileserver"
+      ]
     },
     "label": {
       "name": "MapR 610",
@@ -72,185 +124,217 @@
     "version": "1.0",
     "configSchemaVersion": 7,
     "services": [
-    {
-            "id": "mapr-cs",
-            "label": { "name": "MapR Control System" },
-            "endpoint" : {
-                "urlScheme" : "http",
-                "path": "/app/mcs",
-                "port" : 8443,
-                "isDashboard" : true
-            }
-        },
-        {
-            "id": "hue",
-            "label": { "name": "Hue Console" },
-            "endpoint" : {
-                "urlScheme" : "http",
-                "path": "/",
-                "port" : 8888,
-                "isDashboard" : true
-            }
-        },
-        {
-            "id": "yarn-rm",
-            "label": { "name": "ResourceManager" },
-            "endpoint" : {
-                "urlScheme" : "http",
-                "path": "/cluster",
-                "port" : 8088,
-                "isDashboard" : true
-            }
-        },
-        {
-            "id": "yarn-nm",
-            "label": { "name": "NodeManager" },
-            "endpoint" : {
-                "urlScheme" : "http",
-                "path" : "/node",
-                "port" : 8042,
-                "isDashboard" : true
-            }
-        },
-        {
-            "id": "yarn-hs",
-            "label": { "name": "YARN HistoryServer"},
-            "endpoint" : {
-                "urlScheme" : "http",
-                "path" : "/jobhistory",
-                "port" : 19888,
-                "isDashboard" : true
-            }
-        },
-        {
-            "id": "cldb",
-            "label": { "name": "CLDB Web Port" },
-            "endpoint": {
-                "port" : 7221,
-                "isDashboard" : false
-            }
-        },
-        {
-            "id": "mapr-client",
-            "label": { "name": "MapR Client." }
-        },
-        {
-            "id": "zookeeper",
-            "label": { "name": "Zookeeper Server" },
-            "endpoint" : {
-                "port" : 5181,
-                "isDashboard" : false
-            }
-        },
-        {
-            "id": "webhcat",
-            "label": { "name": "WebHcat" },
-            "endpoint" : {
-                "port" : 50111,
-                "isDashboard" : false
-            }
-        },
-        {
-            "id": "httpfs",
-            "label": { "name": "HTTPFS" },
-            "endpoint" : {
-              "urlScheme": "http",
-              "path": "/webhdfs/v1",
-              "port": 14000,
-              "isDashboard": true
-            }
-        },
-        {
-            "id": "hive-meta",
-            "label": { "name": "HIVE Metastore" }
-        },
       {
-            "id": "mysql",
-            "label": { "name": "MySQL" }
+        "id": "mapr-cs",
+        "label": {
+          "name": "MapR Control System"
         },
-        {
-            "id": "hive-server2",
-            "label": { "name": "HIVE Server 2" },
-            "endpoint" : {
-                "urlScheme" : "http",
-                "path": "/",
-                "port" : 10002,
-                "isDashboard" : true
-            }
-        },
-        {
-            "id": "warden",
-            "label": { "name": "Warden" }
-        },
-        {
-            "id": "fileserver",
-            "label": { "name": "FileServer" }
-        },
-        {
-            "id": "ssh",
-            "label": {
-                "name": "ssh"
-            },
-            "endpoint": {
-                "port": 22,
-                "isDashboard": false
-            }
-        },
-        {
-            "id": "ticketserver",
-            "label": { "name": "Simple Http server to distribute MapR tickets" }
+        "endpoint": {
+          "urlScheme": "http",
+          "path": "/app/mcs",
+          "port": 8443,
+          "isDashboard": true
         }
+      },
+      {
+        "id": "hue",
+        "label": {
+          "name": "Hue Console"
+        },
+        "endpoint": {
+          "urlScheme": "http",
+          "path": "/",
+          "port": 8888,
+          "isDashboard": true
+        }
+      },
+      {
+        "id": "yarn-rm",
+        "label": {
+          "name": "ResourceManager"
+        },
+        "endpoint": {
+          "urlScheme": "http",
+          "path": "/cluster",
+          "port": 8088,
+          "isDashboard": true
+        }
+      },
+      {
+        "id": "yarn-nm",
+        "label": {
+          "name": "NodeManager"
+        },
+        "endpoint": {
+          "urlScheme": "http",
+          "path": "/node",
+          "port": 8042,
+          "isDashboard": true
+        }
+      },
+      {
+        "id": "yarn-hs",
+        "label": {
+          "name": "YARN HistoryServer"
+        },
+        "endpoint": {
+          "urlScheme": "http",
+          "path": "/jobhistory",
+          "port": 19888,
+          "isDashboard": true
+        }
+      },
+      {
+        "id": "cldb",
+        "label": {
+          "name": "CLDB Web Port"
+        },
+        "endpoint": {
+          "port": 7221,
+          "isDashboard": false
+        }
+      },
+      {
+        "id": "mapr-client",
+        "label": {
+          "name": "MapR Client."
+        }
+      },
+      {
+        "id": "zookeeper",
+        "label": {
+          "name": "Zookeeper Server"
+        },
+        "endpoint": {
+          "port": 5181,
+          "isDashboard": false
+        }
+      },
+      {
+        "id": "webhcat",
+        "label": {
+          "name": "WebHcat"
+        },
+        "endpoint": {
+          "port": 50111,
+          "isDashboard": false
+        }
+      },
+      {
+        "id": "httpfs",
+        "label": {
+          "name": "HTTPFS"
+        },
+        "endpoint": {
+          "urlScheme": "http",
+          "path": "/webhdfs/v1",
+          "port": 14000,
+          "isDashboard": true
+        }
+      },
+      {
+        "id": "hive-meta",
+        "label": {
+          "name": "HIVE Metastore"
+        }
+      },
+      {
+        "id": "mysql",
+        "label": {
+          "name": "MySQL"
+        }
+      },
+      {
+        "id": "hive-server2",
+        "label": {
+          "name": "HIVE Server 2"
+        },
+        "endpoint": {
+          "urlScheme": "http",
+          "path": "/",
+          "port": 10002,
+          "isDashboard": true
+        }
+      },
+      {
+        "id": "warden",
+        "label": {
+          "name": "Warden"
+        }
+      },
+      {
+        "id": "fileserver",
+        "label": {
+          "name": "FileServer"
+        }
+      },
+      {
+        "id": "ssh",
+        "label": {
+          "name": "ssh"
+        },
+        "endpoint": {
+          "port": 22,
+          "isDashboard": false
+        }
+      },
+      {
+        "id": "ticketserver",
+        "label": {
+          "name": "Simple Http server to distribute MapR tickets"
+        }
+      }
     ],
     "defaultImageRepoTag": "bluedata/mapr610:1.0",
     "defaultConfigPackage": {
       "packageURL": "file:///opt/configscripts/appconfig-1.0.tgz"
     },
     "roles": [
-        {
-            "id": "control-system",
-            "cardinality": "1"
-        },
-        {
-            "id": "cldb",
-            "cardinality": "1+"
-        },
-        {
-            "id": "zookeeper",
-            "cardinality": "3"
-        },
-        {
-            "id": "hive-meta",
-            "cardinality": "1+"
-        },
       {
-            "id": "hive-server2",
-            "cardinality": "1+"
-        },
-        {
-            "id": "hue",
-            "cardinality": "0+"
-        },
-        {
-            "id": "edge",
-            "imageRepoTag": "bluedata/mapr610edge:1.0",
-            "cardinality": "0+"
-        },
-        {
-            "id": "nodemanager",
-            "cardinality": "1+"
-        },
-        {
-            "id": "resource-manager",
-            "cardinality": "1+"
-        },
-        {
-            "id": "history-server",
-            "cardinality": "1"
-        },
-        {
-            "id": "fileserver",
-            "cardinality": "1+"
-        }
+        "id": "control-system",
+        "cardinality": "1"
+      },
+      {
+        "id": "cldb",
+        "cardinality": "1+"
+      },
+      {
+        "id": "zookeeper",
+        "cardinality": "3"
+      },
+      {
+        "id": "hive-meta",
+        "cardinality": "1+"
+      },
+      {
+        "id": "hive-server2",
+        "cardinality": "1+"
+      },
+      {
+        "id": "hue",
+        "cardinality": "0+"
+      },
+      {
+        "id": "edge",
+        "imageRepoTag": "bluedata/mapr610edge:1.0",
+        "cardinality": "0+"
+      },
+      {
+        "id": "nodemanager",
+        "cardinality": "1+"
+      },
+      {
+        "id": "resource-manager",
+        "cardinality": "1+"
+      },
+      {
+        "id": "history-server",
+        "cardinality": "1"
+      },
+      {
+        "id": "fileserver",
+        "cardinality": "1+"
+      }
     ]
   }
 }

--- a/deploy/example_catalog/cr-app-mapr610-unsecured.json
+++ b/deploy/example_catalog/cr-app-mapr610-unsecured.json
@@ -112,6 +112,10 @@
         "history-server",
         "zookeeper",
         "cldb",
+        "hive-meta",
+        "hive-server2",
+        "hue",
+        "edge",
         "nodemanager",
         "fileserver"
       ]

--- a/deploy/example_catalog/cr-app-mapr610-unsecured.json
+++ b/deploy/example_catalog/cr-app-mapr610-unsecured.json
@@ -1,0 +1,256 @@
+{
+  "apiVersion": "kubedirector.hpe.com/v1beta1",
+  "kind": "KubeDirectorApp",
+  "metadata": {
+    "name" : "mapr610"
+  },
+
+  "spec" : {
+    "systemdRequired": true,
+    "defaultPersistDirs" : ["/opt/mapr"],
+    "config": {
+      "configMeta" : {
+               "storage" : "60",
+               "secure":"false"
+      },
+      "roleServices": [
+        {
+                "roleID": "control-system",
+                "serviceIDs": [ "warden", "mapr-cs", "ssh" ]
+        },
+          {
+                "roleID": "cldb",
+                "serviceIDs": [ "warden", "cldb", "ssh"]
+          },
+          {
+                "roleID": "zookeeper",
+                "serviceIDs": [ "warden", "zookeeper", "ssh"]
+            },
+          {
+                "roleID": "hive-server2",
+                "serviceIDs": [ "warden", "hive-server2","webhcat" ,"ssh"]
+            },
+        {
+                "roleID": "hive-meta",
+                "serviceIDs": [ "warden", "hive-meta", "mysql", "ssh"]
+            },
+            {
+                "roleID": "hue",
+                "serviceIDs": [ "warden", "hue","httpfs", "ssh"]
+            },
+          {
+                "roleID": "edge",
+                "serviceIDs": [ "mapr-client", "ssh"]
+            },
+          {
+                "roleID": "nodemanager",
+                "serviceIDs": [ "warden", "yarn-nm", "ssh"]
+            },
+
+          {
+              "roleID": "resource-manager",
+                "serviceIDs": [ "warden", "yarn-rm", "ssh"]
+          },
+
+          {
+              "roleID": "history-server",
+                "serviceIDs": [ "warden", "yarn-hs", "ssh"]
+          },
+          {
+              "roleID": "fileserver",
+                "serviceIDs": [ "warden", "fileserver", "ssh"]
+          }
+
+      ],
+      "selectedRoles": [ "control-system","resource-manager","history-server", "zookeeper","cldb", "nodemanager","fileserver"]
+    },
+    "label": {
+      "name": "MapR 610",
+      "description": "MapR 6.1 with MEP 6.3"
+    },
+    "distroID": "bluedata/mapr610",
+    "version": "1.0",
+    "configSchemaVersion": 7,
+    "services": [
+    {
+            "id": "mapr-cs",
+            "label": { "name": "MapR Control System" },
+            "endpoint" : {
+                "urlScheme" : "http",
+                "path": "/app/mcs",
+                "port" : 8443,
+                "isDashboard" : true
+            }
+        },
+        {
+            "id": "hue",
+            "label": { "name": "Hue Console" },
+            "endpoint" : {
+                "urlScheme" : "http",
+                "path": "/",
+                "port" : 8888,
+                "isDashboard" : true
+            }
+        },
+        {
+            "id": "yarn-rm",
+            "label": { "name": "ResourceManager" },
+            "endpoint" : {
+                "urlScheme" : "http",
+                "path": "/cluster",
+                "port" : 8088,
+                "isDashboard" : true
+            }
+        },
+        {
+            "id": "yarn-nm",
+            "label": { "name": "NodeManager" },
+            "endpoint" : {
+                "urlScheme" : "http",
+                "path" : "/node",
+                "port" : 8042,
+                "isDashboard" : true
+            }
+        },
+        {
+            "id": "yarn-hs",
+            "label": { "name": "YARN HistoryServer"},
+            "endpoint" : {
+                "urlScheme" : "http",
+                "path" : "/jobhistory",
+                "port" : 19888,
+                "isDashboard" : true
+            }
+        },
+        {
+            "id": "cldb",
+            "label": { "name": "CLDB Web Port" },
+            "endpoint": {
+                "port" : 7221,
+                "isDashboard" : false
+            }
+        },
+        {
+            "id": "mapr-client",
+            "label": { "name": "MapR Client." }
+        },
+        {
+            "id": "zookeeper",
+            "label": { "name": "Zookeeper Server" },
+            "endpoint" : {
+                "port" : 5181,
+                "isDashboard" : false
+            }
+        },
+        {
+            "id": "webhcat",
+            "label": { "name": "WebHcat" },
+            "endpoint" : {
+                "port" : 50111,
+                "isDashboard" : false
+            }
+        },
+        {
+            "id": "httpfs",
+            "label": { "name": "HTTPFS" },
+            "endpoint" : {
+              "urlScheme": "http",
+              "path": "/webhdfs/v1",
+              "port": 14000,
+              "isDashboard": true
+            }
+        },
+        {
+            "id": "hive-meta",
+            "label": { "name": "HIVE Metastore" }
+        },
+      {
+            "id": "mysql",
+            "label": { "name": "MySQL" }
+        },
+        {
+            "id": "hive-server2",
+            "label": { "name": "HIVE Server 2" },
+            "endpoint" : {
+                "urlScheme" : "http",
+                "path": "/",
+                "port" : 10002,
+                "isDashboard" : true
+            }
+        },
+        {
+            "id": "warden",
+            "label": { "name": "Warden" }
+        },
+        {
+            "id": "fileserver",
+            "label": { "name": "FileServer" }
+        },
+        {
+            "id": "ssh",
+            "label": {
+                "name": "ssh"
+            },
+            "endpoint": {
+                "port": 22,
+                "isDashboard": false
+            }
+        },
+        {
+            "id": "ticketserver",
+            "label": { "name": "Simple Http server to distribute MapR tickets" }
+        }
+    ],
+    "defaultImageRepoTag": "bluedata/mapr610:1.0",
+    "defaultConfigPackage": {
+      "packageURL": "file:///opt/configscripts/appconfig-1.0.tgz"
+    },
+    "roles": [
+        {
+            "id": "control-system",
+            "cardinality": "1"
+        },
+        {
+            "id": "cldb",
+            "cardinality": "1+"
+        },
+        {
+            "id": "zookeeper",
+            "cardinality": "3"
+        },
+        {
+            "id": "hive-meta",
+            "cardinality": "1+"
+        },
+      {
+            "id": "hive-server2",
+            "cardinality": "1+"
+        },
+        {
+            "id": "hue",
+            "cardinality": "0+"
+        },
+        {
+            "id": "edge",
+            "imageRepoTag": "bluedata/mapr610edge:1.0",
+            "cardinality": "0+"
+        },
+        {
+            "id": "nodemanager",
+            "cardinality": "1+"
+        },
+        {
+            "id": "resource-manager",
+            "cardinality": "1+"
+        },
+        {
+            "id": "history-server",
+            "cardinality": "1"
+        },
+        {
+            "id": "fileserver",
+            "cardinality": "1+"
+        }
+    ]
+  }
+}

--- a/deploy/example_clusters/cr-cluster-mapr610.yaml
+++ b/deploy/example_clusters/cr-cluster-mapr610.yaml
@@ -79,6 +79,8 @@ spec:
   # hue implements MapR's Hue which connects to Hive Server2 for Hive operations. In a HA environment, the active hive server2 should be manually updated in Hue.ini file, auto fail-over is currently not available
   # fileserver implements MapR filesystem, this can be more than 1 member. This is to scale up the local maprfs facility
   # edge is a client service pod and can be 0 or more of it
+
+  # NOTE: The memory and cpu values are for reference only, higher than the given values is recommended
   roles:
   - id: control-system
     members: 1
@@ -102,29 +104,29 @@ spec:
     members: 3
     resources:
       requests:
-        memory: "2Gi"
+        memory: "4Gi"
         cpu: "4"
       limits:
-        memory: "2Gi"
+        memory: "4Gi"
         cpu: "4"
   - id: resource-manager
     members: 1
     resources:
       requests:
-        memory: "2Gi"
-        cpu: "2"
+        memory: "4Gi"
+        cpu: "4"
       limits:
-        memory: "2Gi"
-        cpu: "2"
+        memory: "4Gi"
+        cpu: "4"
   - id: history-server
     members: 1
     resources:
       requests:
-        memory: "2Gi"
-        cpu: "2"
+        memory: "4Gi"
+        cpu: "4"
       limits:
-        memory: "2Gi"
-        cpu: "2"
+        memory: "4Gi"
+        cpu: "4"
   - id: hive-meta
     members: 1
     resources:
@@ -138,10 +140,10 @@ spec:
     members: 1
     resources:
       requests:
-        memory: "5Gi"
+        memory: "4Gi"
         cpu: "4"
       limits:
-        memory: "5Gi"
+        memory: "4Gi"
         cpu: "4"
   - id: hive-server2
     members: 1
@@ -175,7 +177,7 @@ spec:
     resources:
       requests:
         memory: "4Gi"
-        cpu: "2"
+        cpu: "4"
       limits:
         memory: "4Gi"
-        cpu: "2"
+        cpu: "4"

--- a/deploy/example_clusters/cr-cluster-mapr610.yaml
+++ b/deploy/example_clusters/cr-cluster-mapr610.yaml
@@ -1,0 +1,189 @@
+# Each yaml file is associated with json file in kubedirector implementation
+# json file is called as app definition file and
+# yaml file is called as cluster definition file
+
+# App definition file (JSON file) contains all the details about the app like different roles defined in the app, the docker image location,
+# cardinality permission of the app (scale up facility), secure or unsecure clusters, services available along with their external interfaces,
+# roles to services mapping and many more. This is primary file which should be applied before applying the cluster definition file (YAML)
+
+# Cluster definition file (YAML file) contains what roles has to be implemented in our current cluster and how much resources have to be allocated
+# for each of the roles. The app name in the YAML file should match the app name in the JSON file. When applied, the YAML contents are validated against
+# JSON file.
+
+#------------------------------------------------------------------------------------------------------------------------------------
+# Following is the example yaml for Secret kind
+# The fields in the metadata section are mandatory, the values can be changed, which means value "users-data" can be anything
+# The data section is predominantly used to create users on the pods, the format is
+# <base64 encoded username> : "<base64 encoded password>"
+# The data section has few standard fields which are used for some predefined actions, following are the predfined fields
+# mapr, truststore, conf
+# mapr field is used to change the password for mapr user, password should be base64 encoded
+# truststore field is used to send the base mapr's ssl_truststore file content encoded with base64 -w0
+# conf field is used to send the mapr-clusters.conf content of base mapr, even this data should be base64 encoded
+# truststore and conf fields are mutually dependent fields hence when provided both has to be given
+
+# Following Secret is a template
+#apiVersion: v1
+#kind: Secret
+#metadata:
+#  name: ssl-remote
+#  labels:
+#    kubedirector.hpe.com/secretType : ssl-remote
+#data:
+#  truststore: <remote MapR's ssl_truststore in base64 -w0 encoding>
+#  conf: <remote MapR's mapr-clusters.conf in base64 encoding>
+# ---
+# Following Secret is a template
+#apiVersion: v1
+#kind: Secret
+#metadata:
+#  name: users-data
+#  labels:
+#    kubedirector.hpe.com/secretType : users-data
+#data:
+#  mapr: <mapr user password in base64 encoding>
+---
+#------------------------------------------------------------------------------------------------------------------------------------
+# This is the main section of the kubedirector cluster. In this section we define different roles that should be created in the cluster
+# We also define the resources to be associated with each roles.
+# metadata and spec section of kubedirector are standard kubernetes section
+# under spec, kubedirector provides connections and roles section
+# connections section is used to pass the configmaps and secrets data to the pod
+# roles section defines the different roles that should be implemented in the app.
+# each roles section will have an id, members, resources, storage (optional) and podLabels to define specification of the roles.
+# id should match with roles in app definition (JSON file),
+# members should match the cardinality in the JSON file,
+# resoures has fields requests and limits, request is the default allocation of resources to the pod and limits says how much the resources can be stretched. Here the resouces means memory and cpu
+# storage section attaches a PV to the pod and size field of the storage tells what is the size of the PV
+apiVersion: "kubedirector.hpe.com/v1beta1"
+kind: "KubeDirectorCluster"
+metadata:
+  name: "mapr610"
+spec:
+  app: mapr610
+#  connections:
+#    # attaching secrets data to the cluster
+#    secrets:
+#      - users-data
+#      - ssl-remote
+  # Defining the roles to be implemented
+  # for this current app, the different roles which are defined in the JSON file supplied with the app are
+  # control-system, cldb, resource-manager, history-server, zookeeper, hive-meta, hive-server2, hue, fileserver, nodemanager and edge
+  # control-system hosts the MapR Control System, current cardinality/member count is fixed to 1
+  # cldb implements the CLDB facility of the MapR Eco System, current cardinality/member count is greater than 1. Greater than 1 is for HA environment but it needs MapR license to implement HA
+  # zookeeper implements Zookeeper facility, current cardinality/member count is fixed to 3
+  # resource-manager implements YARN resource-manager, more than 1 member creates a HA  for it
+  # history-server implements YARN history-server it is fixed to 1 member
+  # nodemanager implements YARN nodemanager and it can be more than 1 member
+  # hive-meta implements Hive Metastore, more than 1 member creates HA environment for Hive Metastore
+  # hive-server implements Hive Server2, more than 1 member creates HA environment for Hive Server
+  # hue implements MapR's Hue which connects to Hive Server2 for Hive operations. In a HA environment, the active hive server2 should be manually updated in Hue.ini file, auto failover is currently not available
+  # fileserver implements MapR filesystem, this can be more than 1 member. This is to scale up the local maprfs facility
+  # edge is a client service pod and can be 0 or more of it
+  roles:
+  - id: control-system
+    members: 1
+    resources:
+      requests:
+        memory: "4Gi"
+        cpu: "4"
+      limits:
+        memory: "4Gi"
+        cpu: "4"
+    # storage section is added to attach a PVC with the pod. This PVC is mounted at /data/maprflatfilestorage
+    storage:
+      size:  40Gi
+    # dtap injection provides the dtap library to the pod which will be used for creating connections with
+    # dtap libraries and enabling the pod to use dtap facility
+  - id: cldb
+    members: 1
+    resources:
+      requests:
+        memory: "4Gi"
+        cpu: "4"
+      limits:
+        memory: "4Gi"
+        cpu: "4"
+  - id: zookeeper
+    members: 3
+    resources:
+      requests:
+        memory: "2Gi"
+        cpu: "4"
+      limits:
+        memory: "2Gi"
+        cpu: "4"
+  - id: resource-manager
+    members: 1
+    resources:
+      requests:
+        memory: "2Gi"
+        cpu: "2"
+      limits:
+        memory: "2Gi"
+        cpu: "2"
+  - id: history-server
+    members: 1
+    resources:
+      requests:
+        memory: "2Gi"
+        cpu: "2"
+      limits:
+        memory: "2Gi"
+        cpu: "2"
+  - id: hive-meta
+    members: 1
+    resources:
+      requests:
+        memory: "4Gi"
+        cpu: "4"
+      limits:
+        memory: "4Gi"
+        cpu: "4"
+  - id: fileserver
+    members: 1
+    resources:
+      requests:
+        memory: "5Gi"
+        cpu: "4"
+      limits:
+        memory: "5Gi"
+        cpu: "4"
+    storage:
+      size: "40Gi"
+  - id: hive-server2
+    members: 1
+    resources:
+      requests:
+        memory: "4Gi"
+        cpu: "4"
+      limits:
+        memory: "4Gi"
+        cpu: "4"
+  - id: hue
+    members: 1
+    resources:
+      requests:
+        memory: "4Gi"
+        cpu: "4"
+      limits:
+        memory: "4Gi"
+        cpu: "4"
+  - id: nodemanager
+    members: 1
+    resources:
+      requests:
+        memory: "4Gi"
+        cpu: "4"
+      limits:
+        memory: "4Gi"
+        cpu: "4"
+  - id: edge
+    members: 1
+    resources:
+      requests:
+        memory: "4Gi"
+        cpu: "2"
+      limits:
+        memory: "4Gi"
+        cpu: "2"

--- a/deploy/example_clusters/cr-cluster-mapr610.yaml
+++ b/deploy/example_clusters/cr-cluster-mapr610.yaml
@@ -3,7 +3,7 @@
 # yaml file is called as cluster definition file
 
 # App definition file (JSON file) contains all the details about the app like different roles defined in the app, the docker image location,
-# cardinality permission of the app (scale up facility), secure or unsecure clusters, services available along with their external interfaces,
+# cardinality permission of the app (scale up facility), secure or un-secure clusters, services available along with their external interfaces,
 # roles to services mapping and many more. This is primary file which should be applied before applying the cluster definition file (YAML)
 
 # Cluster definition file (YAML file) contains what roles has to be implemented in our current cluster and how much resources have to be allocated
@@ -15,7 +15,7 @@
 # The fields in the metadata section are mandatory, the values can be changed, which means value "users-data" can be anything
 # The data section is predominantly used to create users on the pods, the format is
 # <base64 encoded username> : "<base64 encoded password>"
-# The data section has few standard fields which are used for some predefined actions, following are the predfined fields
+# The data section has few standard fields which are used for some predefined actions, following are the predefined fields
 # mapr, truststore, conf
 # mapr field is used to change the password for mapr user, password should be base64 encoded
 # truststore field is used to send the base mapr's ssl_truststore file content encoded with base64 -w0
@@ -50,22 +50,21 @@
 # under spec, kubedirector provides connections and roles section
 # connections section is used to pass the configmaps and secrets data to the pod
 # roles section defines the different roles that should be implemented in the app.
-# each roles section will have an id, members, resources, storage (optional) and podLabels to define specification of the roles.
+# each roles section will have an id, members, resources and podLabels to define specification of the roles.
 # id should match with roles in app definition (JSON file),
 # members should match the cardinality in the JSON file,
-# resoures has fields requests and limits, request is the default allocation of resources to the pod and limits says how much the resources can be stretched. Here the resouces means memory and cpu
-# storage section attaches a PV to the pod and size field of the storage tells what is the size of the PV
+# resources has fields requests and limits, request is the default allocation of resources to the pod and limits says how much the resources can be stretched. Here the resources means memory and cpu
 apiVersion: "kubedirector.hpe.com/v1beta1"
 kind: "KubeDirectorCluster"
 metadata:
   name: "mapr610"
 spec:
   app: mapr610
-#  connections:
-#    # attaching secrets data to the cluster
-#    secrets:
-#      - users-data
-#      - ssl-remote
+# connections:
+#   # attaching secrets data to the cluster
+#   secrets:
+#     - users-data
+#     - ssl-remote
   # Defining the roles to be implemented
   # for this current app, the different roles which are defined in the JSON file supplied with the app are
   # control-system, cldb, resource-manager, history-server, zookeeper, hive-meta, hive-server2, hue, fileserver, nodemanager and edge
@@ -77,7 +76,7 @@ spec:
   # nodemanager implements YARN nodemanager and it can be more than 1 member
   # hive-meta implements Hive Metastore, more than 1 member creates HA environment for Hive Metastore
   # hive-server implements Hive Server2, more than 1 member creates HA environment for Hive Server
-  # hue implements MapR's Hue which connects to Hive Server2 for Hive operations. In a HA environment, the active hive server2 should be manually updated in Hue.ini file, auto failover is currently not available
+  # hue implements MapR's Hue which connects to Hive Server2 for Hive operations. In a HA environment, the active hive server2 should be manually updated in Hue.ini file, auto fail-over is currently not available
   # fileserver implements MapR filesystem, this can be more than 1 member. This is to scale up the local maprfs facility
   # edge is a client service pod and can be 0 or more of it
   roles:
@@ -90,11 +89,6 @@ spec:
       limits:
         memory: "4Gi"
         cpu: "4"
-    # storage section is added to attach a PVC with the pod. This PVC is mounted at /data/maprflatfilestorage
-    storage:
-      size:  40Gi
-    # dtap injection provides the dtap library to the pod which will be used for creating connections with
-    # dtap libraries and enabling the pod to use dtap facility
   - id: cldb
     members: 1
     resources:
@@ -149,8 +143,6 @@ spec:
       limits:
         memory: "5Gi"
         cpu: "4"
-    storage:
-      size: "40Gi"
   - id: hive-server2
     members: 1
     resources:


### PR DESCRIPTION
MapR app on KD version 1.0
- This version of the app is designed for KD and also each services is made to run independent pods, while in EPIC few services were grouped
- There is no need for repo location because all the required services are already installed on docker file, based on pod respective services gets enabled and configured
- As per the requirement for 5.1, it was decided to have only MapR core functionality, Hive, Hue and Edge services.
- Through secrets user can change the default MapR admin password and also pass the ssl_truststore and mapr-clusters.conf information to the pod (currently provided as a workaround). Until this feature gets in KD.
- There are 2 dockerfiles one for MEP and other one for edge pod. The reason for having 2 is because few packages cannot co-exist, mapr-core and mapr-client packages cannot co-exist.