### PR TITLE
Fix #467 - nil deref in HandleReadyMembers

### DIFF
--- a/pkg/controller/kubedirectorcluster/members.go
+++ b/pkg/controller/kubedirectorcluster/members.go
@@ -297,7 +297,7 @@ func handleReadyMembers(
 				shared.LogInfof(
 					reqLogger,
 					cr,
-					"",
+					shared.EventReasonNoEvent,
 					"LastConnectionVersion for {%s} is nil. Resetting.",
 					m.Pod,
 				)

--- a/pkg/controller/kubedirectorcluster/members.go
+++ b/pkg/controller/kubedirectorcluster/members.go
@@ -297,7 +297,7 @@ func handleReadyMembers(
 				shared.LogInfof(
 					reqLogger,
 					cr,
-					shared.EventReasonCluster,
+					"",
 					"Member Version for {%s} is nil. Resetting.",
 					m.Pod,
 				)

--- a/pkg/controller/kubedirectorcluster/members.go
+++ b/pkg/controller/kubedirectorcluster/members.go
@@ -298,7 +298,7 @@ func handleReadyMembers(
 					reqLogger,
 					cr,
 					"",
-					"Member Version for {%s} is nil. Resetting.",
+					"LastConnectionVersion for {%s} is nil. Resetting.",
 					m.Pod,
 				)
 

--- a/pkg/controller/kubedirectorcluster/members.go
+++ b/pkg/controller/kubedirectorcluster/members.go
@@ -284,20 +284,26 @@ func handleReadyMembers(
 				return
 			}
 
+			// memberVersion is the connectionVersion of the member.
+			// If it is nil, we set it to connectionsVersion - 1. This is to call startscript with --reconnect and then equalize connectionsVersion and memberVersion
+			// If it is not nil, we set it to the member's connectionVersion
 			var memberVersion int64
 
 			if m.StateDetail.LastConnectionVersion != nil {
 				memberVersion = *m.StateDetail.LastConnectionVersion
 
 			} else {
-				memberVersion = connectionsVersion - 1
 
-				shared.LogInfo(
+				shared.LogInfof(
 					reqLogger,
 					cr,
 					shared.EventReasonCluster,
-					fmt.Sprintf("Member Version is : %d. Was NIL", memberVersion),
+					"Member Version for {%s} is nil. Resetting.",
+					m.Pod,
 				)
+
+				memberVersion = connectionsVersion - 1
+
 			}
 
 			if memberVersion < connectionsVersion {


### PR DESCRIPTION
### Summary:

This issue is encountered in the following scenario:

When a KD Cluster does not contain `lastConnectionVersion` member status (will be typically found in v0.5.1 and below) and the connections are updated. This leads to `handleReadyMembers()` checking for the `memberVersion` (which is nil) and as a result, KD goes in panic state. 


### Proposed Change:

`handleReadyMembers()` gets called only when we are operating on ready members. Currently, it is called to inject configmeta initially and thereafter, every time the connections are modified. We also use this function to call startscript with --reconnect flag only if the connections are modified. 

In the scenario when the deref is encountered, the only possible way to enter `handleReadyMembers()` is when connections are modified. (since the KDCluster is already up) 

Now, we want to call the startscript with --reconnect and initialize the `memberVersion`. Setting it to `connectionVersion - 1` would help both the causes since the flow will call startscript and after that, increment `memberVersion` by 1 and make it equal to `connectionVersion`.  
 