### PR TITLE
Fix appPrepConfigRunCmd to report stderr and status

### DIFF
--- a/pkg/controller/kubedirectorcluster/types.go
+++ b/pkg/controller/kubedirectorcluster/types.go
@@ -89,10 +89,7 @@ const (
 	rm -rf /opt/guestconfig/appconfig.tgz`
 	appPrepConfigStatus = "/opt/guestconfig/configure.status"
 	appPrepConfigRunCmd = `rm -f /opt/guestconfig/configure.* &&
-	echo -n %s= > ` + appPrepConfigStatus + ` &&
-	nohup sh -c "` + appPrepStartscript + ` --configure;
-	echo -n $? >> ` + appPrepConfigStatus + `" > /opt/guestconfig/configure.stdout  
-	2> /opt/guestconfig/configure.stderr  &`
+	echo -n %s= > ` + appPrepConfigStatus + ` && nohup sh -c "` + appPrepStartscript + ` --configure 2>/opt/guestconfig/configure.stderr 1>/opt/guestconfig/configure.stdout;echo $? >> ` + appPrepConfigStatus + `" &`
 	fileInjectionCommand = `mkdir -p %s && cd %s &&
 	curl -L %s -o %s`
 	appPrepConfigReconnectCmd = `echo -n %s= > ` + appPrepConfigStatus + ` &&

--- a/pkg/controller/kubedirectorcluster/types.go
+++ b/pkg/controller/kubedirectorcluster/types.go
@@ -95,9 +95,8 @@ const (
 	fileInjectionCommand = `mkdir -p %s && cd %s &&
 	curl -L %s -o %s`
 	appPrepConfigReconnectCmd = `echo -n %s= > ` + appPrepConfigStatus + ` &&
-	nohup sh -c "` + appPrepStartscript + ` --reconnect;
-	echo -n $? >> ` + appPrepConfigStatus + `" >> /opt/guestconfig/configure.stdout  
-	2>> /opt/guestconfig/configure.stderr  &`
+	nohup sh -c '` + appPrepStartscript + ` --reconnect 2>/opt/guestconfig/configure.stderr 1>/opt/guestconfig/configure.stdout;
+	echo -n $? >> ` + appPrepConfigStatus + `' &`
 )
 
 const (

--- a/pkg/controller/kubedirectorcluster/types.go
+++ b/pkg/controller/kubedirectorcluster/types.go
@@ -90,8 +90,8 @@ const (
 	appPrepConfigStatus = "/opt/guestconfig/configure.status"
 	appPrepConfigRunCmd = `rm -f /opt/guestconfig/configure.* &&
 	echo -n %s= > ` + appPrepConfigStatus + ` && 
-	nohup sh -c "` + appPrepStartscript + ` --configure 2>/opt/guestconfig/configure.stderr 1>/opt/guestconfig/configure.stdout;
-	echo $? >> ` + appPrepConfigStatus + `" &`
+	nohup sh -c '` + appPrepStartscript + ` --configure 2>/opt/guestconfig/configure.stderr 1>/opt/guestconfig/configure.stdout;
+	echo -n $? >> ` + appPrepConfigStatus + `' &`
 	fileInjectionCommand = `mkdir -p %s && cd %s &&
 	curl -L %s -o %s`
 	appPrepConfigReconnectCmd = `echo -n %s= > ` + appPrepConfigStatus + ` &&

--- a/pkg/controller/kubedirectorcluster/types.go
+++ b/pkg/controller/kubedirectorcluster/types.go
@@ -89,7 +89,9 @@ const (
 	rm -rf /opt/guestconfig/appconfig.tgz`
 	appPrepConfigStatus = "/opt/guestconfig/configure.status"
 	appPrepConfigRunCmd = `rm -f /opt/guestconfig/configure.* &&
-	echo -n %s= > ` + appPrepConfigStatus + ` && nohup sh -c "` + appPrepStartscript + ` --configure 2>/opt/guestconfig/configure.stderr 1>/opt/guestconfig/configure.stdout;echo $? >> ` + appPrepConfigStatus + `" &`
+	echo -n %s= > ` + appPrepConfigStatus + ` && 
+	nohup sh -c "` + appPrepStartscript + ` --configure 2>/opt/guestconfig/configure.stderr 1>/opt/guestconfig/configure.stdout;
+	echo $? >> ` + appPrepConfigStatus + `" &`
 	fileInjectionCommand = `mkdir -p %s && cd %s &&
 	curl -L %s -o %s`
 	appPrepConfigReconnectCmd = `echo -n %s= > ` + appPrepConfigStatus + ` &&


### PR DESCRIPTION
Minor tweaks to appPrepConfigRunCmd to fix stderr and status which was getting lost.

Even a failed startscript was not writing anything to /opt/guesstconfig/configure.stderr or /opt/guesstconfig/configure.status.

Tested all /opt/guestconfig/configure.* for successful and unssucessful runs of startscript.