### PR TITLE
Extracted role status management to controller package

### DIFF
--- a/deploy/kubedirector/kubedirector.hpe.com_kubedirectorclusters_crd.yaml
+++ b/deploy/kubedirector/kubedirector.hpe.com_kubedirectorclusters_crd.yaml
@@ -601,7 +601,7 @@ spec:
                         type: string
                       statefulSet:
                         type: string
-                      membersUpgrading:
+                      upgradingMembersCount:
                         type: integer
                       roleUpgradeStatus:
                         type: string

--- a/deploy/kubedirector/kubedirector.hpe.com_kubedirectorclusters_crd.yaml
+++ b/deploy/kubedirector/kubedirector.hpe.com_kubedirectorclusters_crd.yaml
@@ -601,9 +601,8 @@ spec:
                         type: string
                       statefulSet:
                         type: string
-                      upgradingMembers:
-                        type: object
-                        nullable: true
+                      membersUpgrading:
+                        type: integer
                       roleUpgradeStatus:
                         type: string
                       members:

--- a/pkg/apis/kubedirector/v1beta1/kubedirectorcluster_types.go
+++ b/pkg/apis/kubedirector/v1beta1/kubedirectorcluster_types.go
@@ -226,12 +226,12 @@ const (
 
 // RoleStatus describes the component objects of a virtual cluster role.
 type RoleStatus struct {
-	Name                string            `json:"id"`
-	StatefulSet         string            `json:"statefulSet"`
-	Members             []MemberStatus    `json:"members"`
-	EncryptedSecretKeys map[string]string `json:"encryptedSecretKeys,omitempty"`
-	MembersUpgrading    int               `json:"membersUpgrading,omitempty"`
-	RoleUpgradeStatus   RoleUpgradeStatus `json:"roleUpgradeStatus,omitempty"`
+	Name                  string            `json:"id"`
+	StatefulSet           string            `json:"statefulSet"`
+	Members               []MemberStatus    `json:"members"`
+	EncryptedSecretKeys   map[string]string `json:"encryptedSecretKeys,omitempty"`
+	UpgradingMembersCount int32             `json:"upgradingMembersCount,omitempty"`
+	RoleUpgradeStatus     RoleUpgradeStatus `json:"roleUpgradeStatus,omitempty"`
 }
 
 // UpgradeInfo decribes cluster upgrading status

--- a/pkg/apis/kubedirector/v1beta1/kubedirectorcluster_types.go
+++ b/pkg/apis/kubedirector/v1beta1/kubedirectorcluster_types.go
@@ -253,10 +253,8 @@ type RollbackInfo struct {
 type MemberUpgradeStatus string
 
 const (
-	// PodUpgraded means upgrade process is finished
-	PodUpgraded MemberUpgradeStatus = "upgraded"
-	// PodRolledBack means rollback process is finished
-	PodRolledBack MemberUpgradeStatus = "rolledBack"
+	// PodConfigured is default empty value means the pod is in ready state
+	PodConfigured MemberUpgradeStatus = ""
 	// PodUpgrading means the pod is in the middle of upgrade process
 	PodUpgrading MemberUpgradeStatus = "upgrading"
 	// PodRollingBack means the pod is in the middle of rollback process

--- a/pkg/apis/kubedirector/v1beta1/kubedirectorcluster_types.go
+++ b/pkg/apis/kubedirector/v1beta1/kubedirectorcluster_types.go
@@ -224,12 +224,12 @@ const (
 
 // RoleStatus describes the component objects of a virtual cluster role.
 type RoleStatus struct {
-	Name                string             `json:"id"`
-	StatefulSet         string             `json:"statefulSet"`
-	Members             []MemberStatus     `json:"members"`
-	EncryptedSecretKeys map[string]string  `json:"encryptedSecretKeys,omitempty"`
-	UpgradingMembers    map[string]*string `json:"upgradingMembers,omitempty"`
-	RoleUpgradeStatus   RoleUpgradeStatus  `json:"roleUpgradeStatus,omitempty"`
+	Name                string            `json:"id"`
+	StatefulSet         string            `json:"statefulSet"`
+	Members             []MemberStatus    `json:"members"`
+	EncryptedSecretKeys map[string]string `json:"encryptedSecretKeys,omitempty"`
+	MembersUpgrading    int               `json:"membersUpgrading,omitempty"`
+	RoleUpgradeStatus   RoleUpgradeStatus `json:"roleUpgradeStatus,omitempty"`
 }
 
 // UpgradeInfo decribes cluster upgrading status

--- a/pkg/apis/kubedirector/v1beta1/kubedirectorcluster_types.go
+++ b/pkg/apis/kubedirector/v1beta1/kubedirectorcluster_types.go
@@ -212,6 +212,8 @@ type BlockStorage struct {
 type RoleUpgradeStatus string
 
 const (
+	// RoleConfigured is default empty value means the role is in ready state
+	RoleConfigured RoleUpgradeStatus = ""
 	// RoleUpgraded means upgrade process is finished
 	RoleUpgraded RoleUpgradeStatus = "upgraded"
 	// RoleRolledBack means rollback process is finished

--- a/pkg/controller/kubedirectorcluster/cluster.go
+++ b/pkg/controller/kubedirectorcluster/cluster.go
@@ -461,11 +461,11 @@ func handleClusterUpgrade(
 		// There could happens the situation when cluster receives rollback signal
 		// after the part of member were already successfully upgraded
 		// It means, that we shouldn't clean the upgradeInfo object while at least the one
-		// cluster role has upgrade status "Upgraded" instead "RolledBack"
+		// cluster role has upgrade status other than "RolledBack" or empty
 		finalizeUpgrade := true
 		if upgradeInfo.IsRollingBack {
 			for _, rs := range cr.Status.Roles {
-				if rs.RoleUpgradeStatus != kdv1.RoleRolledBack {
+				if rs.RoleUpgradeStatus != kdv1.RoleRolledBack && rs.RoleUpgradeStatus != "" {
 					finalizeUpgrade = false
 					break
 				}

--- a/pkg/controller/kubedirectorcluster/cluster.go
+++ b/pkg/controller/kubedirectorcluster/cluster.go
@@ -461,11 +461,11 @@ func handleClusterUpgrade(
 		// There could happens the situation when cluster receives rollback signal
 		// after the part of member were already successfully upgraded
 		// It means, that we shouldn't clean the upgradeInfo object while at least the one
-		// cluster role has upgrade status other than "RolledBack" or empty
+		// cluster role has upgrade status "RoleUpgraded"
 		finalizeUpgrade := true
 		if upgradeInfo.IsRollingBack {
 			for _, rs := range cr.Status.Roles {
-				if rs.RoleUpgradeStatus != kdv1.RoleRolledBack && rs.RoleUpgradeStatus != "" {
+				if rs.RoleUpgradeStatus == kdv1.RoleUpgraded {
 					finalizeUpgrade = false
 					break
 				}
@@ -480,7 +480,9 @@ func handleClusterUpgrade(
 				*cr.Spec.AppCatalog,
 				upgradeInfo.PrevApp,
 			)
-
+			for i, _ := range cr.Status.Roles {
+				(*cr).Status.Roles[i].RoleUpgradeStatus = kdv1.RoleConfigured
+			}
 			cr.Status.UpgradeInfo = nil
 			upgradeInfo = nil
 		}

--- a/pkg/controller/kubedirectorcluster/cluster.go
+++ b/pkg/controller/kubedirectorcluster/cluster.go
@@ -480,7 +480,7 @@ func handleClusterUpgrade(
 				*cr.Spec.AppCatalog,
 				upgradeInfo.PrevApp,
 			)
-			for i, _ := range cr.Status.Roles {
+			for i := range cr.Status.Roles {
 				(*cr).Status.Roles[i].RoleUpgradeStatus = kdv1.RoleConfigured
 			}
 			cr.Status.UpgradeInfo = nil

--- a/pkg/controller/kubedirectorcluster/members.go
+++ b/pkg/controller/kubedirectorcluster/members.go
@@ -613,19 +613,19 @@ func handleCreatingMembers(
 				return
 			}
 
-			if (*rs).MembersUpgrading > 0 {
-				(*rs).MembersUpgrading--
+			if (*rs).UpgradingMembersCount > 0 {
+				(*rs).UpgradingMembersCount--
 			}
 			(*m).PodUpgradeStatus = kdv1.PodConfigured
 			// When there no role members left, change the role upgrade status that upgrade process is complete
 			// Change the current member upgrade status depends on role upgrade status
 			switch (*rs).RoleUpgradeStatus {
 			case kdv1.RoleUpgrading:
-				if (*rs).MembersUpgrading == 0 {
+				if (*rs).UpgradingMembersCount == 0 {
 					(*rs).RoleUpgradeStatus = kdv1.RoleUpgraded
 				}
 			case kdv1.RoleRollingBack:
-				if (*rs).MembersUpgrading == 0 {
+				if (*rs).UpgradingMembersCount == 0 {
 					(*rs).RoleUpgradeStatus = kdv1.RoleRolledBack
 				}
 			}

--- a/pkg/controller/kubedirectorcluster/members.go
+++ b/pkg/controller/kubedirectorcluster/members.go
@@ -549,10 +549,10 @@ func handleCreatingMembers(
 			m.StateDetail.LastConnectionVersion = &connectionVersion
 
 			if (*rs).RoleUpgradeStatus == kdv1.RoleUpgrading {
-				(*m).PodUpgradeStatus = kdv1.PodUpgrading
+				m.PodUpgradeStatus = kdv1.PodUpgrading
 			}
 			if (*rs).RoleUpgradeStatus == kdv1.RoleRollingBack {
-				(*m).PodUpgradeStatus = kdv1.PodRollingBack
+				m.PodUpgradeStatus = kdv1.PodRollingBack
 			}
 
 			// Check to see if we have to inject one or more files for this member
@@ -611,23 +611,6 @@ func handleCreatingMembers(
 					role.roleStatus.Name,
 				)
 				return
-			}
-
-			if (*rs).UpgradingMembersCount > 0 {
-				(*rs).UpgradingMembersCount--
-			}
-			(*m).PodUpgradeStatus = kdv1.PodConfigured
-			// When there no role members left, change the role upgrade status that upgrade process is complete
-			// Change the current member upgrade status depends on role upgrade status
-			switch (*rs).RoleUpgradeStatus {
-			case kdv1.RoleUpgrading:
-				if (*rs).UpgradingMembersCount == 0 {
-					(*rs).RoleUpgradeStatus = kdv1.RoleUpgraded
-				}
-			case kdv1.RoleRollingBack:
-				if (*rs).UpgradingMembersCount == 0 {
-					(*rs).RoleUpgradeStatus = kdv1.RoleRolledBack
-				}
 			}
 
 			readFile := func(filepath string, writer io.Writer) (bool, error) {
@@ -694,6 +677,20 @@ func handleCreatingMembers(
 		if member.State != string(memberCreating) {
 			member.StateDetail.LastConfiguredContainer = member.StateDetail.ConfiguringContainer
 			member.StateDetail.ConfiguringContainer = ""
+			if member.PodUpgradeStatus != kdv1.PodConfigured {
+				member.PodUpgradeStatus = kdv1.PodConfigured
+				(*rs).UpgradingMembersCount--
+			}
+		}
+	}
+	switch (*rs).RoleUpgradeStatus {
+	case kdv1.RoleUpgrading:
+		if (*rs).UpgradingMembersCount == 0 {
+			(*rs).RoleUpgradeStatus = kdv1.RoleUpgraded
+		}
+	case kdv1.RoleRollingBack:
+		if (*rs).UpgradingMembersCount == 0 {
+			(*rs).RoleUpgradeStatus = kdv1.RoleRolledBack
 		}
 	}
 }

--- a/pkg/controller/kubedirectorcluster/members.go
+++ b/pkg/controller/kubedirectorcluster/members.go
@@ -616,16 +616,15 @@ func handleCreatingMembers(
 			if (*rs).MembersUpgrading > 0 {
 				(*rs).MembersUpgrading--
 			}
+			(*m).PodUpgradeStatus = kdv1.PodConfigured
 			// When there no role members left, change the role upgrade status that upgrade process is complete
 			// Change the current member upgrade status depends on role upgrade status
 			switch (*rs).RoleUpgradeStatus {
 			case kdv1.RoleUpgrading:
-				(*m).PodUpgradeStatus = kdv1.PodUpgraded
 				if (*rs).MembersUpgrading == 0 {
 					(*rs).RoleUpgradeStatus = kdv1.RoleUpgraded
 				}
 			case kdv1.RoleRollingBack:
-				(*m).PodUpgradeStatus = kdv1.PodRolledBack
 				if (*rs).MembersUpgrading == 0 {
 					(*rs).RoleUpgradeStatus = kdv1.RoleRolledBack
 				}

--- a/pkg/controller/kubedirectorcluster/members.go
+++ b/pkg/controller/kubedirectorcluster/members.go
@@ -613,22 +613,20 @@ func handleCreatingMembers(
 				return
 			}
 
-			// If appConfig returns true as a final member state
-			// remove the member from upgrading list
-			delete((*rs).UpgradingMembers, m.Pod)
-
+			if (*rs).MembersUpgrading > 0 {
+				(*rs).MembersUpgrading--
+			}
 			// When there no role members left, change the role upgrade status that upgrade process is complete
-			leftUpgradingMembersCnt := len((*rs).UpgradingMembers)
 			// Change the current member upgrade status depends on role upgrade status
 			switch (*rs).RoleUpgradeStatus {
 			case kdv1.RoleUpgrading:
 				(*m).PodUpgradeStatus = kdv1.PodUpgraded
-				if leftUpgradingMembersCnt == 0 {
+				if (*rs).MembersUpgrading == 0 {
 					(*rs).RoleUpgradeStatus = kdv1.RoleUpgraded
 				}
 			case kdv1.RoleRollingBack:
 				(*m).PodUpgradeStatus = kdv1.PodRolledBack
-				if leftUpgradingMembersCnt == 0 {
+				if (*rs).MembersUpgrading == 0 {
 					(*rs).RoleUpgradeStatus = kdv1.RoleRolledBack
 				}
 			}

--- a/pkg/controller/kubedirectorcluster/roles.go
+++ b/pkg/controller/kubedirectorcluster/roles.go
@@ -386,11 +386,21 @@ func handleRoleConfig(
 	role *roleInfo,
 ) {
 
+	setRoleStatusFn := func(needRollback bool) {
+		rs := (*role).roleStatus
+		if needRollback {
+			(*rs).RoleUpgradeStatus = kdv1.RoleRollingBack
+		} else {
+			(*rs).RoleUpgradeStatus = kdv1.RoleUpgrading
+		}
+	}
+
 	updateErr := executor.UpdateStatefulSetNonReplicas(
 		reqLogger,
 		cr,
 		role.roleSpec,
 		role.statefulSet,
+		setRoleStatusFn,
 	)
 	if updateErr != nil {
 		shared.LogErrorf(

--- a/pkg/controller/kubedirectorcluster/roles.go
+++ b/pkg/controller/kubedirectorcluster/roles.go
@@ -394,15 +394,6 @@ func handleRoleConfig(
 		}
 	}
 
-	setRoleStatusFn := func(needRollback bool) {
-		rs := (*role).roleStatus
-		if needRollback {
-			(*rs).RoleUpgradeStatus = kdv1.RoleRollingBack
-		} else {
-			(*rs).RoleUpgradeStatus = kdv1.RoleUpgrading
-		}
-	}
-
 	updateErr := executor.UpdateStatefulSetNonReplicas(
 		reqLogger,
 		cr,

--- a/pkg/controller/kubedirectorcluster/roles.go
+++ b/pkg/controller/kubedirectorcluster/roles.go
@@ -385,6 +385,14 @@ func handleRoleConfig(
 	cr *kdv1.KubeDirectorCluster,
 	role *roleInfo,
 ) {
+	setRoleStatusFn := func(needRollback bool) {
+		rs := (*role).roleStatus
+		if needRollback {
+			(*rs).RoleUpgradeStatus = kdv1.RoleRollingBack
+		} else {
+			(*rs).RoleUpgradeStatus = kdv1.RoleUpgrading
+		}
+	}
 
 	setRoleStatusFn := func(needRollback bool) {
 		rs := (*role).roleStatus

--- a/pkg/controller/kubedirectorcluster/roles.go
+++ b/pkg/controller/kubedirectorcluster/roles.go
@@ -394,10 +394,10 @@ func handleRoleConfig(
 		// between quantities of all members and members are still not upgraded
 		// It will be used at the syncMembers() step
 		if needRollback {
-			(*rs).MembersUpgrading = len(rs.Members) - (*rs).MembersUpgrading
+			(*rs).UpgradingMembersCount = int32(len(rs.Members)) - (*rs).UpgradingMembersCount
 			(*rs).RoleUpgradeStatus = kdv1.RoleRollingBack
 		} else {
-			(*rs).MembersUpgrading = len(rs.Members)
+			(*rs).UpgradingMembersCount = int32(len(rs.Members))
 			(*rs).RoleUpgradeStatus = kdv1.RoleUpgrading
 		}
 	}

--- a/pkg/executor/statefulset.go
+++ b/pkg/executor/statefulset.go
@@ -235,22 +235,16 @@ func UpdateStatefulSetNonReplicas(
 		copy(patchedContainers, containers)
 		patchedContainers[0].Image = appRoleImage
 
-		// In the case of rollback we should clear UpgradingMembers map
-		// and set role UpgradeStatus field to RoleRollingBack state
-		if needRollback {
-			rs.UpgradingMembers = nil
-		} else {
-			if (*rs).UpgradingMembers == nil {
-				(*rs).UpgradingMembers = make(map[string]*string)
-			}
-
-			// Fill UpgradingMembers map by current role members should be upgraded
-			// It will be used at the syncMembers() step
-			for _, m := range (*rs).Members {
-				(*rs).UpgradingMembers[m.Pod] = &appRoleImage
-			}
-			// Set role UpgradeStatus field to RoleUpgrading state
+		// Fill UpgradingMembers map by current role members should be upgraded
+		// It will be used at the syncMembers() step
+		if (*rs).UpgradingMembers == nil {
+			(*rs).UpgradingMembers = make(map[string]*string)
 		}
+
+		for _, m := range (*rs).Members {
+			(*rs).UpgradingMembers[m.Pod] = &appRoleImage
+		}
+
 		// Set role UpgradeStatus field
 		setRoleStatusFn(needRollback)
 

--- a/pkg/executor/statefulset.go
+++ b/pkg/executor/statefulset.go
@@ -156,6 +156,7 @@ func UpdateStatefulSetNonReplicas(
 	cr *kdv1.KubeDirectorCluster,
 	role *kdv1.Role,
 	statefulSet *appsv1.StatefulSet,
+	setRoleStatusFn func(bool),
 ) error {
 
 	// If no spec, nothing to do.
@@ -238,7 +239,6 @@ func UpdateStatefulSetNonReplicas(
 		// and set role UpgradeStatus field to RoleRollingBack state
 		if needRollback {
 			rs.UpgradingMembers = nil
-			rs.RoleUpgradeStatus = kdv1.RoleRollingBack
 		} else {
 			if (*rs).UpgradingMembers == nil {
 				(*rs).UpgradingMembers = make(map[string]*string)
@@ -250,8 +250,9 @@ func UpdateStatefulSetNonReplicas(
 				(*rs).UpgradingMembers[m.Pod] = &appRoleImage
 			}
 			// Set role UpgradeStatus field to RoleUpgrading state
-			(*rs).RoleUpgradeStatus = kdv1.RoleUpgrading
 		}
+		// Set role UpgradeStatus field
+		setRoleStatusFn(needRollback)
 
 		needPatch = true
 	}

--- a/pkg/executor/statefulset.go
+++ b/pkg/executor/statefulset.go
@@ -235,14 +235,14 @@ func UpdateStatefulSetNonReplicas(
 		copy(patchedContainers, containers)
 		patchedContainers[0].Image = appRoleImage
 
-		// Fill UpgradingMembers map by current role members should be upgraded
+		// Set MembersUpgrading to current role members count when the role should be upgraded
+		// For the rollback case MembersUpgrading count will be equal to difference
+		// between quantities of all members and members are still not upgraded
 		// It will be used at the syncMembers() step
-		if (*rs).UpgradingMembers == nil {
-			(*rs).UpgradingMembers = make(map[string]*string)
-		}
-
-		for _, m := range (*rs).Members {
-			(*rs).UpgradingMembers[m.Pod] = &appRoleImage
+		if needRollback {
+			(*rs).MembersUpgrading = len(rs.Members) - (*rs).MembersUpgrading
+		} else if (*rs).MembersUpgrading == 0 {
+			(*rs).MembersUpgrading = len(rs.Members)
 		}
 
 		// Set role UpgradeStatus field

--- a/pkg/shared/util.go
+++ b/pkg/shared/util.go
@@ -163,20 +163,3 @@ func GetRoleStatusByName(
 	}
 	return nil, fmt.Errorf("RoleStatus for %s role name was not found", roleName)
 }
-
-// RoleStatusIsUpgrading checks, if some cluster member of the
-// passed role is currently in upgrading state
-// If role status is not found by passed roleName returns false
-func RoleStatusIsUpgrading(
-	cr *kdv1.KubeDirectorCluster,
-	roleName string,
-) bool {
-
-	rs, err := GetRoleStatusByName(cr, roleName)
-
-	if err != nil || rs.UpgradingMembers == nil {
-		return false
-	}
-
-	return len(rs.UpgradingMembers) > 0
-}

--- a/pkg/shared/util.go
+++ b/pkg/shared/util.go
@@ -147,19 +147,3 @@ func StatefulSetContainers(
 
 	return statefulSet.Spec.Template.Spec.Containers
 }
-
-// GetRoleStatusByName looks for the RoleStatus
-// in KubeDirectorCluster.KubeDirectorClusterStatus.Roles[] array
-// by the passed role name and, if RoleStatus exists, returns its address or returns nil and error
-func GetRoleStatusByName(
-	cr *kdv1.KubeDirectorCluster,
-	roleName string,
-) (*kdv1.RoleStatus, error) {
-
-	for i, r := range cr.Status.Roles {
-		if r.Name == roleName {
-			return &cr.Status.Roles[i], nil
-		}
-	}
-	return nil, fmt.Errorf("RoleStatus for %s role name was not found", roleName)
-}

--- a/pkg/validator/cluster.go
+++ b/pkg/validator/cluster.go
@@ -394,8 +394,8 @@ func validateGeneralClusterChanges(
 		if !prevVer.LessThan(*newVer) && !rollbackRequested {
 			appModifiedMsg := fmt.Sprintf(
 				versionIsNotNewer,
-				prevVer.String(),
 				newVer.String(),
+				prevVer.String(),
 			)
 			valErrors = append(valErrors, appModifiedMsg)
 			return valErrors


### PR DESCRIPTION
Resolves https://github.com/bluek8s/kubedirector/issues/595

1. Extracted `RoleStatus` management from `executor` to `controller` package
2. Corrected `upgradeInfo` object elimination. Before removing the object cluster should check, if there was a rollback then all role upgrade statuses should be set to `RolledBack` value or should stay empty, if a corresponding role was not changed by the last upgrade. Possibly it should also resolve https://github.com/bluek8s/kubedirector/issues/594
When upgradeInfo is removed and upgrade process is finished, all the role upgrade statuses are set to `RoleConfigured` (default empty value), which partially resolves https://github.com/bluek8s/kubedirector/issues/593
3. As currently we don't need to use a new image value stored in `UpgradingMembers` map, it was replaced by the simple `MembersUpgrading` counter. At the direct upgrade it is set to the current role members quantity and than decreases when the each role member is upgraded. At the rollback case its value is set to the already upgraded members quantity. When `MembersUpgrading` counter decreases to 0, the corresponding `RoleUpgradeStatus` value changes to `RoleUpgraded/RoleRolledback`.