### PR TITLE
deal with some deprecated API

### DIFF
--- a/deploy/example_catalog/cr-app-deployment-engine.json
+++ b/deploy/example_catalog/cr-app-deployment-engine.json
@@ -15,14 +15,10 @@
         "configSchemaVersion": 7,
         "label": {
             "name": "ML Inferencing",
-            "description": "Toolkit: TensorFLow, Keras, PyTorch, Scikit-Learn, XGBoost; Core: Pandas, numpy, Flask",
-            "AIML_category": "Deployment"
+            "description": "Toolkit: TensorFLow, Keras, PyTorch, Scikit-Learn, XGBoost; Core: Pandas, numpy, Flask"
         },
 
         "systemdRequired": true,
-        "categories": [
-            "AIML/Deployment"
-        ],
 
         "services": [{
                 "id": "haproxy-stats",
@@ -58,7 +54,6 @@
                 }
             },
             {
-                "exported_service": "AIML/Deployment",
                 "endpoint": {
                     "urlScheme": "http",
                     "path": "/<<model_name>>/<<model_version>>/predict",

--- a/deploy/example_catalog/cr-app-jupyter-notebook.json
+++ b/deploy/example_catalog/cr-app-jupyter-notebook.json
@@ -25,8 +25,7 @@
         },
         "label": {
             "name": "Jupyter Notebook with ML toolkits",
-            "description": "Toolkits: TensorFlow, Scikit-Learn, PyTorch, Keras, XGBoost, LightGBM, Hyperopt; Core: Numpy, Scipy, Pandas, StatsModels, Anaconda, R kernel, Flask, Jupyter Notebook, Git, Jenkins; Visualization: Matplotlib, Seaborn, Plotly, Bokeh",
-            "AIML_category": "Notebook"
+            "description": "Toolkits: TensorFlow, Scikit-Learn, PyTorch, Keras, XGBoost, LightGBM, Hyperopt; Core: Numpy, Scipy, Pandas, StatsModels, Anaconda, R kernel, Flask, Jupyter Notebook, Git, Jenkins; Visualization: Matplotlib, Seaborn, Plotly, Bokeh"
         },
         "distroID": "hpecp/jupyter-notebook",
         "version": "2.1",

--- a/deploy/example_catalog/cr-app-training-engine.json
+++ b/deploy/example_catalog/cr-app-training-engine.json
@@ -10,9 +10,6 @@
 
     "spec": {
         "logoURL": "https://raw.githubusercontent.com/bluedatainc/solutions/master/MLOps/logos/training-engine-logo.png",
-        "categories": [
-            "AIML/Training"
-        ],
         "config": {
             "configMeta": {
                 "ml_engine": "python"
@@ -41,8 +38,7 @@
         "distroID": "hpecp/training-engine",
         "label": {
             "description": "Toolkit: TensorFlow, Scikit-Learn, PyTorch, Keras, XGBoost, LightGBM, hyperopt, Horovod; Core: Numpy, Scipy, Pandas, StatsModels, Anaconda, R kernel, Flask, CUDA; Visualization: Matplotlib, Seaborn, Plotly, Bokeh", 
-            "name": "ML Training Toolkit, with GPU support",
-            "AIML_category": "Training"
+            "name": "ML Training Toolkit, with GPU support"
         },
         "roles": [{
                 "cardinality": "1",
@@ -102,7 +98,6 @@
                     "port": 32700,
                     "urlScheme": "http"
                 },
-                "exported_service": "AIML/Training",
                 "id": "haproxy-train",
                 "label": {
                     "name": "Training API Server"

--- a/deploy/kubedirector/kubedirector.hpe.com_kubedirectorapps_crd.yaml
+++ b/deploy/kubedirector/kubedirector.hpe.com_kubedirectorapps_crd.yaml
@@ -156,6 +156,7 @@ spec:
                           tty:
                             type: boolean
                       minResources:
+                        x-kubernetes-preserve-unknown-fields: true
                         type: object
                         nullable: true
                         properties:

--- a/deploy/kubedirector/kubedirector.hpe.com_kubedirectorapps_crd.yaml
+++ b/deploy/kubedirector/kubedirector.hpe.com_kubedirectorapps_crd.yaml
@@ -1,10 +1,9 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: kubedirectorapps.kubedirector.hpe.com
 spec:
   group: kubedirector.hpe.com
-  version: v1beta1
   names:
     kind: KubeDirectorApp
     listKind: KubeDirectorAppList
@@ -13,227 +12,231 @@ spec:
     shortNames:
       - kdapp
   scope: Namespaced
-  validation:
-    openAPIV3Schema:
-      type: object
-      required: [apiVersion, kind, metadata, spec]
-      properties:
-        apiVersion:
-          type: string
-        kind:
-          type: string
-        metadata:
+  versions:
+    - name: v1beta1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
           type: object
+          required: [apiVersion, kind, metadata, spec]
           properties:
-            name:
+            apiVersion:
               type: string
-              maxLength: 63
-        spec:
-          type: object
-          required: [label, distroID, version, roles, config, configSchemaVersion]
-          properties:
-            label:
+            kind:
+              type: string
+            metadata:
               type: object
-              required: [name]
               properties:
                 name:
                   type: string
-                  minLength: 1
-                description:
-                  type: string
-            distroID:
-              type: string
-              minLength: 1
-            version:
-              type: string
-              minLength: 1
-            configSchemaVersion:
-              type: integer
-              minimum: 7
-            defaultImageRepoTag:
-              type: string
-              minLength: 1
-            defaultConfigPackage:
+                  maxLength: 63
+            spec:
               type: object
-              nullable: true
-              required: [packageURL]
+              required: [label, distroID, version, roles, config, configSchemaVersion]
               properties:
-                packageURL:
+                label:
+                  type: object
+                  required: [name]
+                  properties:
+                    name:
+                      type: string
+                      minLength: 1
+                    description:
+                      type: string
+                distroID:
                   type: string
-                  pattern: '^(file|https?)://.+\.tgz$'
-                useNewSetupLayout:
-                  type: boolean
-            defaultMaxLogSizeDump:
-              type: integer
-              minimum: 0
-            services:
-              type: array
-              items:
-                type: object
-                required: [id]
-                properties:
-                  id:
-                    type: string
-                    minLength: 1
-                    maxLength: 15
-                    pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
-                  label:
+                  minLength: 1
+                version:
+                  type: string
+                  minLength: 1
+                configSchemaVersion:
+                  type: integer
+                  minimum: 7
+                defaultImageRepoTag:
+                  type: string
+                  minLength: 1
+                defaultConfigPackage:
+                  type: object
+                  nullable: true
+                  required: [packageURL]
+                  properties:
+                    packageURL:
+                      type: string
+                      pattern: '^(file|https?)://.+\.tgz$'
+                    useNewSetupLayout:
+                      type: boolean
+                defaultMaxLogSizeDump:
+                  type: integer
+                  minimum: 0
+                services:
+                  type: array
+                  items:
                     type: object
-                    nullable: true
-                    required: [name]
+                    required: [id]
                     properties:
-                      name:
-                        type: string
-                        minLength: 1
-                      description:
-                        type: string
-                  endpoint:
-                    type: object
-                    nullable: true
-                    required: [port]
-                    properties:
-                      port:
-                        type: integer
-                        minimum: 1
-                        maximum: 65535
-                      urlScheme:
+                      id:
                         type: string
                         minLength: 1
                         maxLength: 15
                         pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
-                      path:
-                        type: string
-                      isDashboard:
-                        type: boolean
-                      hasAuthToken:
-                        type: boolean
-            roles:
-              type: array
-              items:
-                type: object
-                required: [id, cardinality]
-                properties:
-                  id:
-                    type: string
-                    minLength: 1
-                    maxLength: 63
-                    pattern: '^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$'
-                  cardinality:
-                    type: string
-                    pattern: '^\d+\+?$'
-                  imageRepoTag:
-                    type: string
-                    minLength: 1
-                  configPackage:
-                    type: object
-                    nullable: true
-                    required: [packageURL]
-                    properties:
-                      packageURL:
-                        type: string
-                        pattern: '^(file|https?)://.+\.tgz$'
-                      useNewSetupLayout:
-                        type: boolean
-                  persistDirs:
-                    type: array
-                    items:
-                      type: string
-                      pattern: '^/.*[^/]$'
-                  eventList:
-                    type: array
-                    items:
-                      type: string
-                      pattern: '^configure$|^addnodes$|^delnodes$'
-                  containerSpec:
-                    type: object
-                    nullable: true
-                    properties:
-                      stdin:
-                        type: boolean
-                      tty:
-                        type: boolean
-                  minResources:
-                    type: object
-                    nullable: true
-                    properties:
-                      memory:
-                        type: string
-                        pattern: '^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'
-                      cpu:
-                        type: string
-                        pattern: '^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'
-                      ephemeral-storage:
-                        type: string
-                        pattern: '^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'
-                      nvidia.com/gpu:
-                        type: string
-                        pattern: '^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'
-                      amd.com/gpu:
-                        type: string
-                        pattern: '^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'
-                  minStorage:
-                    type: object
-                    nullable: true
-                    required: [size]
-                    properties:
-                      size:
-                        type: string
-                        pattern: '^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'
-                      ephemeralModeSupported:
-                        type: boolean
-                  maxLogSizeDump:
-                    type: integer
-                    minimum: 0
-            config:
-              type: object
-              required: [selectedRoles, roleServices]
-              properties:
-                configMeta:
-                  type: object
-                  nullable: true
-                  additionalProperties:
-                    type: string
-                selectedRoles:
-                  type: array
-                  items:
-                    type: string
-                    minLength: 1
-                roleServices:
+                      label:
+                        type: object
+                        nullable: true
+                        required: [name]
+                        properties:
+                          name:
+                            type: string
+                            minLength: 1
+                          description:
+                            type: string
+                      endpoint:
+                        type: object
+                        nullable: true
+                        required: [port]
+                        properties:
+                          port:
+                            type: integer
+                            minimum: 1
+                            maximum: 65535
+                          urlScheme:
+                            type: string
+                            minLength: 1
+                            maxLength: 15
+                            pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
+                          path:
+                            type: string
+                          isDashboard:
+                            type: boolean
+                          hasAuthToken:
+                            type: boolean
+                roles:
                   type: array
                   items:
                     type: object
-                    required: [roleID, serviceIDs]
+                    required: [id, cardinality]
                     properties:
-                      roleID:
+                      id:
                         type: string
                         minLength: 1
                         maxLength: 63
                         pattern: '^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$'
-                      serviceIDs:
+                      cardinality:
+                        type: string
+                        pattern: '^\d+\+?$'
+                      imageRepoTag:
+                        type: string
+                        minLength: 1
+                      configPackage:
+                        type: object
+                        nullable: true
+                        required: [packageURL]
+                        properties:
+                          packageURL:
+                            type: string
+                            pattern: '^(file|https?)://.+\.tgz$'
+                          useNewSetupLayout:
+                            type: boolean
+                      persistDirs:
                         type: array
                         items:
                           type: string
-                          minLength: 1
-                          maxLength: 15
-                          pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
-            defaultPersistDirs:
-              type: array
-              items:
-                type: string
-                pattern: '^/.*[^/]$'
-            defaultEventList:
-              type: array
-              items:
-                type: string
-                pattern: '^configure$|^addnodes$|^delnodes$'
-            capabilities:
-              type: array
-              items:
-                type: string
-                minLength: 1
-            systemdRequired:
-              type: boolean
-            logoURL:
-              type: string
-              minLength: 1
-              pattern: '^(file|https|http?)://.+\.(jpeg|png)$'
+                          pattern: '^/.*[^/]$'
+                      eventList:
+                        type: array
+                        items:
+                          type: string
+                          pattern: '^configure$|^addnodes$|^delnodes$'
+                      containerSpec:
+                        type: object
+                        nullable: true
+                        properties:
+                          stdin:
+                            type: boolean
+                          tty:
+                            type: boolean
+                      minResources:
+                        type: object
+                        nullable: true
+                        properties:
+                          memory:
+                            type: string
+                            pattern: '^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'
+                          cpu:
+                            type: string
+                            pattern: '^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'
+                          ephemeral-storage:
+                            type: string
+                            pattern: '^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'
+                          nvidia.com/gpu:
+                            type: string
+                            pattern: '^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'
+                          amd.com/gpu:
+                            type: string
+                            pattern: '^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'
+                      minStorage:
+                        type: object
+                        nullable: true
+                        required: [size]
+                        properties:
+                          size:
+                            type: string
+                            pattern: '^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'
+                          ephemeralModeSupported:
+                            type: boolean
+                      maxLogSizeDump:
+                        type: integer
+                        minimum: 0
+                config:
+                  type: object
+                  required: [selectedRoles, roleServices]
+                  properties:
+                    configMeta:
+                      type: object
+                      nullable: true
+                      additionalProperties:
+                        type: string
+                    selectedRoles:
+                      type: array
+                      items:
+                        type: string
+                        minLength: 1
+                    roleServices:
+                      type: array
+                      items:
+                        type: object
+                        required: [roleID, serviceIDs]
+                        properties:
+                          roleID:
+                            type: string
+                            minLength: 1
+                            maxLength: 63
+                            pattern: '^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$'
+                          serviceIDs:
+                            type: array
+                            items:
+                              type: string
+                              minLength: 1
+                              maxLength: 15
+                              pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
+                defaultPersistDirs:
+                  type: array
+                  items:
+                    type: string
+                    pattern: '^/.*[^/]$'
+                defaultEventList:
+                  type: array
+                  items:
+                    type: string
+                    pattern: '^configure$|^addnodes$|^delnodes$'
+                capabilities:
+                  type: array
+                  items:
+                    type: string
+                    minLength: 1
+                systemdRequired:
+                  type: boolean
+                logoURL:
+                  type: string
+                  minLength: 1
+                  pattern: '^(file|https|http?)://.+\.(jpeg|png)$'

--- a/deploy/kubedirector/kubedirector.hpe.com_kubedirectorclusters_crd.yaml
+++ b/deploy/kubedirector/kubedirector.hpe.com_kubedirectorclusters_crd.yaml
@@ -125,6 +125,7 @@ spec:
                         required: [limits]
                         properties:
                           limits:
+                            x-kubernetes-preserve-unknown-fields: true
                             type: object
                             required: [memory, cpu]
                             properties:
@@ -144,6 +145,7 @@ spec:
                                 type: string
                                 pattern: '^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'
                           requests:
+                            x-kubernetes-preserve-unknown-fields: true
                             type: object
                             nullable: true
                             properties:

--- a/deploy/kubedirector/kubedirector.hpe.com_kubedirectorclusters_crd.yaml
+++ b/deploy/kubedirector/kubedirector.hpe.com_kubedirectorclusters_crd.yaml
@@ -1,10 +1,9 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: kubedirectorclusters.kubedirector.hpe.com
 spec:
   group: kubedirector.hpe.com
-  version: v1beta1
   names:
     kind: KubeDirectorCluster
     listKind: KubeDirectorClusterList
@@ -13,605 +12,611 @@ spec:
     shortNames:
       - kdcluster
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      type: object
-      required: [apiVersion, kind, metadata, spec]
-      properties:
-        apiVersion:
-          type: string
-        kind:
-          type: string
-        metadata:
+  versions:
+    - name: v1beta1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
           type: object
-        spec:
-          type: object
-          required: [app, roles]
+          required: [apiVersion, kind, metadata, spec]
           properties:
-            app:
+            apiVersion:
               type: string
-              minLength: 1
-            appCatalog:
+            kind:
               type: string
-              pattern: '^local$|^system$'
-            connections:
+            metadata:
               type: object
-              properties:
-                clusters:
-                  type: array
-                  items:
-                    type: string
-                configmaps:
-                  type: array
-                  items:
-                    type: string
-                secrets:
-                  type: array
-                  items:
-                    type: string
-            namingScheme:
-              type: string
-              pattern: '^UID$|^CrNameRole$'
-            serviceType:
-              type: string
-              pattern: '^ClusterIP$|^NodePort$|^LoadBalancer$'
-            defaultSecret:
+            spec:
               type: object
-              nullable: true
-              required: [name, mountPath]
+              required: [app, roles]
               properties:
-                name:
+                app:
                   type: string
                   minLength: 1
-                mountPath:
+                appCatalog:
                   type: string
-                  minLength: 1
-                  pattern: '^/[a-zA-Z0-9\/-_]*'
-                defaultMode:
-                  type: integer
-                  maximum: 511
-                readOnly:
-                  type: boolean
-            roles:
-              type: array
-              items:
-                type: object
-                required: [id, resources]
-                properties:
-                  id:
-                    type: string
-                    minLength: 1
-                    maxLength: 63
-                    pattern: '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?'
-                  podLabels:
+                  pattern: '^local$|^system$'
+                connections:
+                  type: object
+                  properties:
+                    clusters:
+                      type: array
+                      items:
+                        type: string
+                    configmaps:
+                      type: array
+                      items:
+                        type: string
+                    secrets:
+                      type: array
+                      items:
+                        type: string
+                namingScheme:
+                  type: string
+                  pattern: '^UID$|^CrNameRole$'
+                serviceType:
+                  type: string
+                  pattern: '^ClusterIP$|^NodePort$|^LoadBalancer$'
+                defaultSecret:
+                  type: object
+                  nullable: true
+                  required: [name, mountPath]
+                  properties:
+                    name:
+                      type: string
+                      minLength: 1
+                    mountPath:
+                      type: string
+                      minLength: 1
+                      pattern: '^/[a-zA-Z0-9\/-_]*'
+                    defaultMode:
+                      type: integer
+                      maximum: 511
+                    readOnly:
+                      type: boolean
+                roles:
+                  type: array
+                  items:
                     type: object
-                    nullable: true
-                  podAnnotations:
-                    type: object
-                    nullable: true
-                  serviceLabels:
-                    type: object
-                    nullable: true
-                  serviceAnnotations:
-                    type: object
-                    nullable: true
-                  members:
-                    type: integer
-                    minimum: 0
-                  secret:
-                    type: object
-                    nullable: true
-                    required: [name, mountPath]
+                    required: [id, resources]
                     properties:
-                      name:
+                      id:
                         type: string
                         minLength: 1
-                      mountPath:
-                        type: string
-                        minLength: 1
-                        pattern: '^/[a-zA-Z0-9\/-_]*'
-                      defaultMode:
-                        type: integer
-                        maximum: 511
-                      readOnly:
-                        type: boolean
-                  resources:
-                    type: object
-                    required: [limits]
-                    properties:
-                      limits:
-                        type: object
-                        required: [memory, cpu]
-                        properties:
-                          memory:
-                            type: string
-                            pattern: '^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'
-                          cpu:
-                            type: string
-                            pattern: '^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'
-                          nvidia.com/gpu:
-                            type: string
-                            pattern: '^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'
-                          amd.com/gpu:
-                            type: string
-                            pattern: '^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'
-                          ephemeral-storage:
-                            type: string
-                            pattern: '^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'
-                      requests:
+                        maxLength: 63
+                        pattern: '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?'
+                      podLabels:
                         type: object
                         nullable: true
-                        properties:
-                          memory:
-                            type: string
-                            pattern: '^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'
-                          cpu:
-                            type: string
-                            pattern: '^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'
-                          ephemeral-storage:
-                            type: string
-                            pattern: '^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'
-                  serviceAccountName:
-                        type: string
-                        minLength: 1
-                  env:
-                    type: array
-                    items:
-                      type: object
-                      required: [name, value]
-                      properties:
-                        name:
-                          type: string
-                          minLength: 1
-                        value:
-                          type: string
-                  storage:
-                    type: object
-                    nullable: true
-                    required: [size]
-                    properties:
-                      size:
-                        type: string
-                        pattern: '^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'
-                      storageClassName:
-                        type: string
-                        minLength: 1
-                  blockStorage:
-                    type: object
-                    nullable: true
-                    required: [storageClassName, pathPrefix, numDevices]
-                    properties:
-                      numDevices:
+                      podAnnotations:
+                        type: object
+                        nullable: true
+                      serviceLabels:
+                        type: object
+                        nullable: true
+                      serviceAnnotations:
+                        type: object
+                        nullable: true
+                      members:
                         type: integer
-                        minimum: 1
-                      pathPrefix:
-                        type: string
-                        minLength: 1
-                        pattern: '^/.*$'
-                      storageClassName:
-                        type: string
-                        minLength: 1
-                      size:
-                        type: string
-                        pattern: '^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'
-                  fileInjections:
-                    type: array
-                    items:
-                      type: object
-                      required: [srcURL, destDir]
-                      properties:
-                        srcURL:
-                          type: string
-                          pattern: '^https?://.+$'
-                        destDir:
-                          type: string
-                          pattern: '^/.*$'
-                          minLength: 1
-                        permissions:
-                          type: object
-                          nullable: true
-                          properties:
-                            fileMode:
-                              type: integer
-                            fileOwner:
-                              type: string
-                            fileGroup:
-                              type: string
-                  secretKeys:
-                    type: array
-                    items:
-                      type: object
-                      required: [ name ]
-                      properties:
-                        name:
-                          type: string
-                          minLength: 1
-                        value:
-                          type: string
-                        encryptedValue:
-                          type: string
-                          minLength: 1
-                  affinity:
-                    properties:
-                      nodeAffinity:
+                        minimum: 0
+                      secret:
+                        type: object
+                        nullable: true
+                        required: [name, mountPath]
                         properties:
-                          preferredDuringSchedulingIgnoredDuringExecution:
-                            items:
-                              properties:
-                                preference:
-                                  properties:
-                                    matchExpressions:
-                                      items:
-                                        properties:
-                                          key:
-                                            type: string
-                                          operator:
-                                            type: string
-                                          values:
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                          - key
-                                          - operator
-                                        type: object
-                                      type: array
-                                    matchFields:
-                                      items:
-                                        properties:
-                                          key:
-                                            type: string
-                                          operator:
-                                            type: string
-                                          values:
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                          - key
-                                          - operator
-                                        type: object
-                                      type: array
-                                  type: object
-                                weight:
-                                  format: int32
-                                  type: integer
-                              required:
-                                - preference
-                                - weight
-                              type: object
-                            type: array
-                          requiredDuringSchedulingIgnoredDuringExecution:
+                          name:
+                            type: string
+                            minLength: 1
+                          mountPath:
+                            type: string
+                            minLength: 1
+                            pattern: '^/[a-zA-Z0-9\/-_]*'
+                          defaultMode:
+                            type: integer
+                            maximum: 511
+                          readOnly:
+                            type: boolean
+                      resources:
+                        type: object
+                        required: [limits]
+                        properties:
+                          limits:
+                            type: object
+                            required: [memory, cpu]
                             properties:
-                              nodeSelectorTerms:
+                              memory:
+                                type: string
+                                pattern: '^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'
+                              cpu:
+                                type: string
+                                pattern: '^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'
+                              nvidia.com/gpu:
+                                type: string
+                                pattern: '^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'
+                              amd.com/gpu:
+                                type: string
+                                pattern: '^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'
+                              ephemeral-storage:
+                                type: string
+                                pattern: '^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'
+                          requests:
+                            type: object
+                            nullable: true
+                            properties:
+                              memory:
+                                type: string
+                                pattern: '^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'
+                              cpu:
+                                type: string
+                                pattern: '^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'
+                              ephemeral-storage:
+                                type: string
+                                pattern: '^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'
+                      serviceAccountName:
+                        type: string
+                        minLength: 1
+                      env:
+                        type: array
+                        items:
+                          type: object
+                          required: [name, value]
+                          properties:
+                            name:
+                              type: string
+                              minLength: 1
+                            value:
+                              type: string
+                      storage:
+                        type: object
+                        nullable: true
+                        required: [size]
+                        properties:
+                          size:
+                            type: string
+                            pattern: '^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'
+                          storageClassName:
+                            type: string
+                            minLength: 1
+                      blockStorage:
+                        type: object
+                        nullable: true
+                        required: [storageClassName, pathPrefix, numDevices]
+                        properties:
+                          numDevices:
+                            type: integer
+                            minimum: 1
+                          pathPrefix:
+                            type: string
+                            minLength: 1
+                            pattern: '^/.*$'
+                          storageClassName:
+                            type: string
+                            minLength: 1
+                          size:
+                            type: string
+                            pattern: '^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'
+                      fileInjections:
+                        type: array
+                        items:
+                          type: object
+                          required: [srcURL, destDir]
+                          properties:
+                            srcURL:
+                              type: string
+                              pattern: '^https?://.+$'
+                            destDir:
+                              type: string
+                              pattern: '^/.*$'
+                              minLength: 1
+                            permissions:
+                              type: object
+                              nullable: true
+                              properties:
+                                fileMode:
+                                  type: integer
+                                fileOwner:
+                                  type: string
+                                fileGroup:
+                                  type: string
+                      secretKeys:
+                        type: array
+                        items:
+                          type: object
+                          required: [ name ]
+                          properties:
+                            name:
+                              type: string
+                              minLength: 1
+                            value:
+                              type: string
+                            encryptedValue:
+                              type: string
+                              minLength: 1
+                      affinity:
+                        properties:
+                          nodeAffinity:
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
                                 items:
                                   properties:
-                                    matchExpressions:
-                                      items:
-                                        properties:
-                                          key:
-                                            type: string
-                                          operator:
-                                            type: string
-                                          values:
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                          - key
-                                          - operator
-                                        type: object
-                                      type: array
-                                    matchFields:
-                                      items:
-                                        properties:
-                                          key:
-                                            type: string
-                                          operator:
-                                            type: string
-                                          values:
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                          - key
-                                          - operator
-                                        type: object
-                                      type: array
+                                    preference:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    weight:
+                                      format: int32
+                                      type: integer
+                                  required:
+                                    - preference
+                                    - weight
                                   type: object
                                 type: array
-                            required:
-                              - nodeSelectorTerms
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                properties:
+                                  nodeSelectorTerms:
+                                    items:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    type: array
+                                required:
+                                  - nodeSelectorTerms
+                                type: object
+                            type: object
+                          podAffinity:
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    podAffinityTerm:
+                                      properties:
+                                        labelSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          type: string
+                                      required:
+                                        - topologyKey
+                                      type: object
+                                    weight:
+                                      format: int32
+                                      type: integer
+                                  required:
+                                    - podAffinityTerm
+                                    - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    labelSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      type: string
+                                  required:
+                                    - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                          podAntiAffinity:
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    podAffinityTerm:
+                                      properties:
+                                        labelSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          type: string
+                                      required:
+                                        - topologyKey
+                                      type: object
+                                    weight:
+                                      format: int32
+                                      type: integer
+                                  required:
+                                    - podAffinityTerm
+                                    - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    labelSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      type: string
+                                  required:
+                                    - topologyKey
+                                  type: object
+                                type: array
                             type: object
                         type: object
-                      podAffinity:
-                        properties:
-                          preferredDuringSchedulingIgnoredDuringExecution:
-                            items:
-                              properties:
-                                podAffinityTerm:
-                                  properties:
-                                    labelSelector:
-                                      properties:
-                                        matchExpressions:
-                                          items:
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                items:
-                                                  type: string
-                                                type: array
-                                            required:
-                                              - key
-                                              - operator
-                                            type: object
-                                          type: array
-                                        matchLabels:
-                                          additionalProperties:
-                                            type: string
-                                          type: object
-                                      type: object
-                                    namespaces:
-                                      items:
-                                        type: string
-                                      type: array
-                                    topologyKey:
-                                      type: string
-                                  required:
-                                    - topologyKey
-                                  type: object
-                                weight:
-                                  format: int32
-                                  type: integer
-                              required:
-                                - podAffinityTerm
-                                - weight
-                              type: object
-                            type: array
-                          requiredDuringSchedulingIgnoredDuringExecution:
-                            items:
-                              properties:
-                                labelSelector:
-                                  properties:
-                                    matchExpressions:
-                                      items:
-                                        properties:
-                                          key:
-                                            type: string
-                                          operator:
-                                            type: string
-                                          values:
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                          - key
-                                          - operator
-                                        type: object
-                                      type: array
-                                    matchLabels:
-                                      additionalProperties:
-                                        type: string
-                                      type: object
-                                  type: object
-                                namespaces:
-                                  items:
-                                    type: string
-                                  type: array
-                                topologyKey:
-                                  type: string
-                              required:
-                                - topologyKey
-                              type: object
-                            type: array
-                        type: object
-                      podAntiAffinity:
-                        properties:
-                          preferredDuringSchedulingIgnoredDuringExecution:
-                            items:
-                              properties:
-                                podAffinityTerm:
-                                  properties:
-                                    labelSelector:
-                                      properties:
-                                        matchExpressions:
-                                          items:
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                items:
-                                                  type: string
-                                                type: array
-                                            required:
-                                              - key
-                                              - operator
-                                            type: object
-                                          type: array
-                                        matchLabels:
-                                          additionalProperties:
-                                            type: string
-                                          type: object
-                                      type: object
-                                    namespaces:
-                                      items:
-                                        type: string
-                                      type: array
-                                    topologyKey:
-                                      type: string
-                                  required:
-                                    - topologyKey
-                                  type: object
-                                weight:
-                                  format: int32
-                                  type: integer
-                              required:
-                                - podAffinityTerm
-                                - weight
-                              type: object
-                            type: array
-                          requiredDuringSchedulingIgnoredDuringExecution:
-                            items:
-                              properties:
-                                labelSelector:
-                                  properties:
-                                    matchExpressions:
-                                      items:
-                                        properties:
-                                          key:
-                                            type: string
-                                          operator:
-                                            type: string
-                                          values:
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                          - key
-                                          - operator
-                                        type: object
-                                      type: array
-                                    matchLabels:
-                                      additionalProperties:
-                                        type: string
-                                      type: object
-                                  type: object
-                                namespaces:
-                                  items:
-                                    type: string
-                                  type: array
-                                topologyKey:
-                                  type: string
-                              required:
-                                - topologyKey
-                              type: object
-                            type: array
-                        type: object
-                    type: object
-                  volumeProjections:
-                    type: array
-                    items:
-                      type: object
-                      required: [pvcName, mountPath]
-                      properties:
-                        pvcName:
-                          minLength: 1
-                          type: string
-                        mountPath:
-                          type: string
-                          minLength: 2
-                          pattern: '^/[a-zA-Z0-9\/-_]*'
-                        readOnly:
-                          type: boolean
-        status:
-          type: object
-          nullable: true
-          properties:
-            state:
-              type: string
-            restoreProgress:
+                      volumeProjections:
+                        type: array
+                        items:
+                          type: object
+                          required: [pvcName, mountPath]
+                          properties:
+                            pvcName:
+                              minLength: 1
+                              type: string
+                            mountPath:
+                              type: string
+                              minLength: 2
+                              pattern: '^/[a-zA-Z0-9\/-_]*'
+                            readOnly:
+                              type: boolean
+            status:
               type: object
               nullable: true
               properties:
-                awaitingApp:
-                  type: boolean
-                awaitingStatus:
-                  type: boolean
-                awaitingResources:
-                  type: boolean
-                error:
+                state:
                   type: string
-            memberStateRollup:
-              type: object
-              properties:
-                membershipChanging:
-                  type: boolean
-                membersDown:
-                  type: boolean
-                membersInitializing:
-                  type: boolean
-                membersWaiting:
-                  type: boolean
-                membersRestarting:
-                  type: boolean
-                configErrors:
-                  type: boolean
-                membersNotScheduled:
-                  type: boolean
-            generationUID:
-              type: string
-            lastConnectionHash:
-              type: string  
-            specGenerationToProcess:
-              type: integer
-            clusterService:
-              type: string
-            lastNodeID:
-              type: integer
-            roles:
-              type: array
-              items:
-                type: object
-                properties:
-                  id:
-                    type: string
-                  statefulSet:
-                    type: string
-                  members:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        pod:
-                          type: string
-                        nodeID:
-                          type: integer
-                        service:
-                          type: string
-                        pvc:
-                          type: string
-                        blockDevicePaths:
-                          type: array
-                        authToken:
-                          type: string  
-                        state:
-                          type: string
-                        stateDetail:
+                restoreProgress:
+                  type: object
+                  nullable: true
+                  properties:
+                    awaitingApp:
+                      type: boolean
+                    awaitingStatus:
+                      type: boolean
+                    awaitingResources:
+                      type: boolean
+                    error:
+                      type: string
+                memberStateRollup:
+                  type: object
+                  properties:
+                    membershipChanging:
+                      type: boolean
+                    membersDown:
+                      type: boolean
+                    membersInitializing:
+                      type: boolean
+                    membersWaiting:
+                      type: boolean
+                    membersRestarting:
+                      type: boolean
+                    configErrors:
+                      type: boolean
+                    membersNotScheduled:
+                      type: boolean
+                generationUID:
+                  type: string
+                lastConnectionHash:
+                  type: string  
+                specGenerationToProcess:
+                  type: integer
+                clusterService:
+                  type: string
+                lastNodeID:
+                  type: integer
+                roles:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                      statefulSet:
+                        type: string
+                      members:
+                        type: array
+                        items:
                           type: object
                           properties:
-                            configErrorDetail:
+                            pod:
                               type: string
-                            lastConfigDataGeneration:
+                            nodeID:
                               type: integer
-                            lastSetupGeneration:
-                              type: integer
-                            configuringContainer:
+                            service:
                               type: string
-                            lastConfiguredContainer:
+                            pvc:
                               type: string
-                            lastKnownContainerState:
-                              type: string
-                            lastConnectionVersion:
-                              type: integer
-                            startScriptStdoutMessage:
-                              type: string
-                            startScriptStderrMessage:
-                              type: string
-                            schedulingErrorMessage:
-                              type: string
-                            pendingNotifyCmds:
+                            blockDevicePaths:
                               type: array
                               items:
-                                type: object
-                                properties:
-                                  arguments:
-                                    type: array
-                                    items:
-                                      type: string
+                                type: string
+                            authToken:
+                              type: string  
+                            state:
+                              type: string
+                            stateDetail:
+                              type: object
+                              properties:
+                                configErrorDetail:
+                                  type: string
+                                lastConfigDataGeneration:
+                                  type: integer
+                                lastSetupGeneration:
+                                  type: integer
+                                configuringContainer:
+                                  type: string
+                                lastConfiguredContainer:
+                                  type: string
+                                lastKnownContainerState:
+                                  type: string
+                                lastConnectionVersion:
+                                  type: integer
+                                startScriptStdoutMessage:
+                                  type: string
+                                startScriptStderrMessage:
+                                  type: string
+                                schedulingErrorMessage:
+                                  type: string
+                                pendingNotifyCmds:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      arguments:
+                                        type: array
+                                        items:
+                                          type: string

--- a/deploy/kubedirector/kubedirector.hpe.com_kubedirectorconfigs_crd.yaml
+++ b/deploy/kubedirector/kubedirector.hpe.com_kubedirectorconfigs_crd.yaml
@@ -1,10 +1,9 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: kubedirectorconfigs.kubedirector.hpe.com
 spec:
   group: kubedirector.hpe.com
-  version: v1beta1
   names:
     kind: KubeDirectorConfig
     listKind: KubeDirectorConfigList
@@ -13,65 +12,69 @@ spec:
     shortNames:
       - kdconfig
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      type: object
-      required: [apiVersion, kind, metadata]
-      properties:
-        apiVersion:
-          type: string
-        kind:
-          type: string
-        metadata:
+  versions:
+    - name: v1beta1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
           type: object
+          required: [apiVersion, kind, metadata]
           properties:
-            name:
+            apiVersion:
               type: string
-              pattern: '^kd-global-config$'
-        spec:
-          type: object
-          nullable: true
-          properties:
-            defaultStorageClassName:
+            kind:
               type: string
-              minLength: 1
-            defaultServiceType:
-              type: string
-              pattern: '^ClusterIP$|^NodePort$|^LoadBalancer$'
-            nativeSystemdSupport:
-              type: boolean
-            requiredSecretPrefix:
-              type: string
-            clusterSvcDomainBase:
-              type: string
-            defaultNamingScheme:
-              type: string
-              pattern: '^UID$|^CrNameRole$'
-            masterEncryptionKey:
-              type: string
-            podLabels:
+            metadata:
+              type: object
+              properties:
+                name:
+                  type: string
+                  pattern: '^kd-global-config$'
+            spec:
               type: object
               nullable: true
-            podAnnotations:
+              properties:
+                defaultStorageClassName:
+                  type: string
+                  minLength: 1
+                defaultServiceType:
+                  type: string
+                  pattern: '^ClusterIP$|^NodePort$|^LoadBalancer$'
+                nativeSystemdSupport:
+                  type: boolean
+                requiredSecretPrefix:
+                  type: string
+                clusterSvcDomainBase:
+                  type: string
+                defaultNamingScheme:
+                  type: string
+                  pattern: '^UID$|^CrNameRole$'
+                masterEncryptionKey:
+                  type: string
+                podLabels:
+                  type: object
+                  nullable: true
+                podAnnotations:
+                  type: object
+                  nullable: true
+                serviceLabels:
+                  type: object
+                  nullable: true
+                serviceAnnotations:
+                  type: object
+                  nullable: true
+                backupClusterStatus:
+                  type: boolean
+                allowRestoreWithoutConnections:
+                  type: boolean
+            status:
               type: object
               nullable: true
-            serviceLabels:
-              type: object
-              nullable: true
-            serviceAnnotations:
-              type: object
-              nullable: true
-            backupClusterStatus:
-              type: boolean
-            allowRestoreWithoutConnections:
-              type: boolean
-        status:
-          type: object
-          nullable: true
-          properties:
-            generationUID:
-              type: string
-            state:
-              type: string
+              properties:
+                generationUID:
+                  type: string
+                state:
+                  type: string

--- a/deploy/kubedirector/kubedirector.hpe.com_kubedirectorstatusbackups_crd.yaml
+++ b/deploy/kubedirector/kubedirector.hpe.com_kubedirectorstatusbackups_crd.yaml
@@ -1,10 +1,9 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: kubedirectorstatusbackups.kubedirector.hpe.com
 spec:
   group: kubedirector.hpe.com
-  version: v1beta1
   names:
     kind: KubeDirectorStatusBackup
     listKind: KubeDirectorStatusBackupList
@@ -13,19 +12,23 @@ spec:
     shortNames:
       - kdstatusbackup
   scope: Namespaced
-  validation:
-    openAPIV3Schema:
-      type: object
-      required: [apiVersion, kind, metadata, spec]
-      properties:
-        apiVersion:
-          type: string
-        kind:
-          type: string
-        metadata:
+  versions:
+    - name: v1beta1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
           type: object
-        spec:
-          type: object
+          required: [apiVersion, kind, metadata, spec]
           properties:
-            statusBackup:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
               type: object
+            spec:
+              type: object
+              properties:
+                statusBackup:
+                  type: object

--- a/doc/eks-notes.md
+++ b/doc/eks-notes.md
@@ -7,7 +7,7 @@ The [Getting Started with Amazon EKS](https://docs.aws.amazon.com/eks/latest/use
 As part of this process you will have a choice whether or not to use "AWS Fargate". For example, in the eksctl docs the cluster creation section has two tabs "AWS Fargate-only cluster" and "Cluster with Linux-only workloads". You may wish to follow the available links to read more about Fargate. FWIW we do *not* yet use Fargate when testing KubeDirector deployment and any EKS-related docs in this repo are currently written in the context of a non-Fargate deployment.
 
 Two other important notes to be aware of when creating an EKS cluster:
-* Be sure to specify Kubernetes version 1.14 or later.
+* Be sure to specify a Kubernetes version that is in the range of KubeDirector-supported versions.
 * Choose a worker [instance type](https://aws.amazon.com/ec2/instance-types/) with enough resources to host at least one virtual cluster member. The example type t3.medium is probably too small; consider using t3.xlarge or an m5 instance type.
 
 Use of eksctl and the AWS Management Console can be somewhat intermixed, because in the end they are just manipulating standard AWS resources, but this doc will assume you're just using one process or the other.

--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -1,6 +1,6 @@
 #### KUBERNETES SETUP
 
-You will need a K8s (Kubernetes) cluster for deploying KubeDirector and KubeDirector-managed virtual clusters. Currently we require using K8s version 1.14 or later.
+You will need a K8s (Kubernetes) cluster for deploying KubeDirector and KubeDirector-managed virtual clusters. Currently we require using K8s version 1.16 or later.
 
 We often run KubeDirector on [Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine); see [gke-notes.md](gke-notes.md) for GKE-specific elaborations on the various steps in this document. Or if you would rather use [Amazon Elastic Kubernetes Service](https://aws.amazon.com/eks/), see [eks-notes.md](eks-notes.md). We have also run it on [DigitalOcean Kubernetes](https://www.digitalocean.com/products/kubernetes/) without issues.
 

--- a/doc/upgrade.md
+++ b/doc/upgrade.md
@@ -1,3 +1,12 @@
+#### First, check Kubernetes version requirements
+
+From KubeDirector v0.4.0 up through v0.8.1, the minimum supported K8s version was 1.14 and the maximum was 1.21.
+
+Starting with KD v0.9.0, the minimum supported K8s version is 1.16 and there is no maximum supported K8s version (yet).
+
+Select your desired KubeDirector version accordingly, and possibly also coordinate with any desired K8s upgrades.
+
+
 #### If upgrading from KubeDirector v0.5.0 or later:
 
 **1) Update the Deployment resource named "kubedirector".**

--- a/pkg/observer/observer.go
+++ b/pkg/observer/observer.go
@@ -20,7 +20,7 @@ import (
 	kdv1 "github.com/bluek8s/kubedirector/pkg/apis/kubedirector/v1beta1"
 	"github.com/bluek8s/kubedirector/pkg/shared"
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
-	"k8s.io/api/admissionregistration/v1beta1"
+	arv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
@@ -190,13 +190,13 @@ func GetApp(
 // KubeDirector's namespace.
 func GetValidatorWebhook(
 	validator string,
-) (*v1beta1.MutatingWebhookConfiguration, error) {
+) (*arv1.MutatingWebhookConfiguration, error) {
 
 	kdNamespace, err := shared.GetKubeDirectorNamespace()
 	if err != nil {
 		return nil, err
 	}
-	result := &v1beta1.MutatingWebhookConfiguration{}
+	result := &arv1.MutatingWebhookConfiguration{}
 	err = shared.Get(
 		context.TODO(),
 		types.NamespacedName{Namespace: kdNamespace, Name: validator},

--- a/pkg/validator/app.go
+++ b/pkg/validator/app.go
@@ -23,7 +23,7 @@ import (
 	kdv1 "github.com/bluek8s/kubedirector/pkg/apis/kubedirector/v1beta1"
 	"github.com/bluek8s/kubedirector/pkg/catalog"
 	"github.com/bluek8s/kubedirector/pkg/shared"
-	"k8s.io/api/admission/v1beta1"
+	av1beta1 "k8s.io/api/admission/v1beta1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -406,18 +406,18 @@ func validateServices(
 // the top-specific validation subroutines and composes the admission
 // response.
 func admitAppCR(
-	ar *v1beta1.AdmissionReview,
-) *v1beta1.AdmissionResponse {
+	ar *av1beta1.AdmissionReview,
+) *av1beta1.AdmissionResponse {
 
 	var valErrors []string
 	var patches []appPatchSpec
 
-	var admitResponse = v1beta1.AdmissionResponse{
+	var admitResponse = av1beta1.AdmissionResponse{
 		Allowed: false,
 	}
 
 	// Reject a delete if the app CR is currently in use.
-	if ar.Request.Operation == v1beta1.Delete {
+	if ar.Request.Operation == av1beta1.Delete {
 		references := shared.ClustersUsingApp(
 			ar.Request.Namespace,
 			ar.Request.Name,
@@ -436,7 +436,7 @@ func admitAppCR(
 	}
 
 	// For a delete operation, we're done now.
-	if ar.Request.Operation == v1beta1.Delete {
+	if ar.Request.Operation == av1beta1.Delete {
 		admitResponse.Allowed = true
 		return &admitResponse
 	}
@@ -468,7 +468,7 @@ func admitAppCR(
 			patchResult, patchErr := json.Marshal(patches)
 			if patchErr == nil {
 				admitResponse.Patch = patchResult
-				patchType := v1beta1.PatchTypeJSONPatch
+				patchType := av1beta1.PatchTypeJSONPatch
 				admitResponse.PatchType = &patchType
 			} else {
 				valErrors = append(valErrors, failedToPatch)
@@ -479,7 +479,7 @@ func admitAppCR(
 	// Reject an update if the app CR is currently in use AND this update is
 	// changing the spec. Note that we don't do this at the beginning of the
 	// handler because we want to get defaults populated before comparing.
-	if ar.Request.Operation == v1beta1.Update {
+	if ar.Request.Operation == av1beta1.Update {
 		references := shared.ClustersUsingApp(
 			ar.Request.Namespace,
 			ar.Request.Name,

--- a/pkg/validator/config.go
+++ b/pkg/validator/config.go
@@ -25,7 +25,7 @@ import (
 
 	kdv1 "github.com/bluek8s/kubedirector/pkg/apis/kubedirector/v1beta1"
 	"github.com/bluek8s/kubedirector/pkg/observer"
-	"k8s.io/api/admission/v1beta1"
+	av1beta1 "k8s.io/api/admission/v1beta1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -146,16 +146,16 @@ func validateOrPopulateMasterEncryptionKey(
 // admission response will include PATCH operations as necessary to populate
 // values for missing properties.
 func admitKDConfigCR(
-	ar *v1beta1.AdmissionReview,
-) *v1beta1.AdmissionResponse {
+	ar *av1beta1.AdmissionReview,
+) *av1beta1.AdmissionResponse {
 
-	var admitResponse = v1beta1.AdmissionResponse{
+	var admitResponse = av1beta1.AdmissionResponse{
 		Allowed: false,
 	}
 
 	// If this is a delete, the admission handler only needs to check that
 	// there are no existing kdclusters.
-	if ar.Request.Operation == v1beta1.Delete {
+	if ar.Request.Operation == av1beta1.Delete {
 		if shared.AnyClusters() {
 			admitResponse.Result = &metav1.Status{
 				Message: "\n" + invalidConfigDelete,
@@ -197,7 +197,7 @@ func admitKDConfigCR(
 	// If this is an update, get the previous version of the object ready for
 	// use in some checks.
 	prevConfigCR := kdv1.KubeDirectorConfig{}
-	if ar.Request.Operation == v1beta1.Update {
+	if ar.Request.Operation == av1beta1.Update {
 		prevRaw := ar.Request.OldObject.Raw
 		if prevJSONErr := json.Unmarshal(prevRaw, &prevConfigCR); prevJSONErr != nil {
 			admitResponse.Result = &metav1.Status{
@@ -326,7 +326,7 @@ func admitKDConfigCR(
 			patchResult, patchErr := json.Marshal(patches)
 			if patchErr == nil {
 				admitResponse.Patch = patchResult
-				patchType := v1beta1.PatchTypeJSONPatch
+				patchType := av1beta1.PatchTypeJSONPatch
 				admitResponse.PatchType = &patchType
 			} else {
 				valErrors = append(valErrors, failedToPatch)

--- a/pkg/validator/pvc.go
+++ b/pkg/validator/pvc.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/bluek8s/kubedirector/pkg/observer"
 	"github.com/bluek8s/kubedirector/pkg/shared"
-	"k8s.io/api/admission/v1beta1"
+	av1beta1 "k8s.io/api/admission/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -60,11 +60,11 @@ func mutateOwnerRefs(
 // the top-specific validation subroutines and composes the admission
 // response.
 func admitPVC(
-	ar *v1beta1.AdmissionReview,
-) *v1beta1.AdmissionResponse {
+	ar *av1beta1.AdmissionReview,
+) *av1beta1.AdmissionResponse {
 
 	var patches []pvcPatchSpec
-	var admitResponse = v1beta1.AdmissionResponse{
+	var admitResponse = av1beta1.AdmissionResponse{
 		Allowed: false,
 	}
 
@@ -88,7 +88,7 @@ func admitPVC(
 		patchResult, patchErr := json.Marshal(patches)
 		if patchErr == nil {
 			admitResponse.Patch = patchResult
-			patchType := v1beta1.PatchTypeJSONPatch
+			patchType := av1beta1.PatchTypeJSONPatch
 			admitResponse.PatchType = &patchType
 			admitResponse.Allowed = true
 		} else {

--- a/pkg/validator/server.go
+++ b/pkg/validator/server.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/bluek8s/kubedirector/pkg/observer"
 	"github.com/bluek8s/kubedirector/pkg/shared"
-	"k8s.io/api/admission/v1beta1"
+	av1beta1 "k8s.io/api/admission/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -48,7 +48,7 @@ func validation(
 	r *http.Request,
 ) {
 
-	var admissionResponse *v1beta1.AdmissionResponse
+	var admissionResponse *av1beta1.AdmissionResponse
 
 	var body []byte
 	if r.Body != nil {
@@ -73,9 +73,9 @@ func validation(
 		return
 	}
 
-	ar := v1beta1.AdmissionReview{}
+	ar := av1beta1.AdmissionReview{}
 	if err := json.Unmarshal(body, &ar); err != nil {
-		admissionResponse = &v1beta1.AdmissionResponse{
+		admissionResponse = &av1beta1.AdmissionResponse{
 			Result: &metav1.Status{
 				Message: err.Error(),
 			},
@@ -87,13 +87,13 @@ func validation(
 			admissionResponse = handler(&ar)
 		} else {
 			// No validation handler for this CR. Allow to go through.
-			admissionResponse = &v1beta1.AdmissionResponse{
+			admissionResponse = &av1beta1.AdmissionResponse{
 				Allowed: true,
 			}
 		}
 	}
 
-	admissionReview := v1beta1.AdmissionReview{}
+	admissionReview := av1beta1.AdmissionReview{}
 	if admissionResponse != nil {
 		admissionReview.Response = admissionResponse
 		if ar.Request != nil {

--- a/pkg/validator/types.go
+++ b/pkg/validator/types.go
@@ -16,11 +16,11 @@ package validator
 
 import (
 	"github.com/bluek8s/kubedirector/pkg/shared"
-	"k8s.io/api/admission/v1beta1"
+	av1beta1 "k8s.io/api/admission/v1beta1"
 )
 
 // admitFunc is used as the type for all the callback validators
-type admitFunc func(*v1beta1.AdmissionReview) *v1beta1.AdmissionResponse
+type admitFunc func(*av1beta1.AdmissionReview) *av1beta1.AdmissionResponse
 
 type checkFunc func() error
 

--- a/pkg/validator/util.go
+++ b/pkg/validator/util.go
@@ -24,7 +24,7 @@ import (
 	"github.com/bluek8s/kubedirector/pkg/shared"
 	"github.com/bluek8s/kubedirector/pkg/triple"
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
-	"k8s.io/api/admissionregistration/v1beta1"
+	arv1 "k8s.io/api/admissionregistration/v1"
 	v1auth "k8s.io/api/authentication/v1"
 	sar "k8s.io/api/authorization/v1"
 	v1 "k8s.io/api/core/v1"
@@ -112,28 +112,23 @@ func createAdmissionService(
 		}
 	}
 
-	hardFailurePolicy := v1beta1.Fail
-	softFailurePolicy := v1beta1.Ignore
-	sideEffectsNone := v1beta1.SideEffectClassNone
+	hardFailurePolicy := arv1.Fail
+	softFailurePolicy := arv1.Ignore
+	sideEffectsNone := arv1.SideEffectClassNone
 
 	// Webhook handler with a "fail" failure policy; these operations
 	// will NOT be allowed even when the handler is down.
-	// Use the v1beta1 version until our K8s version support floor is 1.16 or
-	// better.
-	// Also note that until we raise our K8s support floor to 1.15, we can't
-	// use any properties in v1beta1.MutatingWebhook that were not also
-	// present in the old v1beta1.Webhook.
-	hardWebhookHandler := v1beta1.MutatingWebhook{
+	hardWebhookHandler := arv1.MutatingWebhook{
 		Name: "hard-" + webhookHandlerName,
-		ClientConfig: v1beta1.WebhookClientConfig{
-			Service: &v1beta1.ServiceReference{
+		ClientConfig: arv1.WebhookClientConfig{
+			Service: &arv1.ServiceReference{
 				Namespace: namespace,
 				Name:      serviceName,
 				Path:      shared.StrPtr(validationPath),
 			},
 			CABundle: signingCert,
 		},
-		Rules: []v1beta1.RuleWithOperations{
+		Rules: []arv1.RuleWithOperations{
 			// For kubedirectorclusters and kubedirectorconfigs, we don't
 			// actually do any delete validation, but if our whole operator is
 			// down (most likely failure case) the object won't go away
@@ -142,12 +137,12 @@ func createAdmissionService(
 			// let's head all of that off by just registering for Delete
 			// (with Fail failure policy) for those resources too.
 			{
-				Operations: []v1beta1.OperationType{
-					v1beta1.Create,
-					v1beta1.Update,
-					v1beta1.Delete,
+				Operations: []arv1.OperationType{
+					arv1.Create,
+					arv1.Update,
+					arv1.Delete,
 				},
-				Rule: v1beta1.Rule{
+				Rule: arv1.Rule{
 					APIGroups:   []string{"kubedirector.hpe.com"},
 					APIVersions: []string{"v1beta1"},
 					Resources: []string{
@@ -158,52 +153,53 @@ func createAdmissionService(
 				},
 			},
 		},
-		FailurePolicy: &hardFailurePolicy,
-		SideEffects:   &sideEffectsNone,
+		FailurePolicy:           &hardFailurePolicy,
+		SideEffects:             &sideEffectsNone,
+		AdmissionReviewVersions: []string{"v1beta1"},
 	}
 
 	// Webhook handler with an "ignore" failure policy; these operations
 	// WILL be allowed even when the handler is down.
-	// Use the v1beta1 version until our K8s version support floor is 1.16 or
-	// better.
-	// Also note that until we raise our K8s support floor to 1.15, we can't
-	// use any properties in v1beta1.MutatingWebhook that were not also
-	// present in the old v1beta1.Webhook.
-	softWebhookHandler := v1beta1.MutatingWebhook{
+	// To make sure that this webhook times out before an API client times
+	// out, set a shorter-than-30-seconds timeout for the webhook.
+	var softFailTimeoutSeconds int32 = 10
+	softWebhookHandler := arv1.MutatingWebhook{
 		Name: "soft-" + webhookHandlerName,
-		ClientConfig: v1beta1.WebhookClientConfig{
-			Service: &v1beta1.ServiceReference{
+		ClientConfig: arv1.WebhookClientConfig{
+			Service: &arv1.ServiceReference{
 				Namespace: namespace,
 				Name:      serviceName,
 				Path:      shared.StrPtr(validationPath),
 			},
 			CABundle: signingCert,
 		},
-		Rules: []v1beta1.RuleWithOperations{
+		Rules: []arv1.RuleWithOperations{
 			{
-				Operations: []v1beta1.OperationType{
-					v1beta1.Create,
+				Operations: []arv1.OperationType{
+					arv1.Create,
 				},
-				Rule: v1beta1.Rule{
+				Rule: arv1.Rule{
 					APIGroups:   []string{""},
 					APIVersions: []string{"v1"},
 					Resources:   []string{"persistentvolumeclaims"},
 				},
 			},
 		},
-		FailurePolicy: &softFailurePolicy,
-		SideEffects:   &sideEffectsNone,
+		FailurePolicy:           &softFailurePolicy,
+		SideEffects:             &sideEffectsNone,
+		AdmissionReviewVersions: []string{"v1beta1"},
+		TimeoutSeconds:          &softFailTimeoutSeconds,
 	}
 
-	validator := &v1beta1.MutatingWebhookConfiguration{
+	validator := &arv1.MutatingWebhookConfiguration{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "MutatingWebhookConfiguration",
-			APIVersion: "admissionregistration.k8s.io/v1beta1",
+			APIVersion: "admissionregistration.k8s.io/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: validatorWebhook,
 		},
-		Webhooks: []v1beta1.MutatingWebhook{hardWebhookHandler, softWebhookHandler},
+		Webhooks: []arv1.MutatingWebhook{hardWebhookHandler, softWebhookHandler},
 	}
 
 	if createValidator {


### PR DESCRIPTION
closes issue #504

* Moved to v1 instead of v1beta1 for apiextensions.k8s.io and admissionregistration.k8s.io.
  * We can now run on K8s 1.22 and beyond, but our K8s support floor is raised to 1.16.
  * CRs can no longer have non-schema-approved fields, except in locations where we explicitly approve that behavior (as in resource requirements, to support K8s extended resources).

* Didn't change the AdmissionReview/AdmissionResponse versions quite yet; we don't need to (yet), and there are some issues there to untangle. Did mark that module with a unique import alias "av1beta1" to more easily find and change them in the future.

* Updated docs accordingly.