### PR TITLE
resource quantity format changes shouldn't trigger "spec has changed" check

### DIFF
--- a/pkg/controller/kubedirectorcluster/cluster.go
+++ b/pkg/controller/kubedirectorcluster/cluster.go
@@ -20,7 +20,6 @@ import (
 	"crypto/md5"
 	"encoding/hex"
 	"fmt"
-	"reflect"
 	"strconv"
 	"time"
 
@@ -32,6 +31,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 )
 
@@ -77,7 +77,7 @@ func (r *ReconcileKubeDirectorCluster) syncCluster(
 		// don't care if status has changed.
 		statusChanged := false
 		if (cr.DeletionTimestamp == nil) || nowHasFinalizer {
-			statusChanged = !reflect.DeepEqual(cr.Status, oldStatus)
+			statusChanged = !equality.Semantic.DeepEqual(cr.Status, oldStatus)
 		}
 		finalizersChanged := (hadFinalizer != nowHasFinalizer)
 		if !(statusChanged || finalizersChanged) {

--- a/pkg/controller/kubedirectorconfig/config.go
+++ b/pkg/controller/kubedirectorconfig/config.go
@@ -17,7 +17,6 @@ package kubedirectorconfig
 import (
 	"context"
 	"fmt"
-	"reflect"
 	"time"
 
 	kdv1 "github.com/bluek8s/kubedirector/pkg/apis/kubedirector/v1beta1"
@@ -25,6 +24,7 @@ import (
 	"github.com/bluek8s/kubedirector/pkg/shared"
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 )
 
@@ -65,7 +65,7 @@ func (r *ReconcileKubeDirectorConfig) syncConfig(
 		// don't care if status has changed.
 		statusChanged := false
 		if (cr.DeletionTimestamp == nil) || nowHasFinalizer {
-			statusChanged = !reflect.DeepEqual(cr.Status, oldStatus)
+			statusChanged = !equality.Semantic.DeepEqual(cr.Status, oldStatus)
 		}
 		finalizersChanged := (hadFinalizer != nowHasFinalizer)
 		if !(statusChanged || finalizersChanged) {

--- a/pkg/validator/app.go
+++ b/pkg/validator/app.go
@@ -17,7 +17,6 @@ package validator
 import (
 	"encoding/json"
 	"fmt"
-	"reflect"
 	"strconv"
 	"strings"
 
@@ -25,6 +24,7 @@ import (
 	"github.com/bluek8s/kubedirector/pkg/catalog"
 	"github.com/bluek8s/kubedirector/pkg/shared"
 	"k8s.io/api/admission/v1beta1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -463,7 +463,7 @@ func admitAppCR(
 			// to null. See the commit comments in the PR that closes issue
 			// #319 for more details.
 			prevAppCR.Spec.DefaultSetupPackage = appCR.Spec.DefaultSetupPackage
-			if !reflect.DeepEqual(appCR.Spec, prevAppCR.Spec) {
+			if !equality.Semantic.DeepEqual(appCR.Spec, prevAppCR.Spec) {
 				referencesStr := strings.Join(references, ", ")
 				appInUseMsg := fmt.Sprintf(
 					appInUse,

--- a/pkg/validator/cluster.go
+++ b/pkg/validator/cluster.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"strconv"
 	"strings"
 	"time"
@@ -30,6 +29,7 @@ import (
 	"github.com/bluek8s/kubedirector/pkg/observer"
 	"github.com/bluek8s/kubedirector/pkg/shared"
 	"k8s.io/api/admission/v1beta1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	appsvalidation "k8s.io/apimachinery/pkg/apis/meta/v1/validation"
@@ -390,7 +390,7 @@ func validateRoleChanges(
 		// the new spec if anything other than the members count is different.
 		compareRole := *role
 		compareRole.Members = prevRole.Members
-		if !reflect.DeepEqual(&compareRole, prevRole) {
+		if !equality.Semantic.DeepEqual(&compareRole, prevRole) {
 			roleModifiedMsg := fmt.Sprintf(
 				modifiedRole,
 				role.Name,
@@ -890,7 +890,7 @@ func admitClusterCR(
 				return &admitResponse
 			}
 		} else {
-			if !reflect.DeepEqual(clusterCR.Status, prevClusterCR.Status) {
+			if !equality.Semantic.DeepEqual(clusterCR.Status, prevClusterCR.Status) {
 				admitResponse.Result = statusViolation
 				return &admitResponse
 			}
@@ -899,7 +899,7 @@ func admitClusterCR(
 		// it's OK to write the status again as long as nothing is changing.
 		// (For example we'll see this when a PATCH happens.)
 		if expectedStatusGen.Validated {
-			if !reflect.DeepEqual(clusterCR.Status, prevClusterCR.Status) {
+			if !equality.Semantic.DeepEqual(clusterCR.Status, prevClusterCR.Status) {
 				admitResponse.Result = statusViolation
 				return &admitResponse
 			}
@@ -914,7 +914,7 @@ func admitClusterCR(
 	// metadata generation number here because that is incremented after this
 	// validator sees the request.
 	if ar.Request.Operation == v1beta1.Update {
-		if reflect.DeepEqual(clusterCR.Spec, prevClusterCR.Spec) {
+		if equality.Semantic.DeepEqual(clusterCR.Spec, prevClusterCR.Spec) {
 			admitResponse.Allowed = true
 			return &admitResponse
 		}

--- a/pkg/validator/config.go
+++ b/pkg/validator/config.go
@@ -17,7 +17,6 @@ package validator
 import (
 	"encoding/json"
 	"fmt"
-	"reflect"
 	"strings"
 
 	"github.com/bluek8s/kubedirector/pkg/controller/kubedirectorconfig"
@@ -26,6 +25,7 @@ import (
 	kdv1 "github.com/bluek8s/kubedirector/pkg/apis/kubedirector/v1beta1"
 	"github.com/bluek8s/kubedirector/pkg/observer"
 	"k8s.io/api/admission/v1beta1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -176,7 +176,7 @@ func admitKDConfigCR(
 				return &admitResponse
 			}
 		} else {
-			if !reflect.DeepEqual(configCR.Status, prevConfigCR.Status) {
+			if !equality.Semantic.DeepEqual(configCR.Status, prevConfigCR.Status) {
 				admitResponse.Result = statusViolation
 				return &admitResponse
 			}
@@ -185,7 +185,7 @@ func admitKDConfigCR(
 		// it's OK to write the status again as long as nothing is changing.
 		// (For example we'll see this when a PATCH happens.)
 		if expectedStatusGen.Validated {
-			if !reflect.DeepEqual(configCR.Status, prevConfigCR.Status) {
+			if !equality.Semantic.DeepEqual(configCR.Status, prevConfigCR.Status) {
 				admitResponse.Result = statusViolation
 				return &admitResponse
 			}


### PR DESCRIPTION
There are situations where a client is not allowed to change a role spec: if the previous change is still being processed, or if the role has nonzero member count.

As per issue #466 though, there are some cases where a resource quantity is getting its format changed, e.g. from "0.5" to "500m", without its quantity actually being changed. Sometimes this is even happening as part of a status write from KD itself. We're not explicitly asking for this format change -- something along the way in client-go or K8s is doing it -- but whatever the reason, we need to allow it to happen.

So this change to how we handle checking for CR changes is motivated by issue #466, but really it applies everywhere we do such a check.

Along with general regression-test creations of existing kdapp types while monitoring the KD logs, I did these specific tests:

- creating kdcluster with 0.5 CPU (works now)
- changing kdcluster role spec to something "semantically equivalent", for role with existing members (works now)
- changing kdcluster role spec to something non-equivalent, for role with existing members (blocked, as it should be)
- changing the members count for a scaleout kdcluster role (works, as it should)
- manually editing a kdcluster status stanza (blocked, as it should be)
- manually editing a kdconfig status stanza (blocked, as it should be)

My current test K8s/Ezmeral system is pretty old, so I'm going to do a clean install to get up-to-date then test one more time.