### PR TITLE
allow kdapp to specify min persistent storage size

### DIFF
--- a/deploy/kubedirector/kubedirector.hpe.com_kubedirectorapps_crd.yaml
+++ b/deploy/kubedirector/kubedirector.hpe.com_kubedirectorapps_crd.yaml
@@ -164,6 +164,16 @@ spec:
                       amd.com/gpu:
                         type: string
                         pattern: '^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'
+                  minStorage:
+                    type: object
+                    nullable: true
+                    required: [size]
+                    properties:
+                      size:
+                        type: string
+                        pattern: '^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'
+                      ephemeralModeSupported:
+                        type: boolean
             config:
               type: object
               required: [selectedRoles, roleServices]

--- a/pkg/apis/kubedirector/v1beta1/kubedirectorapp_types.go
+++ b/pkg/apis/kubedirector/v1beta1/kubedirectorapp_types.go
@@ -110,7 +110,14 @@ type NodeRole struct {
 	PersistDirs   *[]string            `json:"persistDirs,omitempty"`
 	EventList     *[]string            `json:"eventList,omitempty"`
 	MinResources  *corev1.ResourceList `json:"minResources,omitempty"`
+	MinStorage    *MinStorage          `json:"minStorage,omitempty"`
 	ContainerSpec *ContainerSpec       `json:"containerSpec,omitempty"`
+}
+
+// MinStorage describes the minimum persistent storage requirement, if any.
+type MinStorage struct {
+	Size                   string `json:"size"`
+	EphemeralModeSupported bool   `json:"ephemeralModeSupported"`
 }
 
 //ContainerSpec comments

--- a/pkg/catalog/interrogate.go
+++ b/pkg/catalog/interrogate.go
@@ -111,13 +111,22 @@ func GetRoleCardinality(
 	return int32(count), isScaleOut
 }
 
-// GetRoleMinResources is a utility function that fetching the minimum resources
+// GetRoleMinResources is a utility function that fetches the minimum resources
 // for a given app role
 func GetRoleMinResources(
 	appRole *kdv1.NodeRole,
 ) *v1.ResourceList {
 
 	return appRole.MinResources
+}
+
+// GetRoleMinStorage is a utility function that fetches the minimum persistent
+// storage spec given app role
+func GetRoleMinStorage(
+	appRole *kdv1.NodeRole,
+) *kdv1.MinStorage {
+
+	return appRole.MinStorage
 }
 
 // PortsForRole returns list of service port info (id and port num) for a given role.

--- a/pkg/validator/app.go
+++ b/pkg/validator/app.go
@@ -25,6 +25,7 @@ import (
 	"github.com/bluek8s/kubedirector/pkg/shared"
 	"k8s.io/api/admission/v1beta1"
 	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -264,6 +265,18 @@ func validateRoles(
 							packageURLValue: &packageURL{URL: *globalSetupPackageURL},
 						},
 					},
+				)
+			}
+		}
+		if role.MinStorage != nil {
+			_, minErr := resource.ParseQuantity(role.MinStorage.Size)
+			if minErr != nil {
+				valErrors = append(
+					valErrors,
+					fmt.Sprintf(
+						invalidMinStorageDef,
+						role.ID,
+					),
 				)
 			}
 		}

--- a/pkg/validator/types.go
+++ b/pkg/validator/types.go
@@ -81,11 +81,14 @@ const (
 	invalidStorageSize  = "Storage size for role (%s) should be greater than zero."
 	invalidStorageClass = "Unable to fetch storageClass object with the provided name(%s)."
 
+	invalidMinStorageDef = "Minimum storage size for role (%s) is incorrectly defined."
+
 	invalidRoleStorageClass = "Unable to fetch storageClassName(%s) for role(%s)."
 	noDefaultStorageClass   = "storageClassName is not specified for one or more roles, and no default storage class is available."
 	badDefaultStorageClass  = "storageClassName is not specified for one or more roles, and default storage class (%s) is not available on the system."
 
 	invalidResource = "Specified resource(\"%s\") value(\"%s\") for role(\"%s\") is invalid. Minimum value must be \"%s\"."
+	invalidStorage  = "Specified persistent storage size(\"%s\") for role(\"%s\") is invalid. Minimum size must be \"%s\"."
 	invalidSrcURL   = "Unable to access the specified URL(\"%s\") in file injection spec for the role (%s). error: %s."
 
 	maxMemberLimit = "Maximum number of total members per KD cluster supported is %d."


### PR DESCRIPTION
closes issue #536

If an app is going to use persistent storage, it probably has a size that is the minimum necessary for the app to be successfully brought up. Let's express that.

When the kdcluster asks for resources, persistent storage is in a different section than other resources (for reasons having to do with how these requests get expressed in K8s resources). We'll have a parallel construction in the kdapp here... the new minStorage optional object in a role definition will be parallel to minResources.

Omitting minStorage means that a role doesn't care whether you give it a PV, and if you do give it a PV, it doesn't care what size it is. Generally this should only be omitted for a truly ephmereal role.

If minStorage is specified, you have to provide a size property (with a value in "quantity" format) which is the necessary minimum PV size.

There's an optional bool properly in minStorage, named ephemeralModeSupported. False by default. If you set this true, it means the role members will be OK running without a PV. But if you do give it a PV, the minimum size will be enforced. This option is to support an app where a certain role could make use of persistent storage as an enhancement, but it is not a requirement.

So this is the matrix of behaviors:

** no minStorage in the kdapp:
* ok to create kdcluster role without any persistent storage
* ok to create kdcluster role with persistent storage of any size

** minStorage in the kdapp, ephemeralModeSupported is true:
* ok to create kdcluster role without any persistent storage
* NOT OK to create kdcluster role with persistent storage < min
* ok to create kdcluster role with persistent storage >= min

** minStorage in the kdapp, ephemeralModeSupported is false:
* NOT OK to create kdcluster role without any persistent storage
* NOT OK to create kdcluster role with persistent storage < min
* ok to create kdcluster role with persistent storage >= min