### PR TITLE
Added Datafabric610 to kubedirector

### DIFF
--- a/deploy/example_catalog/cr-app-datafabric610.json
+++ b/deploy/example_catalog/cr-app-datafabric610.json
@@ -1,0 +1,232 @@
+{
+  "apiVersion": "kubedirector.hpe.com/v1beta1",
+  "kind": "KubeDirectorApp",
+  "metadata": {
+    "name": "datafabric610"
+  },
+  "spec": {
+    "systemdRequired": true,
+    "defaultPersistDirs": [
+      "/opt/mapr"
+    ],
+    "config": {
+      "configMeta": {
+        "storage": "60",
+        "secure": "true"
+      },
+      "roleServices": [
+        {
+          "roleID": "control-system",
+          "serviceIDs": [
+            "warden",
+	    "zookeeper",
+            "yarn-hs",
+            "mapr-cs"
+          ]
+        },
+        {
+          "roleID": "cldb",
+          "serviceIDs": [
+            "warden",
+	    "zookeeper",
+            "cldb"
+          ]
+        },
+        {
+        "roleID": "oozie",
+        "serviceIDs": ["warden", "oozie", "mysql"]
+      },
+        {
+          "roleID": "edge",
+          "serviceIDs": [
+            "mapr-client",
+            "ssh"
+          ]
+        },
+        {
+          "roleID": "nodemanager",
+          "serviceIDs": [
+            "warden",
+            "yarn-nm"
+          ]
+        },
+        {
+          "roleID": "resource-manager",
+          "serviceIDs": [
+            "warden",
+	    "zookeeper",
+            "yarn-rm"
+          ]
+        }
+      ],
+      "selectedRoles": [
+        "control-system",
+        "resource-manager",
+        "cldb",
+        "oozie",
+        "edge",
+        "nodemanager"
+      ]
+    },
+    "label": {
+      "name": "Ezmeral Datafabric 610",
+      "description": "Ezmeral Datafabric 610 with YARN and Oozie"
+    },
+    "distroID": "ezmeral/datafabric610",
+    "version": "1.0",
+    "configSchemaVersion": 7,
+    "services": [
+      {
+        "id": "mapr-cs",
+        "label": {
+          "name": "MapR Control System"
+        },
+        "endpoint": {
+          "urlScheme": "https",
+          "path": "/app/mcs",
+          "port": 8443,
+          "isDashboard": true
+        }
+      },
+      {
+        "id": "yarn-rm",
+        "label": {
+          "name": "ResourceManager"
+        },
+        "endpoint": {
+          "urlScheme": "https",
+          "path": "/cluster",
+          "port": 8090,
+          "isDashboard": true
+        }
+      },
+      {
+        "id": "yarn-nm",
+        "label": {
+          "name": "NodeManager"
+        },
+        "endpoint": {
+          "urlScheme": "https",
+          "path": "/node",
+          "port": 8044,
+          "isDashboard": true
+        }
+      },
+      {
+        "id": "yarn-hs",
+        "label": {
+          "name": "YARN HistoryServer"
+        },
+        "endpoint": {
+          "urlScheme": "https",
+          "path": "/jobhistory",
+          "port": 19890,
+          "isDashboard": true
+        }
+      },
+      {
+        "id": "cldb",
+        "label": {
+          "name": "CLDB Web Port"
+        },
+        "endpoint": {
+          "port": 7443,
+          "isDashboard": false
+        }
+      },
+      {
+        "id": "mapr-client",
+        "label": {
+          "name": "MapR Client."
+        }
+      },
+      {
+        "id": "zookeeper",
+        "label": {
+          "name": "Zookeeper Server"
+        },
+        "endpoint": {
+          "port": 5181,
+          "isDashboard": false
+        }
+      },
+      {
+      "id": "oozie",
+      "label": {
+        "name": "OOZIE"
+      },
+      "endpoint": {
+        "urlScheme": "https",
+        "path": "/oozie",
+        "port": 11443,
+        "isDashboard": true
+      }
+    },
+      {
+        "id": "mysql",
+        "label": {
+          "name": "MySQL"
+        }
+      },
+      {
+        "id": "warden",
+        "label": {
+          "name": "Warden"
+        }
+      },
+      {
+        "id": "fileserver",
+        "label": {
+          "name": "FileServer"
+        }
+      },
+      {
+        "id": "ssh",
+        "label": {
+          "name": "ssh"
+        },
+        "endpoint": {
+          "port": 22,
+          "isDashboard": false
+        }
+      },
+      {
+        "id": "ticketserver",
+        "label": {
+          "name": "Simple Http server to distribute MapR tickets"
+        }
+      }
+    ],
+    "defaultImageRepoTag": "bluedata/datafabric610:1.0",
+    "defaultConfigPackage": {
+      "packageURL": "file:///opt/configscripts/appconfig-1.0.tgz"
+    },
+    "roles": [
+      {
+        "id": "control-system",
+        "cardinality": "1"
+      },
+      {
+        "id": "cldb",
+        "cardinality": "1"
+      },
+      {
+        "id": "oozie",
+        "cardinality": "0+"
+      },
+      {
+        "id": "edge",
+        "imageRepoTag": "bluedata/datafabric610edge:1.0",
+        "cardinality": "0+"
+      },
+      {
+        "id": "nodemanager",
+        "cardinality": "1+"
+      },
+      {
+        "id": "resource-manager",
+        "cardinality": "1+"
+      }
+    ]
+  }
+}

--- a/deploy/example_catalog/cr-app-datafabric610.json
+++ b/deploy/example_catalog/cr-app-datafabric610.json
@@ -19,7 +19,7 @@
           "roleID": "control-system",
           "serviceIDs": [
             "warden",
-	    "zookeeper",
+            "zookeeper",
             "yarn-hs",
             "mapr-cs"
           ]
@@ -28,14 +28,18 @@
           "roleID": "cldb",
           "serviceIDs": [
             "warden",
-	    "zookeeper",
+            "zookeeper",
             "cldb"
           ]
         },
         {
-        "roleID": "oozie",
-        "serviceIDs": ["warden", "oozie", "mysql"]
-      },
+          "roleID": "oozie",
+          "serviceIDs": [
+            "warden",
+            "oozie",
+            "mysql"
+          ]
+        },
         {
           "roleID": "edge",
           "serviceIDs": [
@@ -54,7 +58,7 @@
           "roleID": "resource-manager",
           "serviceIDs": [
             "warden",
-	    "zookeeper",
+            "zookeeper",
             "yarn-rm"
           ]
         }
@@ -151,17 +155,17 @@
         }
       },
       {
-      "id": "oozie",
-      "label": {
-        "name": "OOZIE"
+        "id": "oozie",
+        "label": {
+          "name": "OOZIE"
+        },
+        "endpoint": {
+          "urlScheme": "https",
+          "path": "/oozie",
+          "port": 11443,
+          "isDashboard": true
+        }
       },
-      "endpoint": {
-        "urlScheme": "https",
-        "path": "/oozie",
-        "port": 11443,
-        "isDashboard": true
-      }
-    },
       {
         "id": "mysql",
         "label": {

--- a/deploy/example_catalog/cr-app-datafabric610.json
+++ b/deploy/example_catalog/cr-app-datafabric610.json
@@ -2,7 +2,7 @@
   "apiVersion": "kubedirector.hpe.com/v1beta1",
   "kind": "KubeDirectorApp",
   "metadata": {
-    "name": "datafabric610"
+    "name": "dfcompute610"
   },
   "spec": {
     "systemdRequired": true,
@@ -73,17 +73,17 @@
       ]
     },
     "label": {
-      "name": "Ezmeral Datafabric 610",
-      "description": "Ezmeral Datafabric 610 with YARN and Oozie"
+      "name": "Ezmeral Datafabric Compute 610",
+      "description": "Ezmeral Datafabric Compute 610 with YARN and Oozie"
     },
-    "distroID": "ezmeral/datafabric610",
+    "distroID": "ezmeral/dfcompute610",
     "version": "1.0",
     "configSchemaVersion": 7,
     "services": [
       {
         "id": "mapr-cs",
         "label": {
-          "name": "Datafabric Control System"
+          "name": "Datafabric Compute Control System"
         },
         "endpoint": {
           "urlScheme": "https",
@@ -141,7 +141,7 @@
       {
         "id": "mapr-client",
         "label": {
-          "name": "Datafabric Client."
+          "name": "Datafabric Compute Client."
         }
       },
       {
@@ -197,7 +197,7 @@
       {
         "id": "ticketserver",
         "label": {
-          "name": "Simple Http server to distribute Datafabric tickets"
+          "name": "Simple Http server to distribute Datafabric Compute tickets"
         }
       }
     ],

--- a/deploy/example_catalog/cr-app-datafabric610.json
+++ b/deploy/example_catalog/cr-app-datafabric610.json
@@ -79,7 +79,7 @@
       {
         "id": "mapr-cs",
         "label": {
-          "name": "MapR Control System"
+          "name": "Datafabric Control System"
         },
         "endpoint": {
           "urlScheme": "https",
@@ -137,7 +137,7 @@
       {
         "id": "mapr-client",
         "label": {
-          "name": "MapR Client."
+          "name": "Datafabric Client."
         }
       },
       {
@@ -193,7 +193,7 @@
       {
         "id": "ticketserver",
         "label": {
-          "name": "Simple Http server to distribute MapR tickets"
+          "name": "Simple Http server to distribute Datafabric tickets"
         }
       }
     ],

--- a/deploy/example_catalog/docs/datafabric610-readme.md
+++ b/deploy/example_catalog/docs/datafabric610-readme.md
@@ -1,9 +1,9 @@
 ## Overview
-The app is built with MapR 6.1 MEP 6.3 components.
+The app is built with Datafabric 6.1 MEP 6.3 components.
 
-## What is MapR?
-MapR is a complete enterprise-grade distribution for Apache Hadoop. The MapR Converged Data Platform has been engineered to improve Hadoop’s reliability, performance, and ease of use. 
-The MapR distribution provides a full Hadoop stack that includes the MapR File System (MapR-FS), the MapR-DB NoSQL database management system, MapR Streams, the MapR Control System (MCS) user interface, and a full family of Hadoop ecosystem projects. You can use MapR with Apache Hadoop, HDFS, and MapReduce APIs.
+## What is Datafabric?
+Datafabric is a complete enterprise-grade distribution for Apache Hadoop. The Datafabric Converged Data Platform has been engineered to improve Hadoop’s reliability, performance, and ease of use. 
+The Datafabric distribution provides a full Hadoop stack that includes the Datafabric File System (MapR-FS), the Datafabric-DB (MapR-DB) NoSQL database management system, Datafabric Streams, the Datafabric Control System (MCS) user interface, and a full family of Hadoop ecosystem projects. You can use Datafabric with Apache Hadoop, HDFS, and MapReduce APIs.
 
 # Details: 
 
@@ -17,41 +17,41 @@ The MapR distribution provides a full Hadoop stack that includes the MapR File S
     =================================
     Apache Hadoop       2.7.0
     Apache ZooKeeper    3.4.5
-    MapR Core           6.1
+    Datafabric Core     6.1
     Apache Oozie        5.1
 
 #### Default login credential
-    MapR admin user: mapr
+    Datafabric admin user: mapr
     No password is set for this user by default.
     Note: any local user created by app will not have password set
     Note: User can pass the AD/LDAP user details by following the procedure to enable AD/LDAP on Kubedirector
 
 # Details on the Kubedirector App and its features/facilities
-MapR kubedirector app enables user to submit YARN jobs. By default following roles are defined in the app
+Datafabric kubedirector app enables user to submit YARN jobs. By default following roles are defined in the app
 
      Roles	                Services running roles
     ==============================================================================
-     control-system         On this pod/role MapR Control System, Zookeeper and 
-                            YARN History Server are running. MapR Control System is
-                            facility to manage MapR Ecosystem. It has a Web UI which
+     control-system         On this pod/role Datafabric Control System, Zookeeper and 
+                            YARN History Server are running. Datafabric Control System is
+                            facility to manage Datafabric Ecosystem. It has a Web UI which
                             can be launched from "Service Endpoints" tab under
                             kubedirector's tenant -> Applications. Only one instance
                             of control-system is supported. To launch YARN History
-                            server UI, follow procedure similar to launching MapR
+                            server UI, follow procedure similar to launching Datafabric
                             Control System as mentioned earlier.
-     cldb                   On this pod/role MapR CLDB, Zookeeper and MapR Fileserver
-                            services are running. This pod serves the mapr tickets for
-                            secure cluster. In secured cluster mapr tickets are necessary
+     cldb                   On this pod/role Datafabric CLDB, Zookeeper and Datafabric 
+                            Fileserverservices are running. This pod serves the tickets for
+                            secure cluster. In secured cluster tickets are necessary
                             to submit jobs. Only one instance of cldb is supported
-     resource-manager       YARN Resource-Manager customized for MapR Eco system runs
+     resource-manager       YARN Resource-Manager customized for Datafabric Eco system runs
                             on this pod/role along with Zookeeper. When more than one member 
                             is chosen for this role then resource-manager will be 
                             configured as HA. If more than one resource-manager is chosen
                             then Zookeeper will run only on the 1st pod.
-     nodemanager            YARN Nodemanager service customized for MapR Eco system runs
-                            on this pod/role along with MapR Fileserver. More than one 
+     nodemanager            YARN Nodemanager service customized for Datafabric Eco system runs
+                            on this pod/role along with Datafabric Fileserver. More than one 
                             nodemanager can be created based on the need.
-     oozie                  Apache Oozie service customized for MapR Eco system runs on
+     oozie                  Apache Oozie service customized for Datafabric Eco system runs on
                             this pod/role. Currently only one pod of oozie is supported.
      edge                   It provides ssh service and hive client services. So users
                             can connect this pod through ssh. More than one edge role
@@ -62,13 +62,13 @@ MapR kubedirector app enables user to submit YARN jobs. By default following rol
 #### Finding information to connect to pod
 We can login pods of different roles through "kubectl exec" to respective pods. For "edge" role we can also do ssh. To do "kubectl exec" we need to know the pod name or to ssh we need to know the url and port this can be found under "Service Endpoints" tab of Kubedirector tenant applications.
 
-#### Procedure to generate mapr ticket on secure cluster
-To run jobs on secured MapR cluster, mapr ticket is mandatory. Switch to MapR admin user user using "su". Now to generate the mapr ticket run "maprlogin password" and provide MapR admin user's password when prompted. This will generate mapr ticket. If the user is local user and not AD/LDAP user 
+#### Procedure to generate ticket on secure cluster
+To run jobs on secured Datafabric cluster, ticket is mandatory. Switch to Datafabric admin user user using "su". Now to generate the ticket run "maprlogin password" and provide Datafabric admin user's password when prompted. This will generate ticket. If the user is local user and not AD/LDAP user 
 then set the passwd for the local user first and then generate the ticket.
 
 
 #### Running sample YARN job
-To run sample YARN job, login to "edge" role either through "ssh" or through "kubectl exec". Generate MapR ticket as explained earlier for the user. Once ticket is generate run the below instruction to trigger TestDFSIO YARN job
+To run sample YARN job, login to "edge" role either through "ssh" or through "kubectl exec". Generate ticket as explained earlier for the user. Once ticket is generate run the below instruction to trigger TestDFSIO YARN job
 
 `hadoop jar /opt/mapr/hadoop/hadoop-2.7.0/share/hadoop/mapreduce/hadoop-mapreduce-client-jobclient-2.7.0-mapr-1808-tests.jar TestDFSIO -write -nrFiles 2 -size 10`
 

--- a/deploy/example_catalog/docs/datafabric610-readme.md
+++ b/deploy/example_catalog/docs/datafabric610-readme.md
@@ -1,0 +1,82 @@
+## Overview
+The app is built with MapR 6.1 MEP 6.3 components.
+
+## What is MapR?
+MapR is a complete enterprise-grade distribution for Apache Hadoop. The MapR Converged Data Platform has been engineered to improve Hadoop’s reliability, performance, and ease of use. 
+The MapR distribution provides a full Hadoop stack that includes the MapR File System (MapR-FS), the MapR-DB NoSQL database management system, MapR Streams, the MapR Control System (MCS) user interface, and a full family of Hadoop ecosystem projects. You can use MapR with Apache Hadoop, HDFS, and MapReduce APIs.
+
+# Details: 
+
+### Application Image Details:
+
+#### Version:
+1.0
+
+#### Software Included
+    Component	       Component Version
+    =================================
+    Apache Hadoop       2.7.0
+    Apache ZooKeeper    3.4.5
+    MapR Core           6.1
+    Apache Oozie        5.1
+
+#### Default login credential
+    MapR admin user: mapr
+    No password is set for this user by default.
+    Note: any local user created by app will not have password set
+    Note: User can pass the AD/LDAP user details by following the procedure to enable AD/LDAP on Kubedirector
+
+# Details on the Kubedirector App and its features/facilities
+MapR kubedirector app enables user to submit YARN jobs. By default following roles are defined in the app
+
+     Roles	                Services running roles
+    ==============================================================================
+     control-system         On this pod/role MapR Control System, Zookeeper and 
+                            YARN History Server are running. MapR Control System is
+                            facility to manage MapR Ecosystem. It has a Web UI which
+                            can be launched from "Service Endpoints" tab under
+                            kubedirector's tenant -> Applications. Only one instance
+                            of control-system is supported. To launch YARN History
+                            server UI, follow procedure similar to launching MapR
+                            Control System as mentioned earlier.
+     cldb                   On this pod/role MapR CLDB, Zookeeper and MapR Fileserver
+                            services are running. This pod serves the mapr tickets for
+                            secure cluster. In secured cluster mapr tickets are necessary
+                            to submit jobs. Only one instance of cldb is supported
+     resource-manager       YARN Resource-Manager customized for MapR Eco system runs
+                            on this pod/role along with Zookeeper. When more than one member 
+                            is chosen for this role then resource-manager will be 
+                            configured as HA. If more than one resource-manager is chosen
+                            then Zookeeper will run only on the 1st pod.
+     nodemanager            YARN Nodemanager service customized for MapR Eco system runs
+                            on this pod/role along with MapR Fileserver. More than one 
+                            nodemanager can be created based on the need.
+     oozie                  Apache Oozie service customized for MapR Eco system runs on
+                            this pod/role. Currently only one pod of oozie is supported.
+     edge                   It provides ssh service and hive client services. So users
+                            can connect this pod through ssh. More than one edge role
+                            is allowed
+
+# Sample Tests
+
+#### Finding information to connect to pod
+We can login pods of different roles through "kubectl exec" to respective pods. For "edge" role we can also do ssh. To do "kubectl exec" we need to know the pod name or to ssh we need to know the url and port this can be found under "Service Endpoints" tab of Kubedirector tenant applications.
+
+#### Procedure to generate mapr ticket on secure cluster
+To run jobs on secured MapR cluster, mapr ticket is mandatory. Switch to MapR admin user user using "su". Now to generate the mapr ticket run "maprlogin password" and provide MapR admin user's password when prompted. This will generate mapr ticket. If the user is local user and not AD/LDAP user 
+then set the passwd for the local user first and then generate the ticket.
+
+
+#### Running sample YARN job
+To run sample YARN job, login to "edge" role either through "ssh" or through "kubectl exec". Generate MapR ticket as explained earlier for the user. Once ticket is generate run the below instruction to trigger TestDFSIO YARN job
+
+`hadoop jar /opt/mapr/hadoop/hadoop-2.7.0/share/hadoop/mapreduce/hadoop-mapreduce-client-jobclient-2.7.0-mapr-1808-tests.jar TestDFSIO -write -nrFiles 2 -size 10`
+
+In the above code i am running TestDFSIO write test. I am creating 2 file of size 10.
+       
+#### Docker image location
+
+There are 2 images used in the app and the following are the location of images.
+
+docker.io/bluedata/datafabric610:1.0
+docker.io/bluedata/datafabric610edge:1.0

--- a/deploy/example_catalog/docs/dfcompute610-readme.md
+++ b/deploy/example_catalog/docs/dfcompute610-readme.md
@@ -1,9 +1,9 @@
 ## Overview
-The app is built with Datafabric 6.1 MEP 6.3 components.
+The app is built with Datafabric Compute 6.1 MEP 6.3 components.
 
-## What is Datafabric?
-Datafabric is a complete enterprise-grade distribution for Apache Hadoop. The Datafabric Converged Data Platform has been engineered to improve Hadoop’s reliability, performance, and ease of use. 
-The Datafabric distribution provides a full Hadoop stack that includes the Datafabric File System (MapR-FS), the Datafabric-DB (MapR-DB) NoSQL database management system, Datafabric Streams, the Datafabric Control System (MCS) user interface, and a full family of Hadoop ecosystem projects. You can use Datafabric with Apache Hadoop, HDFS, and MapReduce APIs.
+## What is Datafabric Compute?
+Datafabric Compute is a complete enterprise-grade distribution for Apache Hadoop. The Datafabric Compute Converged Data Platform has been engineered to improve Hadoop’s reliability, performance, and ease of use. 
+The Datafabric Compute distribution provides a full Hadoop stack that includes the Datafabric File System (MapR-FS), the Datafabric-DB (MapR-DB) NoSQL database management system, Datafabric Compute Streams, the Datafabric Compute Control System (MCS) user interface, and a full family of Hadoop ecosystem projects. You can use Datafabric Compute with Apache Hadoop, HDFS, and MapReduce APIs.
 
 # Details: 
 
@@ -21,41 +21,40 @@ The Datafabric distribution provides a full Hadoop stack that includes the Dataf
     Apache Oozie        5.1
 
 #### Default login credential
-    Datafabric admin user: mapr
+    Datafabric Compute admin user: mapr
     No password is set for this user by default.
     Note: any local user created by app will not have password set
     Note: User can pass the AD/LDAP user details by following the procedure to enable AD/LDAP on Kubedirector
 
 # Details on the Kubedirector App and its features/facilities
-Datafabric kubedirector app enables user to submit YARN jobs. By default following roles are defined in the app
+Datafabric Compute kubedirector app enables user to submit YARN jobs. By default following roles are defined in the app
 
      Roles	                Services running roles
     ==============================================================================
-     control-system         On this pod/role Datafabric Control System, Zookeeper and 
-                            YARN History Server are running. Datafabric Control System is
-                            facility to manage Datafabric Ecosystem. It has a Web UI which
+     control-system         On this pod/role Datafabric Compute Control System, Zookeeper and 
+                            YARN History Server are running. Datafabric Compute Control System is
+                            facility to manage Datafabric Compute Ecosystem. It has a Web UI which
                             can be launched from "Service Endpoints" tab under
                             kubedirector's tenant -> Applications. Only one instance
                             of control-system is supported. To launch YARN History
-                            server UI, follow procedure similar to launching Datafabric
+                            server UI, follow procedure similar to launching Datafabric Compute 
                             Control System as mentioned earlier.
      cldb                   On this pod/role Datafabric CLDB, Zookeeper and Datafabric 
-                            Fileserverservices are running. This pod serves the tickets for
+                            Fileserver services are running. This pod serves the tickets for
                             secure cluster. In secured cluster tickets are necessary
                             to submit jobs. Only one instance of cldb is supported
-     resource-manager       YARN Resource-Manager customized for Datafabric Eco system runs
+     resource-manager       YARN Resource-Manager customized for Datafabric Compute Eco system runs
                             on this pod/role along with Zookeeper. When more than one member 
                             is chosen for this role then resource-manager will be 
                             configured as HA. If more than one resource-manager is chosen
                             then Zookeeper will run only on the 1st pod.
-     nodemanager            YARN Nodemanager service customized for Datafabric Eco system runs
-                            on this pod/role along with Datafabric Fileserver. More than one 
+     nodemanager            YARN Nodemanager service customized for Datafabric Compute Eco system 
+                            runs on this pod/role along with Datafabric Fileserver. More than one 
                             nodemanager can be created based on the need.
-     oozie                  Apache Oozie service customized for Datafabric Eco system runs on
-                            this pod/role. Currently only one pod of oozie is supported.
-     edge                   It provides ssh service and hive client services. So users
-                            can connect this pod through ssh. More than one edge role
-                            is allowed
+     oozie                  Apache Oozie service customized for Datafabric ComputeEco system runs
+                            on this pod/role. Currently only one pod of oozie is supported. It
+     edge                   provides ssh service and hive client services. So users can connect
+                            this pod through ssh. More than one edge role is allowed.
 
 # Sample Tests
 
@@ -63,7 +62,7 @@ Datafabric kubedirector app enables user to submit YARN jobs. By default followi
 We can login pods of different roles through "kubectl exec" to respective pods. For "edge" role we can also do ssh. To do "kubectl exec" we need to know the pod name or to ssh we need to know the url and port this can be found under "Service Endpoints" tab of Kubedirector tenant applications.
 
 #### Procedure to generate ticket on secure cluster
-To run jobs on secured Datafabric cluster, ticket is mandatory. Switch to Datafabric admin user user using "su". Now to generate the ticket run "maprlogin password" and provide Datafabric admin user's password when prompted. This will generate ticket. If the user is local user and not AD/LDAP user 
+To run jobs on secured Datafabric Compute cluster, ticket is mandatory. Switch to Datafabric Compute admin user user using "su". Now to generate the ticket run "maprlogin password" and provide Datafabric Compute admin user's password when prompted. This will generate ticket. If the user is local user and not AD/LDAP user 
 then set the passwd for the local user first and then generate the ticket.
 
 

--- a/deploy/example_clusters/cr-cluster-datafabric610.yaml
+++ b/deploy/example_clusters/cr-cluster-datafabric610.yaml
@@ -1,0 +1,153 @@
+# Admin user will have all the permissions for performing every activity on the cluster and hence is an important user of the cluster
+# if admin user details is not provided through details then a default user "mapr" is created without password".
+# This admin user can be AD/LDAP user else a local user of same name gets created.
+# The default user "mapr" or local user that gets created will not have any password set and so will not be able launch UI's with these username. To make UI
+# accessible for these users, password has to be set for these users by logging to each pod. If AD/LDAP user is used then AD/LDAP user's password can be used to
+# launch UI
+# Following Secret is a template for providing admin user details to pod
+#apiVersion: v1
+#kind: Secret
+#metadata:
+#  name: users-data
+#  labels:
+#    kubedirector.hpe.com/secretType : users-data
+#data:
+#  admin_user: <admin username in base64 encoding>
+---
+#------------------------------------------------------------------------------------------------------------------------------------
+# This is the main section of the kubedirector cluster. In this section we define different roles that should be created in the cluster
+# We also define the resources to be associated with each roles.
+# metadata and spec section of kubedirector are standard kubernetes section
+# under spec, kubedirector provides connections and roles section
+# connections section is used to pass the configmaps and secrets data to the pod
+# roles section defines the different roles that should be implemented in the app.
+# each roles section will have an id, members, resources and podLabels to define specification of the roles.
+# id should match with roles in app definition (JSON file),
+# members should match the cardinality in the JSON file,
+# resources has fields, requests and limits, requests is the default allocation of resources to the pod and limits says how much the resources can be stretched. Here the resources means memory and cpu
+# In the latest kubedirectory each roles has additional field, blockStorage, this is used for providing raw disks (volumeDevice) to the pods
+# Before using the blockStorage field, the respective storage class and PV's should be applied.
+apiVersion: "kubedirector.hpe.com/v1beta1"
+kind: "KubeDirectorCluster"
+metadata:
+  name: "datafabric610"
+spec:
+  app: datafabric610
+# connections:
+#   # attaching secrets data to the cluster
+#   secrets:
+#     - users-data
+  # Defining the roles to be implemented
+  # for this current app, the different roles which are defined in the JSON file supplied with the app are
+  # control-system, cldb, resource-manager, nodemanager and edge
+  # control-system hosts the MapR Control System,Zookeeper and YARN History Server, current cardinality/member count is fixed to 1
+  # cldb implements the CLDB, Zookeeper and fileserver facility of the MapR Eco System.
+  # resource-manager implements YARN resource-manager and Zookeeper more than 1 member creates a HA for it but Zookeeper will run only on first resource-manager
+  # nodemanager implements YARN nodemanager and it can be more than 1 member
+  # oozie node runs Oozie services.
+  # edge is a client service pod and can be 0 or more of it
+
+  # NOTE: The memory and cpu values are for reference only, higher than the given values is recommended
+  # CLDB and Nodemanager pods compulsorily requires disks either raw disk (block storage) or flat-file-storage. So if raw disks(block storage) are not provided then by default flat-file-storage will be used
+  roles:
+  - id: control-system
+    members: 1
+    resources:
+      requests:
+        memory: "4Gi"
+        cpu: "4"
+      limits:
+        memory: "4Gi"
+        cpu: "4"
+  - id: cldb
+    members: 1
+    resources:
+      requests:
+        memory: "4Gi"
+        cpu: "4"
+      limits:
+        memory: "4Gi"
+        cpu: "4"
+    # Following tags create a raw disk storage on the pod
+    # pathPrefix is the location of device file and name prefix and numDevices tells number of instances of these devices
+    # if only 1 device is mentioned, then we will find /dev/xdb0 in the pod, if more than 1 device was mentioned
+    # then name of the device on pod will be /dev/xdb1, /dev/xdb2 and so on. The name xdb is just a name given, it can be
+    # any name and that name will act as the prefix for the device file.
+    #blockStorage:
+    #  pathPrefix: "/dev/xdb"
+    #  storageClassName: "kd-block-storage"
+    #  numDevices: 1
+  - id: resource-manager
+    members: 1
+    resources:
+      requests:
+        memory: "4Gi"
+        cpu: "2"
+      limits:
+        memory: "4Gi"
+        cpu: "2"
+  - id: nodemanager
+    members: 1
+    resources:
+      requests:
+        memory: "8Gi"
+        cpu: "4"
+      limits:
+        memory: "16Gi"
+        cpu: "4"
+    # Following tags create a raw disk storage on the pod
+    #blockStorage:
+    #  pathPrefix: "/dev/xdb"
+    #  storageClassName: "kd-block-storage"
+    #  numDevices: 1
+  - id: edge
+    members: 0
+    resources:
+      requests:
+        memory: "4Gi"
+        cpu: "2"
+      limits:
+        memory: "4Gi"
+        cpu: "2"
+  - id: oozie
+      members: 1
+      resources:
+        requests:
+          memory: "4Gi"
+          cpu: "2"
+        limits:
+          memory: "4Gi"
+          cpu: "2"
+---
+# Following is a template for applying storage class
+#apiVersion: storage.k8s.io/v1
+#kind: StorageClass
+#metadata:
+#  name: kd-block-storage
+#provisioner: kubernetes.io/no-provisioner
+#volumeBindingMode: Immediate
+#reclaimPolicy: Delete
+---
+# Template for creating PV for block storage
+#apiVersion: v1
+#kind: PersistentVolume
+#metadata:
+#  name: cldb1
+#spec:
+#  accessModes:
+#  - <access modes supported by kubernetes>
+#  capacity:
+#    storage: <size of the raw disk>
+#  local:
+#    path: <raw disk path>
+#  nodeAffinity:
+#    required:
+#      nodeSelectorTerms:
+#      - matchExpressions:
+#        - key: kubernetes.io/hostname
+#          operator: In
+#          values:
+#          - <hostname of the node having the disk>
+#  persistentVolumeReclaimPolicy: <PVC policy supported by kubernetes>
+#  storageClassName: kd-block-storage
+#  volumeMode: Block

--- a/deploy/example_clusters/cr-cluster-datafabric610.yaml
+++ b/deploy/example_clusters/cr-cluster-datafabric610.yaml
@@ -40,8 +40,8 @@ spec:
   # Defining the roles to be implemented
   # for this current app, the different roles which are defined in the JSON file supplied with the app are
   # control-system, cldb, resource-manager, nodemanager and edge
-  # control-system hosts the MapR Control System,Zookeeper and YARN History Server, current cardinality/member count is fixed to 1
-  # cldb implements the CLDB, Zookeeper and fileserver facility of the MapR Eco System.
+  # control-system hosts the Datafabric Control System,Zookeeper and YARN History Server, current cardinality/member count is fixed to 1
+  # cldb implements the CLDB, Zookeeper and fileserver facility of the Datafabric Eco System.
   # resource-manager implements YARN resource-manager and Zookeeper more than 1 member creates a HA for it but Zookeeper will run only on first resource-manager
   # nodemanager implements YARN nodemanager and it can be more than 1 member
   # oozie node runs Oozie services.

--- a/deploy/example_clusters/cr-cluster-datafabric610.yaml
+++ b/deploy/example_clusters/cr-cluster-datafabric610.yaml
@@ -30,9 +30,9 @@
 apiVersion: "kubedirector.hpe.com/v1beta1"
 kind: "KubeDirectorCluster"
 metadata:
-  name: "datafabric610"
+  name: "dfcompute610"
 spec:
-  app: datafabric610
+  app: dfcompute610
 # connections:
 #   # attaching secrets data to the cluster
 #   secrets:
@@ -40,8 +40,8 @@ spec:
   # Defining the roles to be implemented
   # for this current app, the different roles which are defined in the JSON file supplied with the app are
   # control-system, cldb, resource-manager, nodemanager and edge
-  # control-system hosts the Datafabric Control System,Zookeeper and YARN History Server, current cardinality/member count is fixed to 1
-  # cldb implements the CLDB, Zookeeper and fileserver facility of the Datafabric Eco System.
+  # control-system hosts the Datafabric Compute Control System,Zookeeper and YARN History Server, current cardinality/member count is fixed to 1
+  # cldb implements the CLDB, Zookeeper and fileserver facility of the Datafabric Compute Eco System.
   # resource-manager implements YARN resource-manager and Zookeeper more than 1 member creates a HA for it but Zookeeper will run only on first resource-manager
   # nodemanager implements YARN nodemanager and it can be more than 1 member
   # oozie node runs Oozie services.


### PR DESCRIPTION
Datafabric 610 app creates a basic MapR Cluster with facility to run YARN jobs and also has support to Oozie. The minimal cluster will have 4 roles
- cldb: This runs MapR CLDB service, Zookeeper and MapR Fileserver services. 
- control-system: This runs MapR Control System, Zookeeper and YARN History Server
- resource-manager: This runs YARN Resource Manager and Zookeeper 
- nodemanager: This runs YARN Nodemanager and MapR Fileserver. 

There are 2 optional roles also available
- oozie: This runs oozie services
- edge: This is MapR Client to work as a client for Datafabric app.

The special feature in this version of the app is, facility to use the raw disks which is presented to the pod. CLDB and Nodemanager requires disk storage. The disk storage can be raw disk or flat-file based disk. The app will use raw disk on priority and if raw disk is not present then it goes for flat-file based storage.

