### PR TITLE
cdh632 update version to 1.2

### DIFF
--- a/deploy/example_catalog/cr-app-cdh632cm.json
+++ b/deploy/example_catalog/cr-app-cdh632cm.json
@@ -128,13 +128,13 @@
                 "arbiter"
             ]
         },
-        "defaultImageRepoTag": "bluedata/cdh632multi:1.1",
+        "defaultImageRepoTag": "bluedata/cdh632multi:1.2",
         "label": {
             "name": "CDH 6.3.2 multirole 7x",
             "description": "CDH 6.3.2 with YARN and HBase support. Includes Hive, Hue, Impala and Spark."
         },
         "distroID": "bluedata/cdh632multi",
-        "version": "1.1",
+        "version": "1.2",
         "configSchemaVersion": 7,
         "services": [
             {


### PR DESCRIPTION
This fixes https://github.com/bluek8s/kubedirector/issues/335 

Enabled services cloudera-scm-server, cloudera-scm-agent and mysqld so that they auto restart when pod is deleted. The app setup change PR for reference is   https://github.com/bluedatainc/bluedata-catalog/pull/389