### PR TITLE
KD Issues 336 and 337

### DIFF
--- a/pkg/controller/kubedirectorcluster/cluster.go
+++ b/pkg/controller/kubedirectorcluster/cluster.go
@@ -109,6 +109,11 @@ func (r *ReconcileKubeDirectorCluster) syncCluster(
 			if updateErr == nil {
 				return
 			}
+
+			if cr.DeletionTimestamp != nil {
+				statusChanged = false
+			}
+
 			// Some necessary update failed. If the cluster has been deleted,
 			// that's ok... otherwise we'll try again.
 			currentCluster, currentClusterErr := observer.GetCluster(

--- a/pkg/controller/kubedirectorcluster/cluster.go
+++ b/pkg/controller/kubedirectorcluster/cluster.go
@@ -109,11 +109,6 @@ func (r *ReconcileKubeDirectorCluster) syncCluster(
 			if updateErr == nil {
 				return
 			}
-
-			if cr.DeletionTimestamp != nil {
-				statusChanged = false
-			}
-
 			// Some necessary update failed. If the cluster has been deleted,
 			// that's ok... otherwise we'll try again.
 			currentCluster, currentClusterErr := observer.GetCluster(
@@ -125,6 +120,9 @@ func (r *ReconcileKubeDirectorCluster) syncCluster(
 					return
 				}
 			} else {
+				if currentCluster.DeletionTimestamp != nil {
+					statusChanged = false
+				}
 				// If we got a conflict error, update the CR with its current
 				// form, restore our desired status/finalizers, and try again
 				// immediately.

--- a/pkg/validator/cluster.go
+++ b/pkg/validator/cluster.go
@@ -205,6 +205,7 @@ func validateCardinality(
 		if totalMembers > maxKDMembers {
 			anyError = true
 			valErrors = append(valErrors, maxMemberLimit)
+			break
 		}
 
 		// validate user-specified labels

--- a/pkg/validator/cluster.go
+++ b/pkg/validator/cluster.go
@@ -39,6 +39,8 @@ type secretValidateResult int
 
 const nameLengthLimit = 56
 
+const maxKDMembers = 1000
+
 const (
 	secretIsValid secretValidateResult = iota
 	secretPrefixNotMatched
@@ -150,6 +152,7 @@ func validateCardinality(
 ) ([]string, []clusterPatchSpec) {
 
 	anyError := false
+	totalMembers := int32(0)
 
 	numRoles := len(cr.Spec.Roles)
 	rolesPath := field.NewPath("spec", "roles")
@@ -197,6 +200,13 @@ func validateCardinality(
 				},
 			)
 		}
+
+		totalMembers += *role.Members
+		if totalMembers > maxKDMembers {
+			anyError = true
+			valErrors = append(valErrors, maxMemberLimit)
+		}
+
 		// validate user-specified labels
 		rolePath := rolesPath.Index(i)
 		labelErrors := appsvalidation.ValidateLabels(

--- a/pkg/validator/cluster.go
+++ b/pkg/validator/cluster.go
@@ -204,7 +204,13 @@ func validateCardinality(
 		totalMembers += *role.Members
 		if totalMembers > maxKDMembers {
 			anyError = true
-			valErrors = append(valErrors, maxMemberLimit)
+			valErrors = append(
+				valErrors,
+				fmt.Sprint(
+					maxMemberLimit,
+					maxKDMembers,
+				),
+			)
 			break
 		}
 

--- a/pkg/validator/types.go
+++ b/pkg/validator/types.go
@@ -80,5 +80,5 @@ const (
 	nameLimit       = "When using the ClusterRole naming scheme, the total length of KD cluster name + any of its role IDs must not exceed 56 characters."
 	badNamingScheme = "Naming scheme not valid in the config file."
 
-	maxMemberLimit = "Maximum number of total members per KD cluster supported is 1000"
+	maxMemberLimit = "Maximum number of total members per KD cluster supported is %d."
 )

--- a/pkg/validator/types.go
+++ b/pkg/validator/types.go
@@ -79,4 +79,6 @@ const (
 
 	nameLimit       = "When using the ClusterRole naming scheme, the total length of KD cluster name + any of its role IDs must not exceed 56 characters."
 	badNamingScheme = "Naming scheme not valid in the config file."
+
+	maxMemberLimit = "Maximum number of total members per KD cluster supported is 1000"
 )


### PR DESCRIPTION
Introduce a limit on the number of total members for a KD cluster.
Change the statusChange flag to false in case the cluster is being
deleted and update write back fails.