### PR TITLE
cdh632 update version to 1.3 for dtap

### DIFF
--- a/deploy/example_catalog/cr-app-cdh632cm.json
+++ b/deploy/example_catalog/cr-app-cdh632cm.json
@@ -128,13 +128,13 @@
                 "arbiter"
             ]
         },
-        "defaultImageRepoTag": "bluedata/cdh632multi:1.2",
+        "defaultImageRepoTag": "bluedata/cdh632multi:1.3",
         "label": {
             "name": "CDH 6.3.2 multirole 7x",
             "description": "CDH 6.3.2 with YARN and HBase support. Includes Hive, Hue, Impala and Spark."
         },
         "distroID": "bluedata/cdh632multi",
-        "version": "1.2",
+        "version": "1.3",
         "configSchemaVersion": 7,
         "services": [
             {


### PR DESCRIPTION
Following recent changes for dtap in kubedirector, made corresponding changes in app for dtap and bumped up the version to 1.3

Reference pull request in app:

https://github.com/bluedatainc/bluedata-catalog/pull/395