### PR TITLE
Cluster Connection deletion fix

### DIFF
--- a/pkg/catalog/configmeta.go
+++ b/pkg/catalog/configmeta.go
@@ -28,6 +28,7 @@ import (
 	"github.com/bluek8s/kubedirector/pkg/shared"
 	"github.com/google/uuid"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 )
 
 const (
@@ -384,13 +385,14 @@ func clusterBaseConfig(
 	kdConfigMaps, cmErr := genConfigConnections(cr)
 	kdSecrets, secErr := genSecretConnections(cr)
 
-	if cmErr != nil {
+	if !errors.IsNotFound(cmErr) && cmErr != nil {
 		return nil, cmErr
 	}
-	if connErr != nil {
+
+	if !errors.IsNotFound(connErr) && connErr != nil {
 		return nil, connErr
 	}
-	if secErr != nil {
+	if !errors.IsNotFound(secErr) && secErr != nil {
 		return nil, secErr
 	}
 

--- a/pkg/controller/configmap/configmap.go
+++ b/pkg/controller/configmap/configmap.go
@@ -84,6 +84,10 @@ func (r *ReconcileConfigMap) syncConfigMap(
 			for {
 				updateMetaGenerator := &kubecluster
 				annotations := updateMetaGenerator.Annotations
+				// if annotations == nil {
+				// 	annotations := make(map[string]string)
+				// 	updateMetaGenerator.Annotations = annotations
+				// }
 				if v, ok := annotations[shared.ConnectionsIncrementor]; ok {
 					newV, _ := strconv.Atoi(v)
 					annotations[shared.ConnectionsIncrementor] = strconv.Itoa(newV + 1)

--- a/pkg/controller/configmap/configmap.go
+++ b/pkg/controller/configmap/configmap.go
@@ -84,6 +84,10 @@ func (r *ReconcileConfigMap) syncConfigMap(
 			for {
 				updateMetaGenerator := &kubecluster
 				annotations := updateMetaGenerator.Annotations
+				if annotations == nil {
+					annotations := make(map[string]string)
+					updateMetaGenerator.Annotations = annotations
+				}
 				if v, ok := annotations[shared.ConnectionsIncrementor]; ok {
 					newV, _ := strconv.Atoi(v)
 					annotations[shared.ConnectionsIncrementor] = strconv.Itoa(newV + 1)

--- a/pkg/controller/configmap/configmap.go
+++ b/pkg/controller/configmap/configmap.go
@@ -84,10 +84,6 @@ func (r *ReconcileConfigMap) syncConfigMap(
 			for {
 				updateMetaGenerator := &kubecluster
 				annotations := updateMetaGenerator.Annotations
-				// if annotations == nil {
-				// 	annotations := make(map[string]string)
-				// 	updateMetaGenerator.Annotations = annotations
-				// }
 				if v, ok := annotations[shared.ConnectionsIncrementor]; ok {
 					newV, _ := strconv.Atoi(v)
 					annotations[shared.ConnectionsIncrementor] = strconv.Itoa(newV + 1)

--- a/pkg/controller/kubedirectorcluster/cluster.go
+++ b/pkg/controller/kubedirectorcluster/cluster.go
@@ -343,31 +343,37 @@ func calcConnectionsHash(
 	clusterNames := con.Clusters
 	var buffer bytes.Buffer
 	for _, c := range clusterNames {
-		clusterObj, _ := observer.GetCluster(ns, c)
+		clusterObj, clusterErr := observer.GetCluster(ns, c)
 		buffer.WriteString(c)
 		var specNum string
-		// extra careful while dereferencing
-		if clusterObj.Status.SpecGenerationToProcess == nil {
-			specNum = "nil"
-		} else {
-			specNum = strconv.Itoa(
-				int(*clusterObj.Status.SpecGenerationToProcess))
+		if clusterErr == nil {
+			// extra careful while dereferencing
+			if clusterObj.Status.SpecGenerationToProcess == nil {
+				specNum = "nil"
+			} else {
+				specNum = strconv.Itoa(
+					int(*clusterObj.Status.SpecGenerationToProcess))
+			}
 		}
 		buffer.WriteString(specNum)
 	}
 	cmNames := con.ConfigMaps
 	for _, c := range cmNames {
-		cmObj, _ := observer.GetConfigMap(ns, c)
-		rv := cmObj.ResourceVersion
-		buffer.WriteString(c)
-		buffer.WriteString(rv)
+		cmObj, cmErr := observer.GetConfigMap(ns, c)
+		if cmErr == nil {
+			rv := cmObj.ResourceVersion
+			buffer.WriteString(c)
+			buffer.WriteString(rv)
+		}
 	}
 	secretNames := con.Secrets
 	for _, c := range secretNames {
-		secretObj, _ := observer.GetSecret(ns, c)
-		rv := secretObj.ResourceVersion
-		buffer.WriteString(c)
-		buffer.WriteString(rv)
+		secretObj, secErr := observer.GetSecret(ns, c)
+		if secErr == nil {
+			rv := secretObj.ResourceVersion
+			buffer.WriteString(c)
+			buffer.WriteString(rv)
+		}
 	}
 	// md5 is very cheap for small strings
 	md5Sum := md5.Sum([]byte(buffer.String()))

--- a/pkg/controller/kubedirectorcluster/cluster.go
+++ b/pkg/controller/kubedirectorcluster/cluster.go
@@ -360,24 +360,22 @@ func calcConnectionsHash(
 	cmNames := con.ConfigMaps
 	for _, c := range cmNames {
 		cmObj, cmErr := observer.GetConfigMap(ns, c)
-		buffer.WriteString(c)
+		var rv string
 		if cmErr == nil {
-			rv := cmObj.ResourceVersion
-			buffer.WriteString(rv)
-		} else {
-			buffer.WriteString("")
+			rv = cmObj.ResourceVersion
 		}
+		buffer.WriteString(c)
+		buffer.WriteString(rv)
 	}
 	secretNames := con.Secrets
 	for _, c := range secretNames {
 		secretObj, secErr := observer.GetSecret(ns, c)
-		buffer.WriteString(c)
+		var rv string
 		if secErr == nil {
-			rv := secretObj.ResourceVersion
-			buffer.WriteString(rv)
-		} else {
-			buffer.WriteString("")
+			rv = secretObj.ResourceVersion
 		}
+		buffer.WriteString(c)
+		buffer.WriteString(rv)
 	}
 	// md5 is very cheap for small strings
 	md5Sum := md5.Sum([]byte(buffer.String()))

--- a/pkg/controller/kubedirectorcluster/cluster.go
+++ b/pkg/controller/kubedirectorcluster/cluster.go
@@ -360,19 +360,23 @@ func calcConnectionsHash(
 	cmNames := con.ConfigMaps
 	for _, c := range cmNames {
 		cmObj, cmErr := observer.GetConfigMap(ns, c)
+		buffer.WriteString(c)
 		if cmErr == nil {
 			rv := cmObj.ResourceVersion
-			buffer.WriteString(c)
 			buffer.WriteString(rv)
+		} else {
+			buffer.WriteString("")
 		}
 	}
 	secretNames := con.Secrets
 	for _, c := range secretNames {
 		secretObj, secErr := observer.GetSecret(ns, c)
+		buffer.WriteString(c)
 		if secErr == nil {
 			rv := secretObj.ResourceVersion
-			buffer.WriteString(c)
 			buffer.WriteString(rv)
+		} else {
+			buffer.WriteString("")
 		}
 	}
 	// md5 is very cheap for small strings

--- a/pkg/controller/secret/secret.go
+++ b/pkg/controller/secret/secret.go
@@ -85,6 +85,10 @@ func (r *ReconcileSecret) syncSecret(
 			for {
 				updateMetaGenerator := &kubecluster
 				annotations := updateMetaGenerator.Annotations
+				if annotations == nil {
+					annotations := make(map[string]string)
+					updateMetaGenerator.Annotations = annotations
+				}
 				if v, ok := annotations[connectionsIncrementor]; ok {
 					newV, _ := strconv.Atoi(v)
 					annotations[connectionsIncrementor] = strconv.Itoa(newV + 1)


### PR DESCRIPTION
This PR tackles the deletion of the connected cluster, because of which KD was panicking into an unrecoverable state.
Example:

Cluster A's connection
```
connections:
  clusters:
  - "clusterB"
``` 
If clusterB is deleted then KD was panicking while trying to calculate clusterB's configmeta.

Added the required checks to avoid such scenarios. 