### PR TITLE
CDH and ELK add members key for optional roles.

### DIFF
--- a/deploy/example_clusters/cr-cluster-cdh632cm-stor.yaml
+++ b/deploy/example_clusters/cr-cluster-cdh632cm-stor.yaml
@@ -59,6 +59,7 @@ spec:
     storage:
       size: "50Gi"
   # - id: gateway
+  #   members: 1
   #   resources:
   #     requests:
   #       memory: "4Gi"
@@ -69,6 +70,7 @@ spec:
   #   storage:
   #     size: "50Gi"
   # - id: hbase
+  #   members: 1
   #   resources:
   #     requests:
   #       memory: "2Gi"
@@ -79,6 +81,7 @@ spec:
   #   storage:
   #     size: "100Gi"
   # - id: apps
+  #   members: 1
   #   resources:
   #     requests:
   #       memory: "4Gi"
@@ -89,6 +92,7 @@ spec:
   #   storage:
   #     size: "100Gi"
   # - id: impala
+  #   members: 1
   #   resources:
   #     requests:
   #       memory: "2Gi"
@@ -99,6 +103,7 @@ spec:
   #   storage:
   #     size: "50Gi"
   # - id: standby
+  #   members: 1
   #   resources:
   #     requests:
   #       memory: "4Gi"
@@ -109,6 +114,7 @@ spec:
   #   storage:
   #     size: "50Gi"
   # - id: arbiter
+  #   members: 1
   #   resources:
   #     requests:
   #       memory: "2Gi"

--- a/deploy/example_clusters/cr-cluster-elk771.yaml
+++ b/deploy/example_clusters/cr-cluster-elk771.yaml
@@ -16,6 +16,7 @@ spec:
     storage:
       size: "100Gi"
   # - id: data
+  #   members: 1
   #   resources:
   #     requests:
   #       memory: "8Gi"
@@ -26,6 +27,7 @@ spec:
   #   storage:
   #     size: "100Gi"
   # - id: kibana
+  #   members: 1
   #   resources:
   #     requests:
   #       memory: "8Gi"
@@ -36,6 +38,7 @@ spec:
   #   storage:
   #     size: "100Gi"
   # - id: logstash
+  #   members: 1
   #   resources:
   #     requests:
   #       memory: "8Gi"


### PR DESCRIPTION
Added members: 1 for optional roles in cdh cluster yaml and elk cluster yaml. We will need to pass members key so that roles get created when cluster is created since the cardinality of these roles is 0+ and it considers minimum of 0 unless members key is specified.