### PR TITLE
allow startscript to open the /etc/guestconfig perms

### DIFF
--- a/pkg/controller/kubedirectorcluster/members.go
+++ b/pkg/controller/kubedirectorcluster/members.go
@@ -251,20 +251,6 @@ func handleReadyMembers(
 
 	connectionsVersion := getConnectionVersion(reqLogger, cr, role)
 
-	// Fetch setup package info
-	setupInfo, setupInfoErr := catalog.AppSetupPackageInfo(cr, role.roleStatus.Name)
-	if setupInfoErr != nil {
-		shared.LogErrorf(
-			reqLogger,
-			setupInfoErr,
-			cr,
-			shared.EventReasonRole,
-			"failed to fetch setup info for role{%s}",
-			role.roleStatus.Name,
-		)
-		return
-	}
-
 	ready := role.membersByState[memberReady]
 	var wgReady sync.WaitGroup
 	wgReady.Add(len(ready))
@@ -292,7 +278,7 @@ func handleReadyMembers(
 				executor.AppContainerName,
 				configMetaFile,
 				strings.NewReader(configmeta),
-				setupInfo.UseNewSetupLayout,
+				false,
 			)
 			if createFileErr != nil {
 				shared.LogErrorf(


### PR DESCRIPTION
This allows for an intermediate step of app development if an app needs to adopt the new persistent dirs layout but would be broken by the new more restrictive perms on /etc/guestconfig. This lets the startscript be explicit about the need/desire to share configmeta.json with other user accounts, without KD interfering.

The functional change in KD is that we will only set the 700 perms on /etc/guestconfig when first creating that directory and configmeta.json; we'll no longer re-set the perms each timme configmeta.json is updated.