### PR TITLE
fix incomplete schema areas

### DIFF
--- a/deploy/kubedirector/kubedirector.hpe.com_kubedirectorclusters_crd.yaml
+++ b/deploy/kubedirector/kubedirector.hpe.com_kubedirectorclusters_crd.yaml
@@ -108,15 +108,23 @@ spec:
                       podLabels:
                         type: object
                         nullable: true
+                        additionalProperties:
+                          type: string
                       podAnnotations:
                         type: object
                         nullable: true
+                        additionalProperties:
+                          type: string
                       serviceLabels:
                         type: object
                         nullable: true
+                        additionalProperties:
+                          type: string
                       serviceAnnotations:
                         type: object
                         nullable: true
+                        additionalProperties:
+                          type: string
                       members:
                         type: integer
                         minimum: 0

--- a/deploy/kubedirector/kubedirector.hpe.com_kubedirectorconfigs_crd.yaml
+++ b/deploy/kubedirector/kubedirector.hpe.com_kubedirectorconfigs_crd.yaml
@@ -57,15 +57,23 @@ spec:
                 podLabels:
                   type: object
                   nullable: true
+                  additionalProperties:
+                    type: string
                 podAnnotations:
                   type: object
                   nullable: true
+                  additionalProperties:
+                    type: string
                 serviceLabels:
                   type: object
                   nullable: true
+                  additionalProperties:
+                    type: string
                 serviceAnnotations:
                   type: object
                   nullable: true
+                  additionalProperties:
+                    type: string
                 backupClusterStatus:
                   type: boolean
                 allowRestoreWithoutConnections:

--- a/deploy/kubedirector/kubedirector.hpe.com_kubedirectorstatusbackups_crd.yaml
+++ b/deploy/kubedirector/kubedirector.hpe.com_kubedirectorstatusbackups_crd.yaml
@@ -32,3 +32,108 @@ spec:
               properties:
                 statusBackup:
                   type: object
+                  nullable: true
+                  properties:
+                    state:
+                      type: string
+                    restoreProgress:
+                      type: object
+                      nullable: true
+                      properties:
+                        awaitingApp:
+                          type: boolean
+                        awaitingStatus:
+                          type: boolean
+                        awaitingResources:
+                          type: boolean
+                        error:
+                          type: string
+                    memberStateRollup:
+                      type: object
+                      properties:
+                        membershipChanging:
+                          type: boolean
+                        membersDown:
+                          type: boolean
+                        membersInitializing:
+                          type: boolean
+                        membersWaiting:
+                          type: boolean
+                        membersRestarting:
+                          type: boolean
+                        configErrors:
+                          type: boolean
+                        membersNotScheduled:
+                          type: boolean
+                    generationUID:
+                      type: string
+                    lastConnectionHash:
+                      type: string  
+                    specGenerationToProcess:
+                      type: integer
+                    clusterService:
+                      type: string
+                    lastNodeID:
+                      type: integer
+                    roles:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          id:
+                            type: string
+                          statefulSet:
+                            type: string
+                          members:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                pod:
+                                  type: string
+                                nodeID:
+                                  type: integer
+                                service:
+                                  type: string
+                                pvc:
+                                  type: string
+                                blockDevicePaths:
+                                  type: array
+                                  items:
+                                    type: string
+                                authToken:
+                                  type: string  
+                                state:
+                                  type: string
+                                stateDetail:
+                                  type: object
+                                  properties:
+                                    configErrorDetail:
+                                      type: string
+                                    lastConfigDataGeneration:
+                                      type: integer
+                                    lastSetupGeneration:
+                                      type: integer
+                                    configuringContainer:
+                                      type: string
+                                    lastConfiguredContainer:
+                                      type: string
+                                    lastKnownContainerState:
+                                      type: string
+                                    lastConnectionVersion:
+                                      type: integer
+                                    startScriptStdoutMessage:
+                                      type: string
+                                    startScriptStderrMessage:
+                                      type: string
+                                    schedulingErrorMessage:
+                                      type: string
+                                    pendingNotifyCmds:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          arguments:
+                                            type: array
+                                            items:
+                                              type: string


### PR DESCRIPTION
issue #611

In the v1 schema regime, the contents of these objects were being discarded.

In the case of the kdstatusbackup, this copy-and-paste of the status schema is not a great solution for long-term development/maintenance (since any future status schema changes now have to be made in two places), but it's a good and easily-verified-as-correct fix for the immediate issue. Will explore other solutions in a following KD release.