### PR TITLE
More control over labels and annotations

### DIFF
--- a/deploy/kubedirector/kubedirector.hpe.com_kubedirectorclusters_crd.yaml
+++ b/deploy/kubedirector/kubedirector.hpe.com_kubedirectorclusters_crd.yaml
@@ -88,7 +88,13 @@ spec:
                   podLabels:
                     type: object
                     nullable: true
+                  podAnnotations:
+                    type: object
+                    nullable: true
                   serviceLabels:
+                    type: object
+                    nullable: true
+                  serviceAnnotations:
                     type: object
                     nullable: true
                   members:

--- a/deploy/kubedirector/kubedirector.hpe.com_kubedirectorconfigs_crd.yaml
+++ b/deploy/kubedirector/kubedirector.hpe.com_kubedirectorconfigs_crd.yaml
@@ -51,6 +51,18 @@ spec:
               pattern: '^UID$|^CrNameRole$'
             masterEncryptionKey:
               type: string
+            podLabels:
+              type: object
+              nullable: true
+            podAnnotations:
+              type: object
+              nullable: true
+            serviceLabels:
+              type: object
+              nullable: true
+            serviceAnnotations:
+              type: object
+              nullable: true
         status:
           type: object
           nullable: true

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	k8s.io/api v0.0.0
 	k8s.io/apimachinery v0.0.0
 	k8s.io/client-go v12.0.0+incompatible
+	k8s.io/kubernetes v1.16.2
 	sigs.k8s.io/controller-runtime v0.4.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -155,6 +155,7 @@ github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyG
 github.com/docker/cli v0.0.0-20190506213505-d88565df0c2d/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/distribution v2.7.0+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/distribution v2.7.1-0.20190205005809-0d3efadf0154+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
+github.com/docker/distribution v2.7.1+incompatible h1:a5mlkVzth6W5A4fOsS3D2EO5BUmsJpcB+cRlLU7cSug=
 github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker-credential-helpers v0.6.1/go.mod h1:WRaJzqw3CTB9bk10avuGsjVBZsD05qeibJ1/TYlvc0Y=
 github.com/docker/go-connections v0.3.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
@@ -491,6 +492,7 @@ github.com/onsi/gomega v1.3.0/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
+github.com/opencontainers/go-digest v1.0.0-rc1 h1:WzifXhOVOEOuFYOJAW6aQqW0TooG2iki3E3Ii+WN7gQ=
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/opencontainers/runc v0.1.1/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
@@ -861,9 +863,11 @@ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.1-2019.2.2/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 k8s.io/api v0.0.0-20191016110408-35e52d86657a h1:VVUE9xTCXP6KUPMf92cQmN88orz600ebexcRRaBTepQ=
 k8s.io/api v0.0.0-20191016110408-35e52d86657a/go.mod h1:/L5qH+AD540e7Cetbui1tuJeXdmNhO8jM6VkXeDdDhQ=
+k8s.io/apiextensions-apiserver v0.0.0-20191016113550-5357c4baaf65 h1:kThoiqgMsSwBdMK/lPgjtYTsEjbUU9nXCA9DyU3feok=
 k8s.io/apiextensions-apiserver v0.0.0-20191016113550-5357c4baaf65/go.mod h1:5BINdGqggRXXKnDgpwoJ7PyQH8f+Ypp02fvVNcIFy9s=
 k8s.io/apimachinery v0.0.0-20191004115801-a2eda9f80ab8 h1:Iieh/ZEgT3BWwbLD5qEKcY06jKuPEl6zC7gPSehoLw4=
 k8s.io/apimachinery v0.0.0-20191004115801-a2eda9f80ab8/go.mod h1:llRdnznGEAqC3DcNm6yEj472xaFVfLM7hnYofMb12tQ=
+k8s.io/apiserver v0.0.0-20191016112112-5190913f932d h1:leksCBKKBrPJmW1jV4dZUvwqmVtXpKdzpHsqXfFS094=
 k8s.io/apiserver v0.0.0-20191016112112-5190913f932d/go.mod h1:7OqfAolfWxUM/jJ/HBLyE+cdaWFBUoo5Q5pHgJVj2ws=
 k8s.io/autoscaler v0.0.0-20190607113959-1b4f1855cb8e/go.mod h1:QEXezc9uKPT91dwqhSJq3GNI3B1HxFRQHiku9kmrsSA=
 k8s.io/cli-runtime v0.0.0-20191016114015-74ad18325ed5/go.mod h1:sDl6WKSQkDM6zS1u9F49a0VooQ3ycYFBFLqd2jf2Xfo=
@@ -872,6 +876,7 @@ k8s.io/client-go v0.0.0-20191016111102-bec269661e48/go.mod h1:hrwktSwYGI4JK+TJA3
 k8s.io/cloud-provider v0.0.0-20191016115326-20453efc2458/go.mod h1:O5SO5xcgxrjJV9EC9R/47RuBpbk5YX9URDBlg++FA5o=
 k8s.io/cluster-bootstrap v0.0.0-20191016115129-c07a134afb42/go.mod h1:MzCL6kLExQuHruGaqibd8cugC8nw8QRxm3+lzR5l8SI=
 k8s.io/code-generator v0.0.0-20191004115455-8e001e5d1894/go.mod h1:mJUgkl06XV4kstAnLHAIzJPVCOzVR+ZcfPIv4fUsFCY=
+k8s.io/component-base v0.0.0-20191016111319-039242c015a9 h1:2D+G/CCNVdYc0h9D+tX+0SmtcyQmby6uzNityrps1s0=
 k8s.io/component-base v0.0.0-20191016111319-039242c015a9/go.mod h1:SuWowIgd/dtU/m/iv8OD9eOxp3QZBBhTIiWMsBQvKjI=
 k8s.io/cri-api v0.0.0-20190828162817-608eb1dad4ac/go.mod h1:BvtUaNBr0fEpzb11OfrQiJLsLPtqbmulpo1fPwcpP6Q=
 k8s.io/csi-translation-lib v0.0.0-20191016115521-756ffa5af0bd/go.mod h1:lf1VBseeLanBpSXD0N9tuPx1ylI8sA0j6f+rckCKiIk=
@@ -899,6 +904,7 @@ k8s.io/kube-state-metrics v1.7.2/go.mod h1:U2Y6DRi07sS85rmVPmBFlmv+2peBcL8IWGjM+
 k8s.io/kubectl v0.0.0-20191016120415-2ed914427d51/go.mod h1:gL826ZTIfD4vXTGlmzgTbliCAT9NGiqpCqK2aNYv5MQ=
 k8s.io/kubelet v0.0.0-20191016114556-7841ed97f1b2/go.mod h1:SBvrtLbuePbJygVXGGCMtWKH07+qrN2dE1iMnteSG8E=
 k8s.io/kubernetes v1.16.0/go.mod h1:nlP2zevWKRGKuaaVbKIwozU0Rjg9leVDXkL4YTtjmVs=
+k8s.io/kubernetes v1.16.2 h1:k0f/OVp6Yfv+UMTm6VYKhqjRgcvHh4QhN9coanjrito=
 k8s.io/kubernetes v1.16.2/go.mod h1:SmhGgKfQ30imqjFVj8AI+iW+zSyFsswNErKYeTfgoH0=
 k8s.io/legacy-cloud-providers v0.0.0-20191016115753-cf0698c3a16b/go.mod h1:tKW3pKqdRW8pMveUTpF5pJuCjQxg6a25iLo+Z9BXVH0=
 k8s.io/metrics v0.0.0-20191016113814-3b1a734dba6e/go.mod h1:ve7/vMWeY5lEBkZf6Bt5TTbGS3b8wAxwGbdXAsufjRs=

--- a/pkg/apis/kubedirector/v1beta1/kubedirectorcluster_types.go
+++ b/pkg/apis/kubedirector/v1beta1/kubedirectorcluster_types.go
@@ -126,18 +126,20 @@ type FileInjections struct {
 // image, resource requirements, persistent storage definition, and (as
 // defined by the cluster's KubeDirectorApp) set of service endpoints.
 type Role struct {
-	Name           string                      `json:"id"`
-	PodLabels      map[string]string           `json:"podLabels,omitempty"`
-	ServiceLabels  map[string]string           `json:"serviceLabels,omitempty"`
-	Members        *int32                      `json:"members,omitempty"`
-	Resources      corev1.ResourceRequirements `json:"resources"`
-	Affinity       *corev1.Affinity            `json:"affinity,omitempty"`
-	Storage        *ClusterStorage             `json:"storage,omitempty"`
-	EnvVars        []corev1.EnvVar             `json:"env,omitempty"`
-	FileInjections []FileInjections            `json:"fileInjections,omitempty"`
-	Secret         *KDSecret                   `json:"secret,omitempty"`
-	BlockStorage   *BlockStorage               `json:"blockStorage,omitempty"`
-	SecretKeys     []SecretKey                 `json:"secretKeys,omitempty"`
+	Name               string                      `json:"id"`
+	PodLabels          map[string]string           `json:"podLabels,omitempty"`
+	PodAnnotations     map[string]string           `json:"podAnnotations,omitempty"`
+	ServiceLabels      map[string]string           `json:"serviceLabels,omitempty"`
+	ServiceAnnotations map[string]string           `json:"serviceAnnotations,omitempty"`
+	Members            *int32                      `json:"members,omitempty"`
+	Resources          corev1.ResourceRequirements `json:"resources"`
+	Affinity           *corev1.Affinity            `json:"affinity,omitempty"`
+	Storage            *ClusterStorage             `json:"storage,omitempty"`
+	EnvVars            []corev1.EnvVar             `json:"env,omitempty"`
+	FileInjections     []FileInjections            `json:"fileInjections,omitempty"`
+	Secret             *KDSecret                   `json:"secret,omitempty"`
+	BlockStorage       *BlockStorage               `json:"blockStorage,omitempty"`
+	SecretKeys         []SecretKey                 `json:"secretKeys,omitempty"`
 }
 
 // SecretKey holds data which is supposed to be only available on configuration phase

--- a/pkg/apis/kubedirector/v1beta1/kubedirectorconfig_types.go
+++ b/pkg/apis/kubedirector/v1beta1/kubedirectorconfig_types.go
@@ -20,13 +20,17 @@ import (
 
 // KubeDirectorConfigSpec defines the desired state of KubeDirectorConfig.
 type KubeDirectorConfigSpec struct {
-	StorageClass         *string `json:"defaultStorageClassName,omitempty"`
-	ServiceType          *string `json:"defaultServiceType,omitempty"`
-	NativeSystemdSupport *bool   `json:"nativeSystemdSupport,omitempty"`
-	RequiredSecretPrefix *string `json:"requiredSecretPrefix,omitempty"`
-	ClusterSvcDomainBase *string `json:"clusterSvcDomainBase,omitempty"`
-	DefaultNamingScheme  *string `json:"defaultNamingScheme,omitempty"`
-	MasterEncryptionKey  *string `json:"masterEncryptionKey,omitempty"`
+	StorageClass         *string           `json:"defaultStorageClassName,omitempty"`
+	ServiceType          *string           `json:"defaultServiceType,omitempty"`
+	NativeSystemdSupport *bool             `json:"nativeSystemdSupport,omitempty"`
+	RequiredSecretPrefix *string           `json:"requiredSecretPrefix,omitempty"`
+	ClusterSvcDomainBase *string           `json:"clusterSvcDomainBase,omitempty"`
+	DefaultNamingScheme  *string           `json:"defaultNamingScheme,omitempty"`
+	MasterEncryptionKey  *string           `json:"masterEncryptionKey,omitempty"`
+	PodLabels            map[string]string `json:"podLabels,omitempty"`
+	PodAnnotations       map[string]string `json:"podAnnotations,omitempty"`
+	ServiceLabels        map[string]string `json:"serviceLabels,omitempty"`
+	ServiceAnnotations   map[string]string `json:"serviceAnnotations,omitempty"`
 }
 
 // KubeDirectorConfigStatus defines the observed state of KubeDirectorConfig.

--- a/pkg/executor/service.go
+++ b/pkg/executor/service.go
@@ -47,7 +47,7 @@ func CreateHeadlessService(
 			Namespace:       cr.Namespace,
 			OwnerReferences: ownerReferences(cr),
 			Labels:          labelsForService(cr, nil),
-			Annotations:     annotationsForCluster(cr),
+			Annotations:     annotationsForService(cr, nil),
 		},
 		Spec: corev1.ServiceSpec{
 			ClusterIP: "None",
@@ -132,7 +132,7 @@ func CreatePodService(
 			Namespace:       cr.Namespace,
 			OwnerReferences: ownerReferences(cr),
 			Labels:          labelsForService(cr, role),
-			Annotations:     annotationsForCluster(cr),
+			Annotations:     annotationsForService(cr, role),
 		},
 		Spec: corev1.ServiceSpec{
 			Selector:                 map[string]string{statefulSetPodLabel: podName},

--- a/pkg/executor/statefulset.go
+++ b/pkg/executor/statefulset.go
@@ -175,6 +175,8 @@ func getStatefulset(
 
 	labels := labelsForStatefulSet(cr, role)
 	podLabels := labelsForPod(cr, role)
+	annotations := annotationsForStatefulSet(cr, role)
+	podAnnotations := annotationsForPod(cr, role)
 	startupScript := getStartupScript(cr)
 
 	portInfoList, portsErr := catalog.PortsForRole(cr, role.Name)
@@ -317,7 +319,7 @@ func getStatefulset(
 			Namespace:       cr.Namespace,
 			OwnerReferences: ownerReferences(cr),
 			Labels:          labels,
-			Annotations:     annotationsForCluster(cr),
+			Annotations:     annotations,
 		},
 		Spec: appsv1.StatefulSetSpec{
 			PodManagementPolicy: appsv1.ParallelPodManagement,
@@ -329,7 +331,7 @@ func getStatefulset(
 			Template: v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels:      podLabels,
-					Annotations: annotationsForCluster(cr),
+					Annotations: podAnnotations,
 				},
 				Spec: v1.PodSpec{
 					AutomountServiceAccountToken: &useServiceAccount,

--- a/pkg/executor/util.go
+++ b/pkg/executor/util.go
@@ -94,7 +94,8 @@ func annotationsForStatefulSet(
 }
 
 // annotationsForPod generates a set of annotations appropriate for a pod in
-// the given role. This includes any user-requested annotations.
+// the given role. This includes any user-requested or global-config
+// annotations.
 func annotationsForPod(
 	cr *kdv1.KubeDirectorCluster,
 	role *kdv1.Role,
@@ -104,12 +105,15 @@ func annotationsForPod(
 	for name, value := range role.PodAnnotations {
 		result[name] = value
 	}
+	for globalName, globalValue := range shared.GetPodAnnotations() {
+		result[globalName] = globalValue
+	}
 	return result
 }
 
 // annotationsForService generates a set of annotations appropriate for the
-// services created for a cluster. This includes any user-requested annotations.
-// role may be nil if this is the headless service.
+// services created for a cluster. This includes any user-requested or
+// global-config annotations.vrole may be nil if this is the headless service.
 func annotationsForService(
 	cr *kdv1.KubeDirectorCluster,
 	role *kdv1.Role,
@@ -122,6 +126,9 @@ func annotationsForService(
 		result = annotationsForRole(cr, role)
 		for name, value := range role.ServiceAnnotations {
 			result[name] = value
+		}
+		for globalName, globalValue := range shared.GetServiceAnnotations() {
+			result[globalName] = globalValue
 		}
 	}
 	return result
@@ -167,7 +174,7 @@ func labelsForStatefulSet(
 }
 
 // labelsForPod generates a set of resource labels appropriate for a pod in
-// the given role. This includes any user-requested labels.
+// the given role. This includes any user-requested or global-config labels.
 func labelsForPod(
 	cr *kdv1.KubeDirectorCluster,
 	role *kdv1.Role,
@@ -177,12 +184,15 @@ func labelsForPod(
 	for name, value := range role.PodLabels {
 		result[name] = value
 	}
+	for globalName, globalValue := range shared.GetPodLabels() {
+		result[globalName] = globalValue
+	}
 	return result
 }
 
 // labelsForService generates a set of resource labels appropriate for the
-// services created for a cluster. This includes any user-requested labels.
-// role may be nil if this is the headless service.
+// services created for a cluster. This includes any user-requested or
+// global-config labels. role may be nil if this is the headless service.
 func labelsForService(
 	cr *kdv1.KubeDirectorCluster,
 	role *kdv1.Role,
@@ -195,6 +205,9 @@ func labelsForService(
 		result = labelsForRole(cr, role)
 		for name, value := range role.ServiceLabels {
 			result[name] = value
+		}
+		for globalName, globalValue := range shared.GetServiceLabels() {
+			result[globalName] = globalValue
 		}
 	}
 	return result

--- a/pkg/shared/globalconfig.go
+++ b/pkg/shared/globalconfig.go
@@ -115,6 +115,54 @@ func GetMasterEncryptionKey() (string, error) {
 	return "", errors.New("globalConfig is required to generate master encryption key")
 }
 
+// GetPodLabels returns the pod labels specified in the config, or nil if no
+// config.
+func GetPodLabels() map[string]string {
+
+	globalConfigLock.RLock()
+	defer globalConfigLock.RUnlock()
+	if globalConfig != nil {
+		return globalConfig.Spec.PodLabels
+	}
+	return nil
+}
+
+// GetPodAnnotations returns the pod annotations specified in the config, or
+// nil if no config.
+func GetPodAnnotations() map[string]string {
+
+	globalConfigLock.RLock()
+	defer globalConfigLock.RUnlock()
+	if globalConfig != nil {
+		return globalConfig.Spec.PodAnnotations
+	}
+	return nil
+}
+
+// GetServiceLabels returns the service labels specified in the config, or nil
+// if no config.
+func GetServiceLabels() map[string]string {
+
+	globalConfigLock.RLock()
+	defer globalConfigLock.RUnlock()
+	if globalConfig != nil {
+		return globalConfig.Spec.ServiceLabels
+	}
+	return nil
+}
+
+// GetServiceAnnotations returns the service annotations specified in the
+// config, or nil if no config.
+func GetServiceAnnotations() map[string]string {
+
+	globalConfigLock.RLock()
+	defer globalConfigLock.RUnlock()
+	if globalConfig != nil {
+		return globalConfig.Spec.ServiceAnnotations
+	}
+	return nil
+}
+
 // RemoveGlobalConfig removes the current globalConfig
 func RemoveGlobalConfig() {
 

--- a/pkg/validator/config.go
+++ b/pkg/validator/config.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/api/admission/v1beta1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
 // configPatchSpec is used to create the PATCH operation for populating
@@ -264,6 +265,15 @@ func admitKDConfigCR(
 	}
 
 	patches, valErrors = validateOrPopulateMasterEncryptionKey(configCR, patches, valErrors)
+
+	valErrors, _ = validateLabelsAndAnnotations(
+		field.NewPath("spec"),
+		configCR.Spec.PodLabels,
+		configCR.Spec.PodAnnotations,
+		configCR.Spec.ServiceLabels,
+		configCR.Spec.ServiceAnnotations,
+		valErrors,
+	)
 
 	if len(valErrors) == 0 {
 		if len(patches) != 0 {


### PR DESCRIPTION
Allow user-specified annotation in the same way we allow user-specified labels.

Also, let the KD global config specify labels/annotations that will be applied to any pod or member service.

A specific use case for this is to control Velero backups, where we NEVER want Velero to try to back up the tmpfs volumes of KD-created pods. With this change, you can use the global config to specify the following pod annotation to achieve that: backup.velero.io/backup-volumes-excludes: tmpfs-tmp,tmpfs-run,tmpfs-run-lock