### PR TITLE
ELK 771 update version of elk app json for autostart of services.

### DIFF
--- a/deploy/example_catalog/cr-app-elk771.json
+++ b/deploy/example_catalog/cr-app-elk771.json
@@ -57,13 +57,13 @@
                 "logstash"
             ]
         },
-        "defaultImageRepoTag": "bluedata/elk771:1.0",
+        "defaultImageRepoTag": "bluedata/elk771:1.1",
         "label": {
             "name": "ELK Stack 7.7.1 v1",
             "description": "ELK Stack 7.7.1 cluster with elastic, logstash and kibana nodes v1"
         },
         "distroID": "bluedata/elk771",
-        "version": "1.0",
+        "version": "1.1",
         "configSchemaVersion": 7,
         "services": [
             {


### PR DESCRIPTION
This fixes the issue https://github.com/bluek8s/kubedirector/issues/335 regarding autostart of services when pods are deleted. Updated the image version to 1.1
Enabled elasticsearch, kibana and logstash with systemctl.