### PR TITLE
Override STDIN and TTY in Role Spec for KDApp 

### DIFF
--- a/deploy/example_catalog/cr-app-ngc.yaml
+++ b/deploy/example_catalog/cr-app-ngc.yaml
@@ -38,7 +38,8 @@ spec:
       memory: 2000Mi
       cpu: '2'
     containerSpec:
-      #tty: true
+      tty: true
+      stdin: true
   defaultImageRepoTag: nvcr.io/nvidia/tensorflow:20.12-tf1-py3
 #  volumeMounts:
 #    - mountPath: /dev/shm

--- a/deploy/example_catalog/cr-app-ngc.yaml
+++ b/deploy/example_catalog/cr-app-ngc.yaml
@@ -47,5 +47,4 @@ spec:
   defaultPersistDirs: []
   capabilities: []
   systemdRequired: false
-  logoURL: http://mip-bd-vm32.mip.storage.hpecorp.net/repos/OSS-Nvidia-Partnership-Tensorflow.png
 

--- a/deploy/example_catalog/cr-app-ngc.yaml
+++ b/deploy/example_catalog/cr-app-ngc.yaml
@@ -1,0 +1,51 @@
+apiVersion: kubedirector.hpe.com/v1beta1
+kind: KubeDirectorApp
+metadata:
+  name: ngc-tensorflow
+spec:
+#  volumes:
+#  - name: dshm
+#    emptyDir:
+#      medium: Memory
+  label:
+    name: NVIDIA:TensorFlow(NGC)
+    description: TensorFlow is an open-source software library for high-performance
+      numerical computation. Its flexible architecture allows easy deployment of computation
+      across a variety of platforms (CPUs, GPUs, TPUs), and from desktops to clusters
+      of servers to mobile and edge devices.
+  distroID: ngc-tensorflow
+  version: '1.0'
+  configSchemaVersion: 8
+  config:
+    roleServices:
+    - roleID: tensorflow
+      serviceIDs:
+      - ssh
+    selectedRoles:
+    - tensorflow
+  services:
+  - id: ssh
+    label:
+      name: ssh
+    endpoint:
+      port: 22
+      isDashboard: false
+      hasAuthToken: false
+  roles:
+  - id: tensorflow
+    cardinality: 1+
+    minResources:
+      memory: 2000Mi
+      cpu: '2'
+    containerSpec:
+      tty: true
+      stdin: true
+  defaultImageRepoTag: nvcr.io/nvidia/tensorflow:20.12-tf1-py3
+#  volumeMounts:
+#    - mountPath: /dev/shm
+#      name: dshm
+  defaultPersistDirs: []
+  capabilities: []
+  systemdRequired: false
+  logoURL: http://mip-bd-vm32.mip.storage.hpecorp.net/repos/OSS-Nvidia-Partnership-Tensorflow.png
+

--- a/deploy/example_catalog/cr-app-ngc.yaml
+++ b/deploy/example_catalog/cr-app-ngc.yaml
@@ -38,8 +38,7 @@ spec:
       memory: 2000Mi
       cpu: '2'
     containerSpec:
-      tty: true
-      stdin: true
+      #tty: true
   defaultImageRepoTag: nvcr.io/nvidia/tensorflow:20.12-tf1-py3
 #  volumeMounts:
 #    - mountPath: /dev/shm

--- a/deploy/example_clusters/cr-cluster-ngc.yaml
+++ b/deploy/example_clusters/cr-cluster-ngc.yaml
@@ -1,0 +1,18 @@
+apiVersion: "kubedirector.hpe.com/v1beta1"
+kind: "KubeDirectorCluster"
+metadata:
+  name: "ngc-tensorflow-cluster"
+spec:
+  app: ngc-tensorflow
+  roles:
+  - id: tensorflow
+    members: 1
+    resources:
+      requests:
+        memory: "4Gi"
+        cpu: "2"
+        nvidia.com/gpu: "1" 
+      limits:
+        memory: "4Gi"
+        cpu: "2"
+        nvidia.com/gpu: "1" 

--- a/deploy/kubedirector/kubedirector.hpe.com_kubedirectorapps_crd.yaml
+++ b/deploy/kubedirector/kubedirector.hpe.com_kubedirectorapps_crd.yaml
@@ -180,6 +180,7 @@ spec:
                     minLength: 1
                 roleServices:
                   type: array
+                  
                   items:
                     type: object
                     required: [roleID, serviceIDs]

--- a/deploy/kubedirector/kubedirector.hpe.com_kubedirectorapps_crd.yaml
+++ b/deploy/kubedirector/kubedirector.hpe.com_kubedirectorapps_crd.yaml
@@ -137,6 +137,14 @@ spec:
                     items:
                       type: string
                       pattern: '^configure$|^addnodes$|^delnodes$'
+                  containerSpec:
+                    type: object
+                    nullable: true
+                    properties:
+                      stdin:
+                        type: boolean
+                      tty:
+                        type: boolean
                   minResources:
                     type: object
                     nullable: true

--- a/deploy/kubedirector/kubedirector.hpe.com_kubedirectorapps_crd.yaml
+++ b/deploy/kubedirector/kubedirector.hpe.com_kubedirectorapps_crd.yaml
@@ -180,7 +180,6 @@ spec:
                     minLength: 1
                 roleServices:
                   type: array
-                  
                   items:
                     type: object
                     required: [roleID, serviceIDs]

--- a/pkg/apis/kubedirector/v1beta1/kubedirectorapp_types.go
+++ b/pkg/apis/kubedirector/v1beta1/kubedirectorapp_types.go
@@ -110,7 +110,7 @@ type NodeRole struct {
 	PersistDirs   *[]string            `json:"persistDirs,omitempty"`
 	EventList     *[]string            `json:"eventList,omitempty"`
 	MinResources  *corev1.ResourceList `json:"minResources,omitempty"`
-	ContainerSpec *ContainerSpec       `json:"containerSpec, omitempty"`
+	ContainerSpec *ContainerSpec       `json:"containerSpec,omitempty"`
 }
 
 //ContainerSpec comments

--- a/pkg/apis/kubedirector/v1beta1/kubedirectorapp_types.go
+++ b/pkg/apis/kubedirector/v1beta1/kubedirectorapp_types.go
@@ -115,8 +115,8 @@ type NodeRole struct {
 
 //ContainerSpec comments
 type ContainerSpec struct {
-	Stdin *bool `json:"stdin,omitempty"`
-	Tty   *bool `json:"tty,omitempty"`
+	Stdin bool `json:"stdin,omitempty"`
+	Tty   bool `json:"tty,omitempty"`
 }
 
 // NodeGroupConfig identifies a set of roles, and the services on those roles.

--- a/pkg/apis/kubedirector/v1beta1/kubedirectorapp_types.go
+++ b/pkg/apis/kubedirector/v1beta1/kubedirectorapp_types.go
@@ -103,13 +103,20 @@ type ServiceEndpoint struct {
 // the same services. At deployment time all role members will receive
 // identical resource assignments.
 type NodeRole struct {
-	ID           string               `json:"id"`
-	Cardinality  string               `json:"cardinality"`
-	ImageRepoTag *string              `json:"imageRepoTag,omitempty"`
-	SetupPackage SetupPackage         `json:"configPackage,omitempty"`
-	PersistDirs  *[]string            `json:"persistDirs,omitempty"`
-	EventList    *[]string            `json:"eventList,omitempty"`
-	MinResources *corev1.ResourceList `json:"minResources,omitempty"`
+	ID            string               `json:"id"`
+	Cardinality   string               `json:"cardinality"`
+	ImageRepoTag  *string              `json:"imageRepoTag,omitempty"`
+	SetupPackage  SetupPackage         `json:"configPackage,omitempty"`
+	PersistDirs   *[]string            `json:"persistDirs,omitempty"`
+	EventList     *[]string            `json:"eventList,omitempty"`
+	MinResources  *corev1.ResourceList `json:"minResources,omitempty"`
+	ContainerSpec *ContainerSpec       `json:"containerSpec"`
+}
+
+//ContainerSpec comments
+type ContainerSpec struct {
+	Stdin bool `json:"stdin"`
+	Tty   bool `json:"tty"`
 }
 
 // NodeGroupConfig identifies a set of roles, and the services on those roles.

--- a/pkg/apis/kubedirector/v1beta1/kubedirectorapp_types.go
+++ b/pkg/apis/kubedirector/v1beta1/kubedirectorapp_types.go
@@ -110,7 +110,7 @@ type NodeRole struct {
 	PersistDirs   *[]string            `json:"persistDirs,omitempty"`
 	EventList     *[]string            `json:"eventList,omitempty"`
 	MinResources  *corev1.ResourceList `json:"minResources,omitempty"`
-	ContainerSpec *ContainerSpec       `json:"containerSpec"`
+	ContainerSpec *ContainerSpec       `json:"containerSpec, omitempty"`
 }
 
 //ContainerSpec comments

--- a/pkg/apis/kubedirector/v1beta1/kubedirectorapp_types.go
+++ b/pkg/apis/kubedirector/v1beta1/kubedirectorapp_types.go
@@ -115,8 +115,8 @@ type NodeRole struct {
 
 //ContainerSpec comments
 type ContainerSpec struct {
-	Stdin bool `json:"stdin"`
-	Tty   bool `json:"tty"`
+	Stdin *bool `json:"stdin,omitempty"`
+	Tty   *bool `json:"tty,omitempty"`
 }
 
 // NodeGroupConfig identifies a set of roles, and the services on those roles.

--- a/pkg/catalog/interrogate.go
+++ b/pkg/catalog/interrogate.go
@@ -305,6 +305,33 @@ func AppPersistDirs(
 	)
 }
 
+// RoleContainerSpecs fetches the required directories for a given role that
+// has be persisted on a PVC.
+func RoleContainerSpecs(
+	cr *kdv1.KubeDirectorCluster,
+	role string,
+) (*kdv1.ContainerSpec, error) {
+
+	//s := make([]*kdv1.ContainerSpec, 5, 5)
+	// Fetch the app type definition if we haven't yet cached it in this
+	// handler pass.
+	appCR, err := GetApp(cr)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, nodeRole := range appCR.Spec.NodeRoles {
+		if role == nodeRole.ID {
+			if nodeRole.ContainerSpec != nil {
+				return nodeRole.ContainerSpec, nil
+			}
+		}
+	}
+
+	// Should never reach here.
+	return nil, nil
+}
+
 // FindApp returns the app type definition for the given virtual cluster. If
 // the appCatalog property is set to "local", it looks in the same namespace
 // as the cluster. If set to "system", it looks in the same namespace as

--- a/pkg/catalog/interrogate.go
+++ b/pkg/catalog/interrogate.go
@@ -305,16 +305,13 @@ func AppPersistDirs(
 	)
 }
 
-// RoleContainerSpecs fetches the required directories for a given role that
-// has be persisted on a PVC.
+// RoleContainerSpecs fetches container spec properties
+// that needs to be overridden by KDApp author
 func RoleContainerSpecs(
 	cr *kdv1.KubeDirectorCluster,
 	role string,
 ) (*kdv1.ContainerSpec, error) {
 
-	//s := make([]*kdv1.ContainerSpec, 5, 5)
-	// Fetch the app type definition if we haven't yet cached it in this
-	// handler pass.
 	appCR, err := GetApp(cr)
 	if err != nil {
 		return nil, err
@@ -328,7 +325,6 @@ func RoleContainerSpecs(
 		}
 	}
 
-	// Should never reach here.
 	return nil, nil
 }
 

--- a/pkg/executor/statefulset.go
+++ b/pkg/executor/statefulset.go
@@ -790,6 +790,9 @@ func hasSTDIN(
 ) bool {
 
 	containerSpec, err := catalog.RoleContainerSpecs(cr, role)
+	if errors.IsNotFound(err) {
+		return false
+	}
 	if err != nil {
 		return false
 	}
@@ -805,6 +808,9 @@ func hasTTY(
 ) bool {
 
 	containerSpec, err := catalog.RoleContainerSpecs(cr, role)
+	if errors.IsNotFound(err) {
+		return false
+	}
 	if err != nil {
 		return false
 	}

--- a/pkg/executor/statefulset.go
+++ b/pkg/executor/statefulset.go
@@ -352,6 +352,8 @@ func getStatefulset(
 							VolumeDevices:   volumeDevices,
 							SecurityContext: securityContext,
 							Env:             chkModifyEnvVars(role),
+							TTY:             hasTTY(cr, role.Name),
+							Stdin:           hasSTDIN(cr, role.Name),
 						},
 					},
 					Volumes: volumes,
@@ -777,4 +779,35 @@ func generateSecurityContext(
 			Add: appCapabilities,
 		},
 	}, nil
+}
+
+// isContainerStdIn creates security context with Add Capabilities property
+// based on app's capability list. If app doesn't require additional capabilities
+// return nil
+func hasSTDIN(
+	cr *kdv1.KubeDirectorCluster,
+	role string,
+) bool {
+
+	containerSpec, err := catalog.RoleContainerSpecs(cr, role)
+	if err != nil {
+		return false
+	}
+	return containerSpec.Stdin
+}
+
+// isContainerStdIn creates security context with Add Capabilities property
+// based on app's capability list. If app doesn't require additional capabilities
+// return nil
+func hasTTY(
+	cr *kdv1.KubeDirectorCluster,
+	role string,
+) bool {
+
+	containerSpec, err := catalog.RoleContainerSpecs(cr, role)
+	if err != nil {
+		return false
+	}
+	return containerSpec.Tty
+
 }

--- a/pkg/executor/statefulset.go
+++ b/pkg/executor/statefulset.go
@@ -789,14 +789,15 @@ func hasSTDIN(
 	role string,
 ) bool {
 
-	containerSpec, err := catalog.RoleContainerSpecs(cr, role)
-	if errors.IsNotFound(err) {
+	containerSpec, _ := catalog.RoleContainerSpecs(cr, role)
+	if containerSpec == nil {
 		return false
 	}
-	if err != nil {
-		return false
+
+	if containerSpec.Stdin != nil {
+		return *containerSpec.Stdin
 	}
-	return containerSpec.Stdin
+	return false
 }
 
 // hasTTY is a utility function to find out
@@ -807,13 +808,13 @@ func hasTTY(
 	role string,
 ) bool {
 
-	containerSpec, err := catalog.RoleContainerSpecs(cr, role)
-	if errors.IsNotFound(err) {
+	containerSpec, _ := catalog.RoleContainerSpecs(cr, role)
+	if containerSpec == nil {
 		return false
 	}
-	if err != nil {
-		return false
-	}
-	return containerSpec.Tty
 
+	if containerSpec.Tty != nil {
+		return *containerSpec.Tty
+	}
+	return false
 }

--- a/pkg/executor/statefulset.go
+++ b/pkg/executor/statefulset.go
@@ -790,7 +790,7 @@ func hasSTDIN(
 ) bool {
 
 	containerSpec, err := catalog.RoleContainerSpecs(cr, role)
-	if err != nil {
+	if errors.IsNotFound(err) || err != nil {
 		return false
 	}
 	return containerSpec.Stdin
@@ -805,7 +805,7 @@ func hasTTY(
 ) bool {
 
 	containerSpec, err := catalog.RoleContainerSpecs(cr, role)
-	if err != nil {
+	if errors.IsNotFound(err) || err != nil {
 		return false
 	}
 	return containerSpec.Tty

--- a/pkg/executor/statefulset.go
+++ b/pkg/executor/statefulset.go
@@ -790,7 +790,7 @@ func hasSTDIN(
 ) bool {
 
 	containerSpec, err := catalog.RoleContainerSpecs(cr, role)
-	if errors.IsNotFound(err) || err != nil {
+	if err != nil {
 		return false
 	}
 	return containerSpec.Stdin
@@ -805,7 +805,7 @@ func hasTTY(
 ) bool {
 
 	containerSpec, err := catalog.RoleContainerSpecs(cr, role)
-	if errors.IsNotFound(err) || err != nil {
+	if err != nil {
 		return false
 	}
 	return containerSpec.Tty

--- a/pkg/executor/statefulset.go
+++ b/pkg/executor/statefulset.go
@@ -794,10 +794,7 @@ func hasSTDIN(
 		return false
 	}
 
-	if containerSpec.Stdin != nil {
-		return *containerSpec.Stdin
-	}
-	return false
+	return containerSpec.Stdin
 }
 
 // hasTTY is a utility function to find out
@@ -813,8 +810,5 @@ func hasTTY(
 		return false
 	}
 
-	if containerSpec.Tty != nil {
-		return *containerSpec.Tty
-	}
-	return false
+	return containerSpec.Tty
 }

--- a/pkg/executor/statefulset.go
+++ b/pkg/executor/statefulset.go
@@ -781,9 +781,9 @@ func generateSecurityContext(
 	}, nil
 }
 
-// isContainerStdIn creates security context with Add Capabilities property
-// based on app's capability list. If app doesn't require additional capabilities
-// return nil
+// hasSTDIN is a utility function to find out
+// if STDIN was requested by the KubeDirectorApp
+// default is False if left blank by the App
 func hasSTDIN(
 	cr *kdv1.KubeDirectorCluster,
 	role string,
@@ -796,9 +796,9 @@ func hasSTDIN(
 	return containerSpec.Stdin
 }
 
-// isContainerStdIn creates security context with Add Capabilities property
-// based on app's capability list. If app doesn't require additional capabilities
-// return nil
+// hasTTY is a utility function to find out
+// if TTY was requested by the KubeDirectorApp
+// default is False if left blank by the App
 func hasTTY(
 	cr *kdv1.KubeDirectorCluster,
 	role string,

--- a/pkg/validator/app.go
+++ b/pkg/validator/app.go
@@ -267,6 +267,19 @@ func validateRoles(
 				)
 			}
 		}
+		if role.ContainerSpec != nil {
+			if role.ContainerSpec.Tty != nil {
+				if role.ContainerSpec.Stdin == nil {
+					valErrors = append(
+						valErrors,
+						fmt.Sprintf(
+							ttyWithoutStdin,
+							role.ID,
+						),
+					)
+				}
+			}
+		}
 		if role.ImageRepoTag == nil {
 			// We allow roles to have different container images but unlike the
 			// setup package there cannot be a role with no image.

--- a/pkg/validator/app.go
+++ b/pkg/validator/app.go
@@ -268,8 +268,8 @@ func validateRoles(
 			}
 		}
 		if role.ContainerSpec != nil {
-			if role.ContainerSpec.Tty != nil {
-				if role.ContainerSpec.Stdin == nil {
+			if role.ContainerSpec.Tty {
+				if !role.ContainerSpec.Stdin {
 					valErrors = append(
 						valErrors,
 						fmt.Sprintf(

--- a/pkg/validator/types.go
+++ b/pkg/validator/types.go
@@ -64,7 +64,7 @@ const (
 	invalidSecret              = "Unable to find secret(%s) for role(%s) in namespace(%s)."
 
 	noDefaultImage  = "Role(%s) has no specified image, and no top-level default image is specified."
-	ttyWithoutStdin = "Role(%s) requested TTY without stdin."
+	ttyWithoutStdin = "Role(%s) requested TTY without STDIN."
 
 	noURLScheme = "The endpoint for service(%s) must include a urlScheme value because isDashboard is true."
 

--- a/pkg/validator/types.go
+++ b/pkg/validator/types.go
@@ -63,7 +63,8 @@ const (
 	invalidSecretPrefix        = "Secret(%s) for role(%s) does not have the required name prefix(%s)."
 	invalidSecret              = "Unable to find secret(%s) for role(%s) in namespace(%s)."
 
-	noDefaultImage = "Role(%s) has no specified image, and no top-level default image is specified."
+	noDefaultImage  = "Role(%s) has no specified image, and no top-level default image is specified."
+	ttyWithoutStdin = "Role(%s) requested TTY without stdin."
 
 	noURLScheme = "The endpoint for service(%s) must include a urlScheme value because isDashboard is true."
 


### PR DESCRIPTION
A lot of applications like NVIDIA NGC require tty and stdin for the pod. This feature lets App developer specify that in the kdapp spec. Also added the Nvidia NGC app in the catalog

https://github.com/bluek8s/kubedirector/issues/461