### PR TITLE
Add volumeDevice support for KDApps

### DIFF
--- a/deploy/kubedirector/kubedirector.hpe.com_kubedirectorclusters_crd.yaml
+++ b/deploy/kubedirector/kubedirector.hpe.com_kubedirectorclusters_crd.yaml
@@ -169,6 +169,19 @@ spec:
                       storageClassName:
                         type: string
                         minLength: 1
+                  blockStorage:
+                    type: object
+                    nullable: true
+                    required: [storageClassName, path]
+                    properties:
+                      path:
+                        type: string
+                      storageClassName:
+                        type: string
+                        minLength: 1
+                      size:
+                        type: string
+                        pattern: '^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'
                   fileInjections:
                     type: array
                     items:

--- a/deploy/kubedirector/kubedirector.hpe.com_kubedirectorclusters_crd.yaml
+++ b/deploy/kubedirector/kubedirector.hpe.com_kubedirectorclusters_crd.yaml
@@ -258,6 +258,8 @@ spec:
                           type: string
                         pvc:
                           type: string
+                        blockdevicepath:
+                          type: string
                         authToken:
                           type: string  
                         state:

--- a/deploy/kubedirector/kubedirector.hpe.com_kubedirectorclusters_crd.yaml
+++ b/deploy/kubedirector/kubedirector.hpe.com_kubedirectorclusters_crd.yaml
@@ -180,7 +180,7 @@ spec:
                       pathPrefix:
                         type: string
                         minLength: 1
-                        pattern: '^/.*$' #start with '/'. 
+                        pattern: '^/.*$'
                       storageClassName:
                         type: string
                         minLength: 1
@@ -263,7 +263,7 @@ spec:
                           type: string
                         pvc:
                           type: string
-                        blockDevicePath:
+                        blockDevicePaths:
                           type: array
                         authToken:
                           type: string  

--- a/deploy/kubedirector/kubedirector.hpe.com_kubedirectorclusters_crd.yaml
+++ b/deploy/kubedirector/kubedirector.hpe.com_kubedirectorclusters_crd.yaml
@@ -180,6 +180,7 @@ spec:
                       pathPrefix:
                         type: string
                         minLength: 1
+                        pattern: '^/.*$' #start with '/'. 
                       storageClassName:
                         type: string
                         minLength: 1
@@ -262,7 +263,7 @@ spec:
                           type: string
                         pvc:
                           type: string
-                        blockdevicepath:
+                        blockDevicePath:
                           type: array
                         authToken:
                           type: string  

--- a/deploy/kubedirector/kubedirector.hpe.com_kubedirectorclusters_crd.yaml
+++ b/deploy/kubedirector/kubedirector.hpe.com_kubedirectorclusters_crd.yaml
@@ -172,10 +172,14 @@ spec:
                   blockStorage:
                     type: object
                     nullable: true
-                    required: [storageClassName, path]
+                    required: [storageClassName, pathPrefix, numDevices]
                     properties:
-                      path:
+                      numDevices:
+                        type: integer
+                        minimum: 1
+                      pathPrefix:
                         type: string
+                        minLength: 1
                       storageClassName:
                         type: string
                         minLength: 1
@@ -259,7 +263,7 @@ spec:
                         pvc:
                           type: string
                         blockdevicepath:
-                          type: string
+                          type: array
                         authToken:
                           type: string  
                         state:

--- a/pkg/apis/kubedirector/v1beta1/kubedirectorcluster_types.go
+++ b/pkg/apis/kubedirector/v1beta1/kubedirectorcluster_types.go
@@ -135,6 +135,7 @@ type Role struct {
 	EnvVars        []corev1.EnvVar             `json:"env,omitempty"`
 	FileInjections []FileInjections            `json:"fileInjections,omitempty"`
 	Secret         *KDSecret                   `json:"secret,omitempty"`
+	BlockStorage   *BlockStorage               `json:"blockStorage,omitempty"`
 }
 
 // StateRollup surfaces whether any per-member statuses have problems that
@@ -153,6 +154,14 @@ type StateRollup struct {
 type ClusterStorage struct {
 	Size         string  `json:"size"`
 	StorageClass *string `json:"storageClassName,omitempty"`
+}
+
+// BlockStorage defines the block storage type and quantity, if any, to be used
+// for mounting a block volume in a role.
+type BlockStorage struct {
+	StorageClass *string `json:"storageClassName,omitempty"`
+	Path         *string `json:"path,omitempty"`
+	Size         *string `json:"size,omitempty"`
 }
 
 // RoleStatus describes the component objects of a virtual cluster role.

--- a/pkg/apis/kubedirector/v1beta1/kubedirectorcluster_types.go
+++ b/pkg/apis/kubedirector/v1beta1/kubedirectorcluster_types.go
@@ -174,14 +174,14 @@ type RoleStatus struct {
 
 // MemberStatus describes the component objects of a virtual cluster member.
 type MemberStatus struct {
-	Pod             string            `json:"pod"`
-	Service         string            `json:"service"`
-	AuthToken       string            `json:"authToken,omitempty"`
-	PVC             string            `json:"pvc,omitempty"`
-	State           string            `json:"state"`
-	StateDetail     MemberStateDetail `json:"stateDetail,omitempty"`
-	NodeID          int64             `json:"nodeID"`
-	BlockDevicePath []string          `json:"blockDevicePath,omitempty"`
+	Pod              string            `json:"pod"`
+	Service          string            `json:"service"`
+	AuthToken        string            `json:"authToken,omitempty"`
+	PVC              string            `json:"pvc,omitempty"`
+	State            string            `json:"state"`
+	StateDetail      MemberStateDetail `json:"stateDetail,omitempty"`
+	NodeID           int64             `json:"nodeID"`
+	BlockDevicePaths []string          `json:"blockDevicePaths,omitempty"`
 }
 
 // MemberStateDetail digs into detail about the management of configmeta and

--- a/pkg/apis/kubedirector/v1beta1/kubedirectorcluster_types.go
+++ b/pkg/apis/kubedirector/v1beta1/kubedirectorcluster_types.go
@@ -156,7 +156,7 @@ type ClusterStorage struct {
 	StorageClass *string `json:"storageClassName,omitempty"`
 }
 
-// BlockStorage defines the block storage type and quantity, if any, to be used
+// BlockStorage defines the block storage type, path, and optionally size, if any, to be used
 // for mounting a block volume in a role.
 type BlockStorage struct {
 	StorageClass *string `json:"storageClassName,omitempty"`
@@ -173,13 +173,14 @@ type RoleStatus struct {
 
 // MemberStatus describes the component objects of a virtual cluster member.
 type MemberStatus struct {
-	Pod         string            `json:"pod"`
-	Service     string            `json:"service"`
-	AuthToken   string            `json:"authToken,omitempty"`
-	PVC         string            `json:"pvc,omitempty"`
-	State       string            `json:"state"`
-	StateDetail MemberStateDetail `json:"stateDetail,omitempty"`
-	NodeID      int64             `json:"nodeID"`
+	Pod             string            `json:"pod"`
+	Service         string            `json:"service"`
+	AuthToken       string            `json:"authToken,omitempty"`
+	PVC             string            `json:"pvc,omitempty"`
+	State           string            `json:"state"`
+	StateDetail     MemberStateDetail `json:"stateDetail,omitempty"`
+	NodeID          int64             `json:"nodeID"`
+	BlockDevicePath string            `json:"blockdevicepath,omitempty"`
 }
 
 // MemberStateDetail digs into detail about the management of configmeta and

--- a/pkg/apis/kubedirector/v1beta1/kubedirectorcluster_types.go
+++ b/pkg/apis/kubedirector/v1beta1/kubedirectorcluster_types.go
@@ -160,8 +160,9 @@ type ClusterStorage struct {
 // for mounting a block volume in a role.
 type BlockStorage struct {
 	StorageClass *string `json:"storageClassName,omitempty"`
-	Path         *string `json:"path,omitempty"`
+	Path         *string `json:"pathPrefix,omitempty"`
 	Size         *string `json:"size,omitempty"`
+	NumDevices   *int32  `json:"numDevices,omitempty"`
 }
 
 // RoleStatus describes the component objects of a virtual cluster role.
@@ -180,7 +181,7 @@ type MemberStatus struct {
 	State           string            `json:"state"`
 	StateDetail     MemberStateDetail `json:"stateDetail,omitempty"`
 	NodeID          int64             `json:"nodeID"`
-	BlockDevicePath string            `json:"blockdevicepath,omitempty"`
+	BlockDevicePath []string          `json:"blockdevicepath,omitempty"`
 }
 
 // MemberStateDetail digs into detail about the management of configmeta and

--- a/pkg/apis/kubedirector/v1beta1/kubedirectorcluster_types.go
+++ b/pkg/apis/kubedirector/v1beta1/kubedirectorcluster_types.go
@@ -181,7 +181,7 @@ type MemberStatus struct {
 	State           string            `json:"state"`
 	StateDetail     MemberStateDetail `json:"stateDetail,omitempty"`
 	NodeID          int64             `json:"nodeID"`
-	BlockDevicePath []string          `json:"blockdevicepath,omitempty"`
+	BlockDevicePath []string          `json:"blockDevicePath,omitempty"`
 }
 
 // MemberStateDetail digs into detail about the management of configmeta and

--- a/pkg/catalog/configmeta.go
+++ b/pkg/catalog/configmeta.go
@@ -469,15 +469,15 @@ func ConfigmetaGenerator(
 			memberName := member.Pod
 
 			perNodeConfig[memberName] = &node{
-				RoleID:          roleName,
-				NodegroupID:     "1",
-				ID:              strconv.FormatInt(member.NodeID, 10),
-				Hostname:        memberName + "." + domain,
-				FQDN:            memberName + "." + domain,
-				Domain:          domain,
-				DistroID:        appCR.Spec.DistroID,
-				DependsOn:       make(refkeysMap),       // currently, always empty
-				BlockDevicePath: member.BlockDevicePath, // present only if block device is to be mounted
+				RoleID:           roleName,
+				NodegroupID:      "1",
+				ID:               strconv.FormatInt(member.NodeID, 10),
+				Hostname:         memberName + "." + domain,
+				FQDN:             memberName + "." + domain,
+				Domain:           domain,
+				DistroID:         appCR.Spec.DistroID,
+				DependsOn:        make(refkeysMap), // currently, always empty
+				BlockDevicePaths: member.BlockDevicePaths,
 			}
 		}
 	}

--- a/pkg/catalog/configmeta.go
+++ b/pkg/catalog/configmeta.go
@@ -467,15 +467,17 @@ func ConfigmetaGenerator(
 	for roleName, members := range membersForRole {
 		for _, member := range members {
 			memberName := member.Pod
+
 			perNodeConfig[memberName] = &node{
-				RoleID:      roleName,
-				NodegroupID: "1",
-				ID:          strconv.FormatInt(member.NodeID, 10),
-				Hostname:    memberName + "." + domain,
-				FQDN:        memberName + "." + domain,
-				Domain:      domain,
-				DistroID:    appCR.Spec.DistroID,
-				DependsOn:   make(refkeysMap), // currently, always empty
+				RoleID:          roleName,
+				NodegroupID:     "1",
+				ID:              strconv.FormatInt(member.NodeID, 10),
+				Hostname:        memberName + "." + domain,
+				FQDN:            memberName + "." + domain,
+				Domain:          domain,
+				DistroID:        appCR.Spec.DistroID,
+				DependsOn:       make(refkeysMap),       // currently, always empty
+				BlockDevicePath: member.BlockDevicePath, // present only if block device is to be mounted
 			}
 		}
 	}

--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -57,16 +57,15 @@ type cluster struct {
 }
 
 type node struct {
-	RoleID          string     `json:"role_id"`
-	NodegroupID     string     `json:"nodegroup_id"`
-	ID              string     `json:"id"`
-	Hostname        string     `json:"hostname"`
-	FQDN            string     `json:"fqdn"`
-	Domain          string     `json:"domain"`
-	DistroID        string     `json:"distro_id"`
-	DependsOn       refkeysMap `json:"depends_on"`
-	BlockDevicePath []string   `json:"block_device_path,omitempty"`
-	// we do not want the field if no block device is attached. Hence omitempty
+	RoleID           string     `json:"role_id"`
+	NodegroupID      string     `json:"nodegroup_id"`
+	ID               string     `json:"id"`
+	Hostname         string     `json:"hostname"`
+	FQDN             string     `json:"fqdn"`
+	Domain           string     `json:"domain"`
+	DistroID         string     `json:"distro_id"`
+	DependsOn        refkeysMap `json:"depends_on"`
+	BlockDevicePaths []string   `json:"block_device_paths,omitempty"`
 }
 
 type role struct {

--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -57,14 +57,16 @@ type cluster struct {
 }
 
 type node struct {
-	RoleID      string     `json:"role_id"`
-	NodegroupID string     `json:"nodegroup_id"`
-	ID          string     `json:"id"`
-	Hostname    string     `json:"hostname"`
-	FQDN        string     `json:"fqdn"`
-	Domain      string     `json:"domain"`
-	DistroID    string     `json:"distro_id"`
-	DependsOn   refkeysMap `json:"depends_on"`
+	RoleID          string     `json:"role_id"`
+	NodegroupID     string     `json:"nodegroup_id"`
+	ID              string     `json:"id"`
+	Hostname        string     `json:"hostname"`
+	FQDN            string     `json:"fqdn"`
+	Domain          string     `json:"domain"`
+	DistroID        string     `json:"distro_id"`
+	DependsOn       refkeysMap `json:"depends_on"`
+	BlockDevicePath string     `json:"block_device_path,omitempty"`
+	// we do not want the field if no block device is attached. Hence omitempty
 }
 
 type role struct {

--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -65,7 +65,7 @@ type node struct {
 	Domain          string     `json:"domain"`
 	DistroID        string     `json:"distro_id"`
 	DependsOn       refkeysMap `json:"depends_on"`
-	BlockDevicePath string     `json:"block_device_path,omitempty"`
+	BlockDevicePath []string   `json:"block_device_path,omitempty"`
 	// we do not want the field if no block device is attached. Hence omitempty
 }
 

--- a/pkg/controller/kubedirectorcluster/cluster.go
+++ b/pkg/controller/kubedirectorcluster/cluster.go
@@ -66,15 +66,6 @@ func (r *ReconcileKubeDirectorCluster) syncCluster(
 	if annotations == nil {
 		annotations = make(map[string]string)
 		cr.Annotations = annotations
-
-		if shared.Update(context.TODO(), cr) == nil {
-			shared.LogInfo(
-				reqLogger,
-				cr,
-				shared.EventReasonCluster,
-				"Initialized Annotations and updated context",
-			)
-		}
 	}
 
 	// Set a defer func to write new status and/or finalizers if they change.

--- a/pkg/controller/kubedirectorcluster/roles.go
+++ b/pkg/controller/kubedirectorcluster/roles.go
@@ -504,8 +504,7 @@ func addMemberStatuses(
 		if role.roleSpec.BlockStorage != nil {
 			numDevices := *role.roleSpec.BlockStorage.NumDevices
 			pathPrefix := *role.roleSpec.BlockStorage.Path
-			var i int32
-			for i = 0; i < numDevices; i++ {
+			for i := int32(0); i < numDevices; i++ {
 				blockDevPath := pathPrefix + strconv.FormatInt(int64(i), 10)
 				blockDevPaths = append(blockDevPaths, blockDevPath)
 			}

--- a/pkg/controller/kubedirectorcluster/roles.go
+++ b/pkg/controller/kubedirectorcluster/roles.go
@@ -499,10 +499,17 @@ func addMemberStatuses(
 		}
 		// check if there is block device to be mounted in the member.
 		// assign path value if there is else it'd be an empty string
-		blockDevPath := ""
+		var blockDevPaths []string
 
 		if role.roleSpec.BlockStorage != nil {
-			blockDevPath = *role.roleSpec.BlockStorage.Path
+			numDevices := *role.roleSpec.BlockStorage.NumDevices
+			pathPrefix := *role.roleSpec.BlockStorage.Path
+			var i int32
+			for i = 0; i < numDevices; i++ {
+				blockDevPath := pathPrefix + strconv.FormatInt(int64(i), 10)
+				blockDevPaths = append(blockDevPaths, blockDevPath)
+			}
+
 		}
 
 		// role.roleStatus.Members was created with enough capacity to
@@ -516,7 +523,7 @@ func addMemberStatuses(
 				PVC:             pvcName,
 				NodeID:          atomic.AddInt64(lastNodeID, 1),
 				State:           string(memberCreatePending),
-				BlockDevicePath: blockDevPath,
+				BlockDevicePath: blockDevPaths,
 			},
 		)
 		role.membersByState[memberCreatePending] = append(

--- a/pkg/controller/kubedirectorcluster/roles.go
+++ b/pkg/controller/kubedirectorcluster/roles.go
@@ -517,12 +517,12 @@ func addMemberStatuses(
 		role.roleStatus.Members = append(
 			role.roleStatus.Members,
 			kdv1.MemberStatus{
-				Pod:             memberName,
-				Service:         "",
-				PVC:             pvcName,
-				NodeID:          atomic.AddInt64(lastNodeID, 1),
-				State:           string(memberCreatePending),
-				BlockDevicePath: blockDevPaths,
+				Pod:              memberName,
+				Service:          "",
+				PVC:              pvcName,
+				NodeID:           atomic.AddInt64(lastNodeID, 1),
+				State:            string(memberCreatePending),
+				BlockDevicePaths: blockDevPaths,
 			},
 		)
 		role.membersByState[memberCreatePending] = append(

--- a/pkg/controller/kubedirectorcluster/roles.go
+++ b/pkg/controller/kubedirectorcluster/roles.go
@@ -497,17 +497,26 @@ func addMemberStatuses(
 		} else {
 			pvcName = executor.PvcNamePrefix + "-" + memberName
 		}
+		// check if there is block device to be mounted in the member.
+		// assign path value if there is else it'd be an empty string
+		blockDevPath := ""
+
+		if role.roleSpec.BlockStorage != nil {
+			blockDevPath = *role.roleSpec.BlockStorage.Path
+		}
+
 		// role.roleStatus.Members was created with enough capacity to
 		// avoid realloc, so we can safely grow it w/o disturbing our
 		// pointers to its elements.
 		role.roleStatus.Members = append(
 			role.roleStatus.Members,
 			kdv1.MemberStatus{
-				Pod:     memberName,
-				Service: "",
-				PVC:     pvcName,
-				NodeID:  atomic.AddInt64(lastNodeID, 1),
-				State:   string(memberCreatePending),
+				Pod:             memberName,
+				Service:         "",
+				PVC:             pvcName,
+				NodeID:          atomic.AddInt64(lastNodeID, 1),
+				State:           string(memberCreatePending),
+				BlockDevicePath: blockDevPath,
 			},
 		)
 		role.membersByState[memberCreatePending] = append(

--- a/pkg/executor/statefulset.go
+++ b/pkg/executor/statefulset.go
@@ -270,9 +270,8 @@ func getStatefulset(
 	if role.BlockStorage != nil {
 
 		numDevices := *role.BlockStorage.NumDevices
-		var i int32
 
-		for i = 0; i < numDevices; i++ {
+		for i := int32(0); i < numDevices; i++ {
 
 			deviceID := strconv.FormatInt(int64(i), 10)
 			devicePath := *role.BlockStorage.Path + deviceID
@@ -489,9 +488,8 @@ func getVolumeClaimTemplate(
 		}
 
 		numDevices := *role.BlockStorage.NumDevices
-		var i int32
 
-		for i = 0; i < numDevices; i++ {
+		for i := int32(0); i < numDevices; i++ {
 
 			deviceID := strconv.FormatInt(int64(i), 10)
 			deviceName := blockPvcNamePrefix + deviceID

--- a/pkg/executor/statefulset.go
+++ b/pkg/executor/statefulset.go
@@ -264,6 +264,16 @@ func getStatefulset(
 		return nil, volumesErr
 	}
 
+	// check if BlockStorage field is present. If it is, create a volumeDevices field
+	var volumeDevices []v1.VolumeDevice
+	if role.BlockStorage != nil {
+		volumeDevice := v1.VolumeDevice{
+			Name:       blockPvcNamePrefix,
+			DevicePath: *role.BlockStorage.Path,
+		}
+		volumeDevices = append(volumeDevices, volumeDevice)
+
+	}
 	imageID, imageErr := catalog.ImageForRole(cr, role.Name)
 	if imageErr != nil {
 		return nil, imageErr
@@ -282,6 +292,8 @@ func getStatefulset(
 	} else if namingScheme == v1beta1.UID {
 		objectName = statefulSetNamePrefix
 	}
+
+	vct := getVolumeClaimTemplate(cr, role, PvcNamePrefix)
 
 	return &appsv1.StatefulSet{
 		TypeMeta: metav1.TypeMeta{
@@ -324,6 +336,7 @@ func getStatefulset(
 							Lifecycle:       &v1.Lifecycle{PostStart: &startupScript},
 							Ports:           endpointPorts,
 							VolumeMounts:    volumeMounts,
+							VolumeDevices:   volumeDevices,
 							SecurityContext: securityContext,
 							Env:             chkModifyEnvVars(role),
 						},
@@ -331,7 +344,7 @@ func getStatefulset(
 					Volumes: volumes,
 				},
 			},
-			VolumeClaimTemplates: getVolumeClaimTemplate(cr, role, PvcNamePrefix),
+			VolumeClaimTemplates: vct,
 		},
 	}, nil
 }
@@ -417,22 +430,20 @@ func getInitContainer(
 	return
 }
 
-// getVolumeClaimTemplate prepares the PVC template to be used with the
+// getVolumeClaimTemplate prepares the PVC templates to be used with the
 // given role (for acquiring shared persistent storage). The result will be
-// empty if the role does not use shared persistent storage.
+// empty if the role does not use shared persistent storage. If the spec contains
+// Storage field, a volume Volume Claim with Filesystem volume mode is created. If spec contains a BlockStorage field,
+// BlockStorage field, a block Claim with Block volume mode is created.
 func getVolumeClaimTemplate(
 	cr *kdv1.KubeDirectorCluster,
 	role *kdv1.Role,
 	pvcNamePrefix string,
 ) (volTemplate []v1.PersistentVolumeClaim) {
 
-	if role.Storage == nil {
-		return
-	}
-
-	volSize, _ := resource.ParseQuantity(role.Storage.Size)
-	volTemplate = []v1.PersistentVolumeClaim{
-		v1.PersistentVolumeClaim{
+	if role.Storage != nil {
+		volSize, _ := resource.ParseQuantity(role.Storage.Size)
+		volClaim := v1.PersistentVolumeClaim{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: pvcNamePrefix,
 				Annotations: map[string]string{
@@ -450,9 +461,46 @@ func getVolumeClaimTemplate(
 					},
 				},
 			},
-		},
+		}
+		volTemplate = append(volTemplate, volClaim)
 	}
-	return
+
+	if role.BlockStorage != nil {
+
+		block := v1.PersistentVolumeBlock
+
+		blockVolSize, _ := resource.ParseQuantity(defaultBlockDeviceSize)
+
+		if role.BlockStorage.Size != nil {
+			blockVolSize, _ = resource.ParseQuantity(*role.BlockStorage.Size)
+		}
+
+		blockClaim := v1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: blockPvcNamePrefix,
+				Annotations: map[string]string{
+					storageClassName: *role.BlockStorage.StorageClass,
+				},
+				OwnerReferences: ownerReferences(cr),
+			},
+			Spec: v1.PersistentVolumeClaimSpec{
+				AccessModes: []v1.PersistentVolumeAccessMode{
+					v1.ReadWriteOnce,
+				},
+				Resources: v1.ResourceRequirements{
+					Requests: v1.ResourceList{
+						v1.ResourceStorage: blockVolSize,
+					},
+				},
+				StorageClassName: role.BlockStorage.StorageClass,
+
+				VolumeMode: &block,
+			},
+		}
+
+		volTemplate = append(volTemplate, blockClaim)
+	}
+	return volTemplate
 }
 
 // getStartupScript composes the startup script used for each app container.

--- a/pkg/executor/types.go
+++ b/pkg/executor/types.go
@@ -70,6 +70,11 @@ const (
 	// nvidiaGpuVisWorkaroundEnvVarValue is the value to be set for the environment variable
 	// named nvidiaGpuVisWorkaroundEnvVarName, in the above work-around
 	nvidiaGpuVisWorkaroundEnvVarValue = "VOID"
+	// defaultBlockDeviceSize is the size for a block volume if it is not specified in the spec
+	defaultBlockDeviceSize = "1Gi"
+	// blockPvcNamePrefix is the prefix name for the volume device that is auto-created by the statefulset.
+	// This is assigned in accordance with the PvcPrefix
+	blockPvcNamePrefix = "b"
 )
 
 // Streams for stdin, stdout, stderr of executed commands


### PR DESCRIPTION
### Summary
- Implementation for issue #444
- Support to mount block devices.
- If such block device(s) is/are mounted, add the mount path(s) in appconfig JSON

- Fix #442  

### What's new?

The Cluster Spec is updated to have `BlockStorage` field which takes `prefixPath`, `numDevices`, and `storageClassName` for mounting block(s) to the role's statefulset. `size` is an optional parameter and a default size of `1Gi` is set if it is not specified. 

`storageClassName` will be used to bind an appropriate PV. The `PV` and `StorageClass` need to be created before launching a KDApp with block devices. 

~~Currently, the code supports one deviceVolume which is commensurate with volume mount support.~~ The code now supports mounting multiple blocks. `numDevices` reads the number of blocks required, and `prefixPath` reads the template to the path where the device is to be mounted. 

After the block device(s) are added, the mount path is registered in appconfig JSON (configmeta.json) 
The path is registered as `block_device_path` sub-field in the `node` parent field.

### Example

#### Sample `centos` App with block device and volume mount:

```yaml
apiVersion: "kubedirector.hpe.com/v1beta1"
kind: "KubeDirectorCluster"
metadata: 
  name: "centos7x-instance"
  namespace: "pvc-test-4"
spec: 
  app: "centos7x"
  appCatalog: "local"
  roles: 
    - 
      id: "vanilla_centos"
      members: 1
      resources: 
        requests: 
          memory: "4Gi"
          cpu: "2"
        limits: 
          memory: "4Gi"
          cpu: "2"
      storage: 
        size: "1Gi"
      blockStorage:
        pathPrefix: "/dev/xdb"
        storageClassName: "kd-block-storage"
        numDevices: 2
``` 

Corresponding `node` field in the App's `configmeta.json`:

```json
...
...
"node": {
        "role_id": "vanilla_centos",
        "nodegroup_id": "1",
        "id": "1",
        "hostname": "kdss-tl5zz-0.kdhs-4dnfp.seldon-t.svc.cluster.local",
        "fqdn": "kdss-tl5zz-0.kdhs-4dnfp.seldon-t.svc.cluster.local",
        "domain": "kdhs-4dnfp.seldon-t.svc.cluster.local",
        "distro_id": "hpecp/centos7",
        "depends_on": {}
        "block_device_path": ["/dev/xdb0", "/dev/xdb1"] 
    },
...
...
``` 

Sample `PersistentVolume` which uses `/dev/sdb` path on the specified host as a block when bound to a statefulset can be like the following. Note that if `n` blocks are to be mounted for a member, there should at least `n` PVs on one of the cluster nodes:
```yaml

apiVersion: v1
kind: PersistentVolume
metadata:
  name: cldb1
spec:
  accessModes:
  - ReadWriteOnce
  capacity:
    storage: 1Gi
  local:
    path: /dev/sdb
  nodeAffinity:
    required:
      nodeSelectorTerms:
      - matchExpressions:
        - key: kubernetes.io/hostname
          operator: In
          values:
          - my-host.net
  persistentVolumeReclaimPolicy: Retain
  storageClassName: kd-block-storage
  volumeMode: Block
```

Sample `StorageClass`:

```yaml
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: kd-block-storage
provisioner: kubernetes.io/no-provisioner
volumeBindingMode: Immediate
reclaimPolicy: Delete
```

*Note* the `volumeBindingMode` and `reclaimPolicy` values are for illustration. One may or may not need to alter them for the Volumes to bind.