### PR TITLE
specify additionalPrinterColumns for kdcluster/kdapp

### DIFF
--- a/deploy/kubedirector/kubedirector.hpe.com_kubedirectorapps_crd.yaml
+++ b/deploy/kubedirector/kubedirector.hpe.com_kubedirectorapps_crd.yaml
@@ -16,6 +16,19 @@ spec:
     - name: v1beta1
       served: true
       storage: true
+      additionalPrinterColumns:
+      - name: App Name
+        type: string
+        description: Human-readable app name
+        jsonPath: .spec.label.name
+      - name: Distro ID
+        type: string
+        description: Unique identifier of a series of kdapp versions
+        jsonPath: .spec.distroID
+      - name: Version
+        type: string
+        description: A specific release of a kdapp distro ID
+        jsonPath: .spec.version
       schema:
         openAPIV3Schema:
           type: object

--- a/deploy/kubedirector/kubedirector.hpe.com_kubedirectorclusters_crd.yaml
+++ b/deploy/kubedirector/kubedirector.hpe.com_kubedirectorclusters_crd.yaml
@@ -18,6 +18,23 @@ spec:
       storage: true
       subresources:
         status: {}
+      additionalPrinterColumns:
+      - name: KDApp
+        type: string
+        description: Resource name of the instantiated kdapp
+        jsonPath: .spec.app
+      - name: State
+        type: string
+        description: Overall state of kdcluster configuration
+        jsonPath: .status.state
+      - name: Any Down
+        type: string
+        description: Whether any member containers are down
+        jsonPath: .status.memberStateRollup.membersDown
+      - name: Any ConfigError
+        type: string
+        description: Whether any member configuration returned error status
+        jsonPath: .status.memberStateRollup.configErrors
       schema:
         openAPIV3Schema:
           type: object


### PR DESCRIPTION
For issue #288

Examples:
```
> kubectl -n aiml get kdapp
NAME                APP NAME                                DISTROID                 VERSION
jupyter-notebook    Jupyter Notebook with ML toolkits       hpecp/jupyter-notebook   3.1

> kubectl -n aiml get kdcluster
NAME   KDAPP              STATE        ANY DOWN   ANY CONFIGERROR
nb     jupyter-notebook   configured   false      false
```