### PR TITLE
Issue-562 | Added code changes to update pod scheduling error message…

### DIFF
--- a/deploy/kubedirector/kubedirector.hpe.com_kubedirectorclusters_crd.yaml
+++ b/deploy/kubedirector/kubedirector.hpe.com_kubedirectorclusters_crd.yaml
@@ -543,6 +543,8 @@ spec:
                   type: boolean
                 configErrors:
                   type: boolean
+                membersNotScheduled:
+                  type: boolean
             generationUID:
               type: string
             lastConnectionHash:
@@ -601,6 +603,8 @@ spec:
                             startScriptStdoutMessage:
                               type: string
                             startScriptStderrMessage:
+                              type: string
+                            schedulingErrorMessage:
                               type: string
                             pendingNotifyCmds:
                               type: array

--- a/pkg/apis/kubedirector/v1beta1/kubedirectorcluster_types.go
+++ b/pkg/apis/kubedirector/v1beta1/kubedirectorcluster_types.go
@@ -183,6 +183,7 @@ type StateRollup struct {
 	MembersWaiting      bool `json:"membersWaiting"`
 	MembersRestarting   bool `json:"membersRestarting"`
 	ConfigErrors        bool `json:"configErrors"`
+	MembersNotScheduled bool `json:"membersNotScheduled"`
 }
 
 // ClusterStorage defines the persistent storage size/type, if any, to be used
@@ -234,6 +235,7 @@ type MemberStateDetail struct {
 	LastConnectionVersion    *int64              `json:"lastConnectionVersion,omitempty"`
 	StartScriptOutMsg        string              `json:"startScriptStdoutMessage,omitempty"`
 	StartScriptErrMsg        string              `json:"startScriptStderrMessage,omitempty"`
+	SchedulingErrorMessage   *string             `json:"schedulingErrorMessage,omitempty"`
 }
 
 // NotificationDesc contains the info necessary to perform a notify command.

--- a/pkg/controller/kubedirectorcluster/cluster.go
+++ b/pkg/controller/kubedirectorcluster/cluster.go
@@ -498,6 +498,8 @@ func checkContainerStates(
 		for j := 0; j < numMemberStatuses; j++ {
 			memberStatus := &(roleStatus.Members[j])
 			containerID := ""
+			// clear SchedulingErrorMessage in MemberStateDetail
+			memberStatus.StateDetail.SchedulingErrorMessage = nil
 			if memberStatus.Pod != "" {
 				memberStatus.StateDetail.LastKnownContainerState = containerMissing
 				pod, podErr := observer.GetPod(cr.Namespace, memberStatus.Pod)
@@ -579,6 +581,8 @@ func checkContainerStates(
 						}
 					}
 				}
+				// Set pod blocking message in MemberStateDetail if LastKnownContainerState is containerMissing
+				updateSchedulingErrorMessage(pod, memberStatus)
 			}
 		}
 	}
@@ -619,6 +623,9 @@ func updateStateRollup(
 				// Count missing container as waiting, at this point.
 				if memberStatus.StateDetail.LastKnownContainerState == containerMissing {
 					cr.Status.MemberStateRollup.MembersWaiting = true
+					if memberStatus.StateDetail.SchedulingErrorMessage != nil {
+						cr.Status.MemberStateRollup.MembersNotScheduled = true
+					}
 				}
 			case memberCreating:
 				checkMemberDown(memberStatus)

--- a/pkg/controller/kubedirectorcluster/cluster.go
+++ b/pkg/controller/kubedirectorcluster/cluster.go
@@ -600,6 +600,7 @@ func updateStateRollup(
 	cr.Status.MemberStateRollup.MembersWaiting = false
 	cr.Status.MemberStateRollup.MembersRestarting = false
 	cr.Status.MemberStateRollup.ConfigErrors = false
+	cr.Status.MemberStateRollup.MembersNotScheduled = false
 
 	checkMemberDown := func(memberStatus kdv1.MemberStatus) {
 		if (memberStatus.StateDetail.LastKnownContainerState == containerTerminated) ||

--- a/pkg/controller/kubedirectorcluster/util.go
+++ b/pkg/controller/kubedirectorcluster/util.go
@@ -24,6 +24,7 @@ func updateSchedulingErrorMessage(
 	pod *corev1.Pod,
 	memberStatus *kdv1.MemberStatus,
 ) {
+
 	if memberStatus.StateDetail.LastKnownContainerState == containerMissing {
 		for _, condition := range pod.Status.Conditions {
 			if condition.Type == corev1.PodScheduled {

--- a/pkg/controller/kubedirectorcluster/util.go
+++ b/pkg/controller/kubedirectorcluster/util.go
@@ -1,0 +1,36 @@
+// Copyright 2019 Hewlett Packard Enterprise Development LP
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubedirectorcluster
+
+import (
+	kdv1 "github.com/bluek8s/kubedirector/pkg/apis/kubedirector/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// updateSchedulingErrorMessage updates MemberStateDetails with SchedulingErrorMessage
+func updateSchedulingErrorMessage(
+	pod *corev1.Pod,
+	memberStatus *kdv1.MemberStatus,
+) {
+	if memberStatus.StateDetail.LastKnownContainerState == containerMissing {
+		for _, condition := range pod.Status.Conditions {
+			if condition.Type == corev1.PodScheduled {
+				if condition.Reason == corev1.PodReasonUnschedulable {
+					memberStatus.StateDetail.SchedulingErrorMessage = &condition.Message
+				}
+			}
+		}
+	}
+}

--- a/pkg/controller/kubedirectorcluster/util.go
+++ b/pkg/controller/kubedirectorcluster/util.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Hewlett Packard Enterprise Development LP
+// Copyright 2022 Hewlett Packard Enterprise Development LP
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
Details about code changes

https://github.com/bluek8s/kubedirector/issues/562

Testing

Created 5 member ubuntu cluster

<img width="493" alt="Screenshot 2022-03-18 at 12 12 52 AM" src="https://user-images.githubusercontent.com/16591256/158873676-e833544d-510f-4e73-9e6c-7bf0c97a1239.png">


Couple of pods' scheduling failed because of less resource availability in the k8s cluster. 

<img width="1790" alt="Screenshot 2022-03-17 at 11 56 04 PM" src="https://user-images.githubusercontent.com/16591256/158872940-6489b070-de6a-4dfc-92d4-a2dcf7ec3d1f.png">

Then untainted the master node so that some of the pods can be scheduled on master.

<img width="1605" alt="Screenshot 2022-03-17 at 11 57 16 PM" src="https://user-images.githubusercontent.com/16591256/158873084-4d64a54b-0ac8-4e6e-9b92-caceb25ee3ee.png">

Change in kd node id 5 status - Configured And No Scheduling Error Message

<img width="1585" alt="Screenshot 2022-03-18 at 12 00 45 AM" src="https://user-images.githubusercontent.com/16591256/158873231-f9be0e35-4522-4f26-b497-179cb7507f4d.png">




