### PR TITLE
Spark245:v1.7 is updated as per the changes done for dtap.

### DIFF
--- a/deploy/example_catalog/cr-app-spark245.json
+++ b/deploy/example_catalog/cr-app-spark245.json
@@ -109,9 +109,9 @@
         }
       }
     ],
-    "defaultImageRepoTag": "bluedata/spark245:1.6",
+    "defaultImageRepoTag": "bluedata/spark245:1.7",
     "defaultConfigPackage": {
-      "packageURL": "file:///opt/configscripts/appconfig-1.6.tgz"
+      "packageURL": "file:///opt/configscripts/appconfig-1.7.tgz"
     },
     "roles": [
       {


### PR DESCRIPTION
Spark245:v1.7 is updated as per the changes done for dtap.

As per new changes dtap, /opt/bdfs folder created and bluedata-dtap.jar file placed by default. Spark245 start script is updated as per the changes.

Reference:
https://github.com/bluedatainc/bluedata-catalog/pull/382/commits/20a90bcc7c24bf9ec36b319763aedc3fc2b73974