### PR TITLE
Added pause until validator service start

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,6 +159,9 @@ deploy:
         done
 	@echo
 	@echo
+	while ! kubectl get service kubedirector-validator &> /dev/null; do \
+	    sleep 3; \
+	done
 	@echo \* Creating example application types...
 	kubectl create -f deploy/example_catalog/
 	@echo


### PR DESCRIPTION
Quick-fix for the Makefile deploy target problem, when application examples are started to deploy but `kubectl-validator` service is not ready, which causes the error:
`Error from server (InternalError): error when creating "deploy/example_catalog/cr-app-cassandra-3.11.json": Internal error occurred: failed calling webhook "hard-validate-cr.kubedirector.hpe.com": Post "https://kubedirector-validator.hpecp.svc:443/validate?timeout=30s": service "kubedirector-validator" not found`
