### PR TITLE
allow PUT to an in-use kdapp if nothing in the spec is being changed

### DIFF
--- a/pkg/validator/app.go
+++ b/pkg/validator/app.go
@@ -153,7 +153,7 @@ func validateSelectedRoles(
 // in the schema. If any overrideable properties are unspecified, the corresponding
 // global values are used. This will add an PATCH spec for mutation the app CR.
 // The role in appCR will be correspondingly updated so that it can later be
-// to check whether the resulting CR differs from the current stored appCR.
+// used to check whether the resulting CR differs from the current stored appCR.
 func validateRoles(
 	appCR *kdv1.KubeDirectorApp,
 	patches []appPatchSpec,
@@ -166,6 +166,7 @@ func validateRoles(
 	var globalSetupPackageURL *string
 	var globalPersistDirs *[]string
 	var globalEventList *[]string
+
 	if appCR.Spec.DefaultImageRepoTag == nil {
 		globalImageRepoTag = nil
 	} else {

--- a/pkg/validator/types.go
+++ b/pkg/validator/types.go
@@ -40,6 +40,7 @@ const (
 	multipleSpecChange = "Change to spec not allowed before previous spec change has been processed."
 	pendingNotifies    = "Change to spec not allowed because some members have not processed notifications of previous change."
 
+	appInUse           = "KubeDirectorApp resource cannot be deleted or modified while referenced by the following KubeDirectorCluster resources: %s"
 	invalidAppMessage  = "Invalid app(%s). This app resource ID has not been registered."
 	invalidCardinality = "Invalid member count for role(%s). Specified member count:%d Role cardinality:%s"
 	invalidRole        = "Invalid role(%s) in app(%s) specified. Valid roles: \"%s\""


### PR DESCRIPTION
closes issue #319

It's not super-trivial to see whether an incoming spec changes anything, because of the way we handle global defaults and apply them to roles. So the validateRoles function here is changed to not only generate patches to modify the resulting document, but also apply the same changes to the in-memory appCR so we can use it for comparisons if this is a PUT.

Then admitAppCR does the comparison.

There's a big comment added to admitAppCR so more about that below...

==========

This change also fixes a minor bug in our defaults handling. The pattern is that we apply the global default to the roles (if necessary) and then remove the default from the spec. However in the case of defaultConfigPackage, if it was explicitly set to null, we were not removing it.

Among our own example apps, this only happened in our "vanilla OS" apps (for CentOS etc.) and is functionally harmless, but I needed to fix this behavior so that everything worked uniformly and I could do the necessary comparisons.

That does mean that any previously-created kdapps with a null defaultConfigPackage would not be able to take advantage of this change. That exception might kind of mess with upgrade processes. So I made the additional change in admitAppCR to ignore any difference in defaultConfigPackage value. These defaults don't directly affect how kdclusters behave in any case; they only affect the roles (which we ARE checking for differences).