### PR TITLE
CDH 632 update version of app after change in configmap structure

### DIFF
--- a/deploy/example_catalog/cr-app-cdh632cm.json
+++ b/deploy/example_catalog/cr-app-cdh632cm.json
@@ -128,13 +128,13 @@
                 "arbiter"
             ]
         },
-        "defaultImageRepoTag": "bluedata/cdh632multi:1.3",
+        "defaultImageRepoTag": "bluedata/cdh632multi:1.4",
         "label": {
             "name": "CDH 6.3.2 multirole 7x",
             "description": "CDH 6.3.2 with YARN and HBase support. Includes Hive, Hue, Impala and Spark."
         },
         "distroID": "bluedata/cdh632multi",
-        "version": "1.3",
+        "version": "1.4",
         "configSchemaVersion": 7,
         "services": [
             {


### PR DESCRIPTION
Updated version of cdh 632 app after changes in configmap data structure.
Below is pull request in bluedata-catalog 
https://github.com/bluedatainc/bluedata-catalog/pull/395