### PR TITLE
issue #537: prune down the default persist dirs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ bin_name := kubedirector
 
 home_dir := /home/kubedirector
 
-configcli_version := 0.7.2
+configcli_version := 0.8
 configcli_pkg := v$(configcli_version).tar.gz
 configcli_pkg_pattern := v*.tar.gz
 configcli_container_pkg := configcli.tgz

--- a/Makefile
+++ b/Makefile
@@ -187,7 +187,7 @@ redeploy:
 	@set -e; \
         podname=`kubectl get -o jsonpath='{.items[0].metadata.name}' pods -l name=${project_name}`; \
         kubectl exec $$podname -- mv -f ${home_dir}/${configcli_container_pkg} ${home_dir}/${configcli_container_pkg}.bak || true; \
-        kubectl cp build/${configcli_container_pkg} $$podname:${home_dir}/${configcli_container_pkg}; \
+        kubectl cp build/${configcli_pkg} $$podname:${home_dir}/${configcli_container_pkg}; \
         kubectl exec $$podname -- chgrp 0 ${home_dir}/${configcli_container_pkg}; \
         kubectl exec $$podname -- chmod ug=rw ${home_dir}/${configcli_container_pkg}
 	@echo

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,11 @@ project_name := kubedirector
 bin_name := kubedirector
 
 home_dir := /home/kubedirector
+
 configcli_version := 0.7.2
+configcli_pkg := v$(configcli_version).tar.gz
+configcli_pkg_pattern := v*.tar.gz
+configcli_container_pkg := configcli.tgz
 
 local_deploy_yaml := deploy/kubedirector/deployment-localbuilt.yaml
 
@@ -35,7 +39,6 @@ sedignorecase =
 endif
 
 build_dir := build/_output
-configcli_dest := build/configcli.tgz
 goarch := amd64
 cgo_enabled := 0
 
@@ -67,9 +70,12 @@ build: configcli pkg/apis/kubedirector/v1beta1/zz_generated.deepcopy.go version-
 	@echo
 
 configcli:
-	@if [ -e $(configcli_dest) ]; then exit 0; fi;                             \
+	@if [ -e build/$(configcli_container_pkg) ] && [ -e build/$(configcli_pkg) ]; then exit 0; fi;                             \
      echo "* Downloading configcli package ...";                               \
-     curl -L -o $(configcli_dest) https://github.com/bluek8s/configcli/archive/v$(configcli_version).tar.gz
+     rm -f build/$(configcli_container_pkg) build/$(configcli_pkg_pattern); \
+     cd build && \
+     curl -L -O https://github.com/bluek8s/configcli/archive/$(configcli_pkg) && \
+     ln -sf $(configcli_pkg) $(configcli_container_pkg)
 
 pkg/apis/kubedirector/v1beta1/zz_generated.deepcopy.go:  \
         pkg/apis/kubedirector/v1beta1/${app_resource_name}_types.go \
@@ -180,10 +186,10 @@ redeploy:
 	@echo \* Injecting new configcli package...
 	@set -e; \
         podname=`kubectl get -o jsonpath='{.items[0].metadata.name}' pods -l name=${project_name}`; \
-        kubectl exec $$podname -- mv -f ${home_dir}/configcli.tgz ${home_dir}/configcli.tgz.bak || true; \
-        kubectl cp ${configcli_dest} $$podname:${home_dir}/configcli.tgz; \
-        kubectl exec $$podname -- chgrp 0 ${home_dir}/configcli.tgz; \
-        kubectl exec $$podname -- chmod ug=rw ${home_dir}/configcli.tgz
+        kubectl exec $$podname -- mv -f ${home_dir}/${configcli_container_pkg} ${home_dir}/${configcli_container_pkg}.bak || true; \
+        kubectl cp build/${configcli_container_pkg} $$podname:${home_dir}/${configcli_container_pkg}; \
+        kubectl exec $$podname -- chgrp 0 ${home_dir}/${configcli_container_pkg}; \
+        kubectl exec $$podname -- chmod ug=rw ${home_dir}/${configcli_container_pkg}
 	@echo
 	@echo \* Injecting and starting new KubeDirector binary...
 	@set -e; \
@@ -339,7 +345,7 @@ clean:
 	-rm -f deploy/kubedirector/deployment-localbuilt.yaml
 	-rm -f pkg/apis/kubedirector/v1beta1/zz_generated.deepcopy.go
 	-rm -rf ${build_dir}
-	-rm -f ${configcli_dest}
+	-rm -f build/$(configcli_container_pkg) build/$(configcli_pkg_pattern)
 
 modules:
 	go mod tidy

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -5,9 +5,9 @@ ENV OPERATOR=/home/kubedirector/kubedirector \
     USER_NAME=kubedirector \
     USER_HOME=/home/kubedirector
 
-# Support ps and killall, for redeploy.
+# Support ps, killall, and tar for redeploy.
 RUN microdnf update -y && rm -rf /var/cache/yum
-RUN microdnf -y install --nodocs psmisc procps-ng \
+RUN microdnf -y install --nodocs psmisc procps-ng tar \
     && microdnf clean all
 
 COPY build/bin/entrypoint /usr/local/bin/entrypoint

--- a/deploy/example_catalog/cr-app-cassandra-3.11.json
+++ b/deploy/example_catalog/cr-app-cassandra-3.11.json
@@ -8,7 +8,7 @@
     "spec" : {
         "logoURL": "https://raw.githubusercontent.com/bluedatainc/solutions/master/MLOps/logos/cassandra-3.11.png",
         "systemdRequired" : true,
-        "defaultPersistDirs" : ["/usr", "/opt", "/var", "/data"],
+        "defaultPersistDirs" : ["/var/lib/cassandra", "/var/log/cassandra", "/data"],
         "defaultEventList" : ["configure", "addnodes", "delnodes"],
         "capabilities" : [
             "SYS_RESOURCE",
@@ -43,7 +43,7 @@
             "description": "Cassandra 3.11 on centos 7.x"
         },
         "distroID": "bluedata/cassandra311",
-        "version": "3.1",
+        "version": "3.2",
         "configSchemaVersion": 7,
         "services": [
             {
@@ -69,7 +69,8 @@
             }
         ],
         "defaultConfigPackage": {
-            "packageURL": "file:///opt/configscripts/appconfig-3.1.tgz"
+            "packageURL": "file:///opt/configscripts/appconfig-3.1.tgz",
+            "useNewSetupLayout": true
         },
         "roles": [
             {

--- a/deploy/example_catalog/cr-app-jupyter-notebook.json
+++ b/deploy/example_catalog/cr-app-jupyter-notebook.json
@@ -29,7 +29,7 @@
             "AIML_category": "Notebook"
         },
         "distroID": "hpecp/jupyter-notebook",
-        "version": "2.0",
+        "version": "2.1",
         "configSchemaVersion": 7,
         "services": [{
                 "endpoint": {
@@ -55,14 +55,14 @@
             }
         ],
         "defaultConfigPackage": {
-            "packageURL": "file:///opt/configscript/appconfig.tgz"
+            "packageURL": "file:///opt/configscript/appconfig.tgz",
+            "useNewSetupLayout", true
         },
         "roles": [{
             "imageRepoTag": "bluedata/kd-notebook:2.0",
             "cardinality": "1",
             "id": "controller",
             "persistDirs": [
-              "/opt",
               "/home"
             ]
         }]

--- a/deploy/kubedirector/kubedirector.hpe.com_kubedirectorapps_crd.yaml
+++ b/deploy/kubedirector/kubedirector.hpe.com_kubedirectorapps_crd.yaml
@@ -61,6 +61,8 @@ spec:
                 packageURL:
                   type: string
                   pattern: '^(file|https?)://.+\.tgz$'
+                useNewSetupLayout:
+                  type: boolean
             services:
               type: array
               items:
@@ -127,6 +129,8 @@ spec:
                       packageURL:
                         type: string
                         pattern: '^(file|https?)://.+\.tgz$'
+                      useNewSetupLayout:
+                        type: boolean
                   persistDirs:
                     type: array
                     items:

--- a/doc/app-filesystem-layout.md
+++ b/doc/app-filesystem-layout.md
@@ -1,0 +1,99 @@
+#### OVERVIEW
+
+In the container image used for a particular role of a kdapp, generally the filesystem can have whatever layout the app requires. However there are a few KubeDirector-specific considerations that it is good to be aware of, especially if these role members can/must use persistent storage or if they have a specified application setup package.
+
+Most of these KubeDirector behaviors are affected by a boolean flag in the kdapp resource. This is the "useNewSetupLayout" flag supported by KubeDirector v0.8.0 and later releases, which can be found in the "configPackage" object for a role (or in the top-level "defaultConfigPackage"). This flag defaults to false for backward compatibility, but you should set it to true for any new kdapp development. It's also worth considering making an update to old kdapps so that they can set this flag to true as well. The effects of this flag are covered in detail in the sections below.
+
+#### PERSISTED DIRECTORIES
+
+##### Concepts
+
+Normally any changes to the container filesystem will be lost if a container needs to be restarted, for example if its hosting node goes down.
+
+However, if you specify an amount of persistent storage for a role (when launching a kdcluster), each member in that role will get to use an associated PV of the requested size. This PV will store the content of certain filesystem directories.
+
+Ideally these directories would ONLY contain data that is created or changed at runtime. However, in many older applications there are directories that contain a mix of immutable files (e.g. binaries), files from the container image that will be changed at runtime, and files that will be created at runtime. For these directories to have correct content on the PV, a one-time cost must be incurred at kdcluster startup, to copy all of that initial directory content over to the PV.
+
+The set of directories-to-persist is a union of those requested by the kdapp and those required by KubeDirector itself, as described below. This includes resolving any requests that are subdirectories of other requests; for example if the app requests "/usr/local" and KubeDirector requests "/usr/local/bin", then all of "/usr/local" will be persisted on the PV.
+
+##### Persisted on kdapp request
+
+The kdapp resource can define directories containing data used by the application that must be persisted across container restart. This directory list is in the "persistDirs" for each kdapp role (or in the top-level "defaultPersistDirs").
+
+The persistDirs list should specify the necessary directories-to-persist as tightly as possible. For example if you only need to persist the contents of a directory "/usr/share/foo" then that should be what you specify, as opposed to persisting all of "/usr" or "/usr/share". Casting too wide a net with the persistDirs can have a dramatic impact on kdcluster startup time when a PV is requested.
+
+##### Always persisted
+
+If kdcluster role requests a PV, then KubeDirector will mandate that "/etc" will always be in the list of persisted directories. This is true regardless of the kdapp configuration. Any kdapp can depend on this invariant, i.e. a kdapp does not need to specifically request persistence for "/etc" -- although doing so would be harmless.
+
+##### Persisted if config package is used
+
+If a role requests a PV and the kdapp defines a config package to be used in that role, then KubeDirector itself will have additional persistent directory requests.
+
+Note that a kdapp should NOT depend on this info. If a kdapp role also requires the persistence of one of the directories mentioned below, the kdapp should explicitly request that in the role's persistDirs. This additional persistence behavior is described here only to help with kdapp development and debugging.
+
+In the case where useNewSetupLayout is true, KubeDirector will persist these directories: "/etc", "/opt/guestconfig", "/var/log/guestconfig", "/usr/local/bin", "/usr/local/lib"
+
+In the case where useNewSetupLayout is false, KubeDirector will persist these directories: "/etc", "/opt", "/usr"
+
+#### CONFIG PACKAGE LOCATION
+
+If an application config package is defined for a role, then when a member of that role first starts up the package will be installed in the member's container.
+
+Regardless of whether the package comes from a "file://" location on the container image or is fetched by http(s), at container startup it will be extracted into "/opt/guestconfig" by KubeDirector. The exact sequence of steps (executed as the "container user") are:
+
+```bash
+cd /opt/guestconfig/
+rm -rf /opt/guestconfig/*
+curl -L <config package URL> -o appconfig.tgz
+tar xzf appconfig.tgz
+chmod +x /opt/guestconfig/*/startscript
+rm -rf /opt/guestconfig/appconfig.tgz
+```
+
+The "startscript" is what will then be executed by KubeDirector as the script hook for lifecycle events.
+
+Note that "/opt/guestconfig" is one of the locations mounted to persistent storage, if the member is using a PV. Therefore if this container is restarted, these steps (and initial configuration through the startscript) will normally be re-run only if the member is NOT using a PV.
+
+If the member IS using a PV, these steps (and initial configuration) will be re-run only if one of the following circumstances holds true:
+* The container was restarted before initial configuration could finish.
+* The previous run of initial configuration ended in an error.
+
+Since "/var/log/guestconfig" will also be persisted (if useNewSetupLayout is true), then ideally any important logging from the startscript should go to into the "/opt/guestconfig" or "/var/log/guestconfig" directory.
+
+KubeDirector itself will log the stderr and stdout of the most recent startscript invocation to the "configure.stderr", and "configure.stdout" files in "/opt/guestconfig". The "/opt/guestconfig/configure.status" file also contains the container ID and exit status from the last run of the startscript, concatenated by an "=" character.
+
+#### CONFIGCLI ARTIFACTS LOCATION
+
+At any time that config package setup is going to be (re)run, KubeDirector also checks to see whether the [configcli](https://github.com/bluek8s/configcli) Python modules and scripts need to be installed in the container. The "canary" files used for this determination are "/usr/local/bin/configcli" and "/usr/bin/configcli" ... if either of those files already exist, then configcli setup is skipped.
+
+KubeDirector does the configcli installation by injecting the configcli archive into the container's "/tmp" directory and then running the following steps (executed as the "container user"):
+
+```bash
+cd /tmp
+tar xzf configcli.tgz
+chmod +x /tmp/configcli-*/install
+# <the configcli install script is executed at this point; see below>
+rm -rf /tmp/configcli-*
+rm -f /tmp/configcli.tgz
+```
+
+The configcli install script is invoked with different arguments depending on whether useNewSetupLayout is true for this member's role. The upshot in the case where useNewSetupLayout is true:
+* configcli Python modules installed under "/usr/local/lib" (exact location depends on version of container's default "python" executable)
+* configcli scripts and alias links ("bdvcli", "bd_vcli", "ccli", "configcli", "configmacro") installed under "/usr/local/bin"
+
+Alternately, in the case where useNewSetupLayout is false:
+* configcli Python modules installed under "/usr/lib"
+* configcli scripts and alias links installed under "/usr/bin"
+
+If useNewSetupLayout is true, then KubeDirector will configure the container so that the "PYTHONUSERBASE" environment variable is set to "/usr/local" for the "container user". Therefore when KubeDirector invokes the startscript, and startscript uses configcli, these Python modules will be loaded without issue. If for some reason your app requires that some other user account inside the container be able to load these modules, then some additional Python directories configuration may be needed for that user.
+
+#### CONFIGCLI LEGACY SUPPORT
+
+Application images and config packages from before KubeDirector v0.8.0 may not have "/usr/local/bin" on the PATH used when the startscript runs, and/or the scripts in the config package may have hardcoded paths to the previous "/usr/bin" locations of the configcli scripts. This has the potential to cause extra work for app developers that want to change an existing kdapp to make it work with useNewSetupLayout=true.
+
+To take this particular issue off the table, KubeDirector creates symlinks in the old "/usr/bin" locations when useNewSetupLayout is true. Since "/usr" is not (by default) persisted when useNewSetupLayout is true, KubeDirector will re-create those symlinks if the pod container is restarted.
+
+#### CONFIGMETA LOCATION
+
+The "configmeta.json" file read by configcli is located in the "/etc/guestconfig" directory. If at all possible however it should not be directly parsed; access this information using the configcli scripts and Python modules.

--- a/doc/gke-notes.md
+++ b/doc/gke-notes.md
@@ -7,7 +7,7 @@ If you're starting from scratch with GKE, the first few sections of [Google's GK
 With gcloud configured to use the appropriate project, you can then launch a GKE cluster.
 
 Two important notes to be aware of when creating a GKE cluster:
-* Be sure to specify Kubernetes version 1.14 or later.
+* Be sure to specify a Kubernetes version that is in the range of KubeDirector-supported versions.
 * Choose a [machine type](https://cloud.google.com/compute/docs/machine-types) with enough resources to host at least one virtual cluster member.
 
 For a list of available GKE Kubernetes versions you can run the following query. For simplest cluster launching syntax, you would want to find a version that is in both the validMasterVersions list and the validNodeVersions list.
@@ -15,9 +15,9 @@ For a list of available GKE Kubernetes versions you can run the following query.
     gcloud container get-server-config
 ```
 
-So for example, at the time this doc was written, the following gcloud command would create a 3-node GKE cluster named "my-gke" using Kubernetes version 1.16.13 and the n1-highmem-4 machine type:
+So for example, at the time this doc was written, the following gcloud command would create a 3-node GKE cluster named "my-gke" using Kubernetes version 1.20.12 and the n1-highmem-4 machine type:
 ```bash
-    gcloud container clusters create my-gke --cluster-version=1.16.13-gke.1 --machine-type=n1-highmem-4
+    gcloud container clusters create my-gke --cluster-version=1.20.12-gke.1500 --machine-type=n1-highmem-4
 ```
 At the current time when you're reading this, you may need or want to use some different value for cluster-version.
 

--- a/pkg/apis/kubedirector/v1beta1/decode.go
+++ b/pkg/apis/kubedirector/v1beta1/decode.go
@@ -36,7 +36,7 @@ func (setupPackage *SetupPackage) UnmarshalJSON(
 		return nil
 	}
 
-	if err := json.Unmarshal(data, &setupPackage.PackageURL); err != nil {
+	if err := json.Unmarshal(data, &setupPackage.Info); err != nil {
 		return err
 	}
 	setupPackage.IsNull = false

--- a/pkg/apis/kubedirector/v1beta1/kubedirectorapp_types.go
+++ b/pkg/apis/kubedirector/v1beta1/kubedirectorapp_types.go
@@ -69,14 +69,16 @@ type Label struct {
 // "explicitly set null". Therefore "operator-sdk generate crds" cannot be
 // used to generate a correct CRD in this case.
 type SetupPackage struct {
-	IsSet      bool
-	IsNull     bool
-	PackageURL SetupPackageURL
+	IsSet  bool
+	IsNull bool
+	Info   SetupPackageInfo
 }
 
-// SetupPackageURL is the URL of the setup package.
-type SetupPackageURL struct {
-	PackageURL string `json:"packageURL"`
+// SetupPackageInfo is the URL of the setup package, plus a flag on whether
+// the new setup layout (for configcli and persisted dirs) should be used.
+type SetupPackageInfo struct {
+	PackageURL        string `json:"packageURL"`
+	UseNewSetupLayout bool   `json:"useNewSetupLayout"`
 }
 
 // Service describes a network endpoint that should be exposed for external

--- a/pkg/catalog/interrogate.go
+++ b/pkg/catalog/interrogate.go
@@ -205,19 +205,19 @@ func ImageForRole(
 	)
 }
 
-// AppSetupPackageURL returns the app setup package url for a given role. The
+// AppSetupPackageInfo returns the app setup package info for a given role. The
 // fact that this function is invoked means that setup package was specified
 // either for the node role or the application as a whole.
-func AppSetupPackageURL(
+func AppSetupPackageInfo(
 	cr *kdv1.KubeDirectorCluster,
 	role string,
-) (string, error) {
+) (*kdv1.SetupPackageInfo, error) {
 
 	// Fetch the app type definition if we haven't yet cached it in this
 	// handler pass.
 	appCR, err := GetApp(cr)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	for _, nodeRole := range appCR.Spec.NodeRoles {
@@ -227,16 +227,16 @@ func AppSetupPackageURL(
 			// setupPackage will always be set because we mutated the spec during
 			// validation.
 			if setupPackage.IsNull == false {
-				return setupPackage.PackageURL.PackageURL, nil
+				return &setupPackage.Info, nil
 			}
 
 			// No config package for this role.
-			return "", nil
+			return nil, nil
 		}
 	}
 
 	// Should never reach here.
-	return "", fmt.Errorf(
+	return nil, fmt.Errorf(
 		"Role {%s} not found for app {%s} when searching for config package",
 		role,
 		cr.Spec.AppID,

--- a/pkg/controller/kubedirectorcluster/types.go
+++ b/pkg/controller/kubedirectorcluster/types.go
@@ -101,6 +101,15 @@ const (
 	echo -n $? >> ` + appPrepConfigStatus + `' &`
 )
 
+// Support for old images/scripts that expect configcli to be in /usr/bin.
+const (
+	legacyLinksCmd = `ln -sf /usr/local/bin/configcli /usr/bin/bdvcli &&
+	ln -sf /usr/local/bin/configcli /usr/bin/bd_vcli &&
+	ln -sf /usr/local/bin/configcli /usr/bin/configcli &&
+	ln -sf /usr/local/bin/ccli /usr/bin/ccli &&
+	ln -sf /usr/local/bin/configmacro /usr/bin/configmacro`
+)
+
 const (
 	zeroPortsService = "n/a"
 )

--- a/pkg/controller/kubedirectorcluster/types.go
+++ b/pkg/controller/kubedirectorcluster/types.go
@@ -16,6 +16,7 @@ package kubedirectorcluster
 
 import (
 	kdv1 "github.com/bluek8s/kubedirector/pkg/apis/kubedirector/v1beta1"
+	"github.com/bluek8s/kubedirector/pkg/shared"
 	appsv1 "k8s.io/api/apps/v1"
 )
 
@@ -71,19 +72,20 @@ const (
 )
 
 const (
-	configMetaFile      = "/etc/guestconfig/configmeta.json"
-	configcliSrcFile    = "/home/kubedirector/configcli.tgz"
-	configcliDestFile   = "/tmp/configcli.tgz"
-	configcliInstallCmd = `cd /tmp && tar xzf configcli.tgz &&
-	chmod +x /tmp/configcli-*/install && /tmp/configcli-*/install &&
+	configMetaFile         = "/etc/guestconfig/configmeta.json"
+	configcliSrcFile       = "/home/kubedirector/configcli.tgz"
+	configcliDestFile      = "/tmp/configcli.tgz"
+	configcliInstallCmdFmt = `cd /tmp && tar xzf configcli.tgz &&
+	chmod +x /tmp/configcli-*/install && /tmp/configcli-*/install %[1]s &&
 	rm -rf /tmp/configcli-* && rm -f /tmp/configcli.tgz &&
-	ln -sf /usr/bin/configcli /usr/bin/bdvcli &&
-	ln -sf /usr/bin/configcli /usr/bin/bd_vcli`
-	configcliTestFile  = "/usr/bin/configcli"
-	appPrepStartscript = "/opt/guestconfig/*/startscript"
-	appPrepInitCmd     = `cd /opt/guestconfig/ &&
+	ln -sf %[2]s/bin/configcli %[2]s/bin/bdvcli &&
+	ln -sf %[2]s/bin/configcli %[2]s/bin/bd_vcli`
+	configcliTestFile       = shared.ConfigCliLoc + "/bin/configcli"
+	configcliLegacyTestFile = shared.ConfigCliLegacyLoc + "/bin/configcli"
+	appPrepStartscript      = "/opt/guestconfig/*/startscript"
+	appPrepInitCmdFmt       = `cd /opt/guestconfig/ &&
 	rm -rf /opt/guestconfig/* &&
-	curl -L {{APP_CONFIG_URL}} -o appconfig.tgz &&
+	curl -L %s -o appconfig.tgz &&
 	tar xzf appconfig.tgz &&
 	chmod +x ` + appPrepStartscript + ` &&
 	rm -rf /opt/guestconfig/appconfig.tgz`

--- a/pkg/shared/types.go
+++ b/pkg/shared/types.go
@@ -48,6 +48,16 @@ const (
 	// DefaultNamingScheme - default naming scheme if not specified in
 	// the configCR
 	DefaultNamingScheme = "UID"
+
+	// ConfigCliLoc is the root directory for installing configcli scripts
+	// and python modules within the member container, if the role asks for
+	// the new setup layout.
+	ConfigCliLoc = "/usr/local"
+
+	// ConfigCliLegacyLoc is the root directory for installing configcli scripts
+	// and python modules within the member container, if the role uses the
+	// old setup layout.
+	ConfigCliLegacyLoc = "/usr"
 )
 
 // Event reason constants for recording events


### PR DESCRIPTION
This change allows a kdapp resource to opt-in to a different filesystem layout which can make PV initialization much faster.

The best functional description is in the new app-filesystem-layout.md doc contained in this changelist.

The Makefile change here is tangentially related; since a new configcli package is used, I want the build process to make sure that it will get the new configcli if the currently downloaded package is not the right one.

I'll add some other notes as code comments in the changes.

====================

A quick example of the benefits of the new layout. One my usual test system (granted, VMs with slow I/O) launching jupyter notebook with a PV can take hours with the old layout. With the new layout, less than a minute.