### PR TITLE
Bluek8s ConfluentKafka app name changed to ConfluentPlatform

### DIFF
--- a/deploy/example_catalog/cr-app-kafka55.json
+++ b/deploy/example_catalog/cr-app-kafka55.json
@@ -2,7 +2,7 @@
     "apiVersion": "kubedirector.hpe.com/v1beta1",
     "kind": "KubeDirectorApp",
     "metadata": {
-        "name" : "confluentkafka55"
+        "name" : "confluentplatform55"
     },
     "spec" : {
         "logoURL": "https://raw.githubusercontent.com/bluedatainc/solutions/master/MLOps/logos/confluentkafka55-logo.png",
@@ -86,10 +86,10 @@
     },
     "defaultImageRepoTag": "bluedata/kafka:1.0",
     "label": {
-        "name": "ConfluentKafka5.5",
-        "description": "Confluent Kafka Platform, with Control Center, KSQL, Kafka Broker, Zookeeper, Kafka Connect, REST Proxy, Schema Registry and optional Kafka Client"
+        "name": "ConfluentPlatform5.5",
+        "description": "Confluent Platform, with Control Center, Kafka KSQL, Kafka Broker, Zookeeper, Kafka Connect, REST Proxy, Schema Registry and optional Kafka Client"
     },
-    "distroID": "bluedata/confluentkafka5",
+    "distroID": "bluedata/confluentplatform55",
     "version": "1.0",
     "configSchemaVersion": 7,
     "services": [

--- a/deploy/example_catalog/docs/kafka55-readme.md
+++ b/deploy/example_catalog/docs/kafka55-readme.md
@@ -1,6 +1,6 @@
 #### KAFKA BRIEF
-Kafka is a distributed stream processing, message broker service. Confluent Kafka Platform has 7 components and corresponding roles: broker, zookeeper, schema-registry, ksql, connect, rest-proxy, and control-center. An optional client pod for running test loads is also provided in the yaml file. The client pod role is test-client. The first six components are available in the community version whereas the seventh - control center has to be licensed in 30 days.
-More about the Confluent Kafka cluster can be read [here.](https://docs.confluent.io/current/platform.html#cp-platform)
+Kafka is a distributed stream processing, message broker service. Confluent Platform has 7 components and corresponding roles: broker, zookeeper, schema-registry, ksql, connect, rest-proxy, and control-center. An optional client pod for running test loads is also provided in the yaml file. The client pod role is test-client. The first six components are available in the community version whereas the seventh - control center has to be licensed in 30 days.
+More about the Confluent cluster can be read [here.](https://docs.confluent.io/current/platform.html#cp-platform)
 
 #### KAFKA ROLES
 * Broker is the main component for Kafka loads. It is a cluster with minimum of 3 nodes. With the increase in load, number of brokers can be scaled up horizontally to be able to take more load.

--- a/deploy/example_clusters/cr-cluster-kafka55-stor.yaml
+++ b/deploy/example_clusters/cr-cluster-kafka55-stor.yaml
@@ -3,7 +3,7 @@ kind: "KubeDirectorCluster"
 metadata:
   name: "kafka55-persistent"
 spec:
-  app: confluentkafka55
+  app: confluentplatform55
   roles:
   - id: control-center
     members: 1


### PR DESCRIPTION
EZEPIC-22 - Need to rename "Confluent Kafka" in the app store - equivalent changes in KD App for Confluent Platform:
Changes done on App json, Cluster yaml definitions and documentation to reflect Confluent Platform instead of Confluent Kafka in app description