### PR TITLE
Bump configcli version for compatibility with python3.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ project_name := kubedirector
 bin_name := kubedirector
 
 home_dir := /home/kubedirector
-configcli_version := 0.5
+configcli_version := 0.7
 
 local_deploy_yaml := deploy/kubedirector/deployment-localbuilt.yaml
 
@@ -32,7 +32,7 @@ endif
 build_dir := build/_output
 configcli_dest := build/configcli.tgz
 goarch := amd64
-cgo_enabled := 0 
+cgo_enabled := 0
 
 .DEFAULT_GOAL := build
 


### PR DESCRIPTION
This can be done once a new release of configcli has been made.