### PR TITLE
Duplicate mountPath validation

### DIFF
--- a/pkg/executor/statefulset.go
+++ b/pkg/executor/statefulset.go
@@ -361,7 +361,7 @@ func getStatefulset(
 	if role.ServiceAccountName != "" {
 		useServiceAccount = true
 	}
-	volumeMounts, volumes, volumesErr := generateVolumeMounts(
+	volumeMounts, volumes, volumesErr := GenerateVolumeMounts(
 		cr,
 		role,
 		PvcNamePrefix,
@@ -777,7 +777,7 @@ func generateVolumeProjectionMounts(
 	projectedVol *kdv1.VolumeProjections,
 ) ([]v1.VolumeMount, []v1.Volume) {
 
-	volName := "projected-vol-" + strconv.Itoa(volIndex)
+	volName := ProjectedVolNamePrefix + strconv.Itoa(volIndex)
 	volSource := v1.PersistentVolumeClaimVolumeSource{
 		ClaimName: projectedVol.PvcName,
 		ReadOnly:  projectedVol.ReadOnly,
@@ -800,13 +800,13 @@ func generateVolumeProjectionMounts(
 
 }
 
-// generateVolumeMounts generates all of an app container's volume and mount
+// GenerateVolumeMounts generates all of an app container's volume and mount
 // specs for persistent storage, tmpfs and systemctl support that are
 // appropriate for members of the given role. For systemctl support,
 // nativeSystemdSupport flag is examined along with the app requirement.
 // Additionally generate volume mount spec if a role has
 // requested for volume projections.
-func generateVolumeMounts(
+func GenerateVolumeMounts(
 	cr *kdv1.KubeDirectorCluster,
 	role *kdv1.Role,
 	pvcNamePrefix string,

--- a/pkg/executor/types.go
+++ b/pkg/executor/types.go
@@ -77,6 +77,7 @@ const (
 	// This is assigned in accordance with the PvcPrefix
 	blockPvcNamePrefix = "b"
 
+	// ProjectedVolNamePrefix is the prefix used for volume names/mounts for project volumes for a role
 	ProjectedVolNamePrefix = "projected-vol-"
 )
 

--- a/pkg/executor/types.go
+++ b/pkg/executor/types.go
@@ -76,6 +76,8 @@ const (
 	// blockPvcNamePrefix is the prefix name for the volume device that is auto-created by the statefulset.
 	// This is assigned in accordance with the PvcPrefix
 	blockPvcNamePrefix = "b"
+
+	ProjectedVolNamePrefix = "projected-vol-"
 )
 
 // Streams for stdin, stdout, stderr of executed commands

--- a/pkg/validator/cluster.go
+++ b/pkg/validator/cluster.go
@@ -1171,7 +1171,7 @@ func validateVolumeProjections(
 			}
 		}
 
-		for mountPath, _ := range systemMountPathConflict {
+		for mountPath := range systemMountPathConflict {
 			valErrors = append(
 				valErrors,
 				fmt.Sprintf(

--- a/pkg/validator/cluster.go
+++ b/pkg/validator/cluster.go
@@ -1097,7 +1097,7 @@ func validateVolumeProjections(
 			for j := 0; j < totalVolMnts; j++ {
 				if !strings.HasPrefix(allVolumeMnts[j].Name, executor.ProjectedVolNamePrefix) &&
 					allVolumeMnts[j].MountPath == volume.MountPath {
-					// Bump up systemMountPaths map to check later
+					// Bump up systemMountPathConflict map to check later
 					systemMountPathConflict[volume.MountPath] = true
 				}
 			}

--- a/pkg/validator/cluster.go
+++ b/pkg/validator/cluster.go
@@ -26,6 +26,7 @@ import (
 	kdv1 "github.com/bluek8s/kubedirector/pkg/apis/kubedirector/v1beta1"
 	"github.com/bluek8s/kubedirector/pkg/catalog"
 	"github.com/bluek8s/kubedirector/pkg/controller/kubedirectorcluster"
+	"github.com/bluek8s/kubedirector/pkg/executor"
 	"github.com/bluek8s/kubedirector/pkg/observer"
 	"github.com/bluek8s/kubedirector/pkg/secretkeys"
 	"github.com/bluek8s/kubedirector/pkg/shared"
@@ -1043,7 +1044,8 @@ func addRestoreLabel(
 // If PVC is validated, following additional checks are made
 // - VolumeMode must be FileSystem
 // - Within a cluster if a pvc is reused, validate AccessModes to contain either ReadWriteMany or ReadOnlyMany
-// - Within a role, make sure mountPaths are unique
+// - Within a role, make sure mountPaths specified through volumeProjections are unique
+// - make sure mountPaths specified through volumeProjections doesn't conflict with system generated mountPaths
 func validateVolumeProjections(
 	cr *kdv1.KubeDirectorCluster,
 	userInfo v1.UserInfo,
@@ -1053,19 +1055,52 @@ func validateVolumeProjections(
 
 	numRoles := len(cr.Spec.Roles)
 	exclusivePvcs := make(map[string]int32)
+	nativeSystemdSupport := shared.GetNativeSystemdSupport()
 
 	for i := 0; i < numRoles; i++ {
 		mountPaths := make(map[string]int32)
+		systemMountPathConflict := make(map[string]bool)
 		role := &(cr.Spec.Roles[i])
 		if len(role.VolumeProjections) == 0 {
 			continue
 		}
+
+		// Fetch all volumemounts and volumes for this role
+		allVolumeMnts, _, err := executor.GenerateVolumeMounts(
+			cr,
+			role,
+			executor.PvcNamePrefix,
+			nativeSystemdSupport,
+			[]string{},
+		)
+
+		if err != nil {
+			valErrors = append(
+				valErrors,
+				fmt.Sprintf(
+					failedVolumeMountCheck,
+					role.Name,
+				),
+			)
+			continue
+		}
+
 		numVolumes := len(role.VolumeProjections)
 		for j := 0; j < numVolumes; j++ {
 			volume := role.VolumeProjections[j]
 
 			// Bump up mountPath map to check later
 			mountPaths[volume.MountPath]++
+
+			// Check for clash with system mountPaths
+			totalVolMnts := len(allVolumeMnts)
+			for j := 0; j < totalVolMnts; j++ {
+				if !strings.HasPrefix(allVolumeMnts[j].Name, executor.ProjectedVolNamePrefix) &&
+					allVolumeMnts[j].MountPath == volume.MountPath {
+					// Bump up systemMountPaths map to check later
+					systemMountPathConflict[volume.MountPath] = true
+				}
+			}
 
 			// Check to make sure pvc exists in the cluster namespace
 			pvc, pvcErr := observer.GetPVC(cr.Namespace, volume.PvcName)
@@ -1117,22 +1152,34 @@ func validateVolumeProjections(
 				role.ServiceAccountName,
 				"get",
 			)
+
 			if errStr != "" {
 				valErrors = append(valErrors, errStr)
 			}
-		}
 
+		}
 		for mountPath, mountNum := range mountPaths {
 			if mountNum > 1 {
 				valErrors = append(
 					valErrors,
 					fmt.Sprintf(
-						invalidMountPath,
+						duplicateMountPath,
 						mountPath,
 						role.Name,
 					),
 				)
 			}
+		}
+
+		for mountPath, _ := range systemMountPathConflict {
+			valErrors = append(
+				valErrors,
+				fmt.Sprintf(
+					systemMountPathClash,
+					mountPath,
+					role.Name,
+				),
+			)
 		}
 	}
 

--- a/pkg/validator/types.go
+++ b/pkg/validator/types.go
@@ -103,7 +103,10 @@ const (
 	invalidPVC        = "Unable to find persistentvolumeclaim(%s) in namespace(%s) as specified for role(%s)."
 	invalidVolumeMode = "Specified persistentvolumeclaim(%s) for role (%s) is invalid. VolumeMode(%s) for the underlying volume must be configured as Filesystem."
 	invalidAccessMode = "Specified persistentvolumeclaim(%s) is invalid. AccessModes for this volume must contain either ReadWriteMany or ReadOnlyMany, since its consumed by more than 1 member of the cluster."
-	invalidMountPath  = "Specified mountPath(%s) for role(%s) is invalid. It must be unique within the role."
+
+	duplicateMountPath     = "Specified mountPath(%s) for role(%s) is invalid. It must be unique within the role."
+	systemMountPathClash   = "Specified mountPath(%s) for role(%s) is invalid. It clashes with system generated mountPath."
+	failedVolumeMountCheck = "Unexpected error while validating for unique volume mount paths for role(%s)."
 )
 
 type dictValue map[string]string


### PR DESCRIPTION
Fixes 

https://github.com/bluek8s/kubedirector/issues/555


During validation, generate all system generated volumes. Use this to match it against provided Volume Projections. If there is a clash in mountPath report an error.

Use an existing function generateVolumeMounts.

