### PR TITLE
support custom size for /dev/shm

### DIFF
--- a/deploy/kubedirector/kubedirector.hpe.com_kubedirectorclusters_crd.yaml
+++ b/deploy/kubedirector/kubedirector.hpe.com_kubedirectorclusters_crd.yaml
@@ -197,6 +197,9 @@ spec:
                               minLength: 1
                             value:
                               type: string
+                      sharedMemory:
+                        type: string
+                        pattern: '^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'
                       storage:
                         type: object
                         nullable: true

--- a/deploy/kubedirector/kubedirector.hpe.com_kubedirectorconfigs_crd.yaml
+++ b/deploy/kubedirector/kubedirector.hpe.com_kubedirectorconfigs_crd.yaml
@@ -78,6 +78,8 @@ spec:
                   type: boolean
                 allowRestoreWithoutConnections:
                   type: boolean
+                forceSharedMemorySizeSupport:
+                  type: boolean
             status:
               type: object
               nullable: true

--- a/pkg/apis/kubedirector/v1beta1/kubedirectorcluster_types.go
+++ b/pkg/apis/kubedirector/v1beta1/kubedirectorcluster_types.go
@@ -145,6 +145,7 @@ type Role struct {
 	Affinity           *corev1.Affinity            `json:"affinity,omitempty"`
 	Storage            *ClusterStorage             `json:"storage,omitempty"`
 	EnvVars            []corev1.EnvVar             `json:"env,omitempty"`
+	SharedMemory       *string                     `json:"sharedMemory,omitempty"`
 	FileInjections     []FileInjections            `json:"fileInjections,omitempty"`
 	Secret             *KDSecret                   `json:"secret,omitempty"`
 	BlockStorage       *BlockStorage               `json:"blockStorage,omitempty"`

--- a/pkg/apis/kubedirector/v1beta1/kubedirectorconfig_types.go
+++ b/pkg/apis/kubedirector/v1beta1/kubedirectorconfig_types.go
@@ -33,6 +33,7 @@ type KubeDirectorConfigSpec struct {
 	ServiceAnnotations             map[string]string `json:"serviceAnnotations,omitempty"`
 	BackupClusterStatus            *bool             `json:"backupClusterStatus,omitempty"`
 	AllowRestoreWithoutConnections *bool             `json:"allowRestoreWithoutConnections,omitempty"`
+	ForceSharedMemorySizeSupport   *bool             `json:"forceSharedMemorySizeSupport,omitempty"`
 }
 
 // KubeDirectorConfigStatus defines the observed state of KubeDirectorConfig.

--- a/pkg/shared/globalconfig.go
+++ b/pkg/shared/globalconfig.go
@@ -187,6 +187,18 @@ func GetAllowRestoreWithoutConnections() bool {
 	return false
 }
 
+// GetForceSharedMemorySizeSupport extracts the boolean-or-nil value from the
+// globalConfig CR data if present, otherwise returns nil.
+func GetForceSharedMemorySizeSupport() *bool {
+
+	globalConfigLock.RLock()
+	defer globalConfigLock.RUnlock()
+	if globalConfig != nil {
+		return globalConfig.Spec.ForceSharedMemorySizeSupport
+	}
+	return nil
+}
+
 // RemoveGlobalConfig removes the current globalConfig
 func RemoveGlobalConfig() {
 

--- a/pkg/validator/cluster.go
+++ b/pkg/validator/cluster.go
@@ -530,12 +530,24 @@ func validateRoleSharedMemory(
 		if role.SharedMemory == nil {
 			continue
 		}
-		k8sVersionOk, _ := shared.K8sVersionIsAtLeast(1, 22)
-		if !k8sVersionOk {
+		forceSharedMemorySizeSupport := shared.GetForceSharedMemorySizeSupport()
+		if forceSharedMemorySizeSupport == nil {
+			k8sVersionOk, _ := shared.K8sVersionIsAtLeast(1, 22)
+			if !k8sVersionOk {
+				valErrors = append(
+					valErrors,
+					fmt.Sprintf(
+						invalidShmemK8sVersion,
+						role.Name,
+					),
+				)
+				continue
+			}
+		} else if *forceSharedMemorySizeSupport == false {
 			valErrors = append(
 				valErrors,
 				fmt.Sprintf(
-					invalidShmemK8sVersion,
+					invalidShmemFeature,
 					role.Name,
 				),
 			)
@@ -550,6 +562,7 @@ func validateRoleSharedMemory(
 					role.Name,
 				),
 			)
+			continue
 		}
 		if shmemQuant.Sign() != 1 {
 			valErrors = append(

--- a/pkg/validator/cluster.go
+++ b/pkg/validator/cluster.go
@@ -517,7 +517,8 @@ func validateRoleStorageClass(
 	return valErrors, patches
 }
 
-// validateRoleSharedMemory checks for valid quantity syntax.
+// validateRoleSharedMemory checks for valid quantity syntax. Also the K8s
+// version must be >= 1.22.
 func validateRoleSharedMemory(
 	cr *kdv1.KubeDirectorCluster,
 	valErrors []string,
@@ -527,6 +528,17 @@ func validateRoleSharedMemory(
 	for i := 0; i < numRoles; i++ {
 		role := &(cr.Spec.Roles[i])
 		if role.SharedMemory == nil {
+			continue
+		}
+		k8sVersionOk, _ := shared.K8sVersionIsAtLeast(1, 22)
+		if !k8sVersionOk {
+			valErrors = append(
+				valErrors,
+				fmt.Sprintf(
+					invalidShmemK8sVersion,
+					role.Name,
+				),
+			)
 			continue
 		}
 		shmemQuant, err := resource.ParseQuantity(*role.SharedMemory)

--- a/pkg/validator/types.go
+++ b/pkg/validator/types.go
@@ -87,9 +87,10 @@ const (
 	noDefaultStorageClass   = "storageClassName is not specified for one or more roles, and no default storage class is available."
 	badDefaultStorageClass  = "storageClassName is not specified for one or more roles, and default storage class (%s) is not available on the system."
 
-	invalidShmemDef  = "Shared memory size for role (%s) is incorrectly defined."
-	invalidShmemSize = "Shared memory size for role (%s) should be greater than zero."
+	invalidShmemDef        = "Shared memory size for role (%s) is incorrectly defined."
+	invalidShmemSize       = "Shared memory size for role (%s) should be greater than zero."
 	invalidShmemK8sVersion = "Specifying shared memory size for role (%s) requires K8s version >= 1.22."
+	invalidShmemFeature    = "Specifying shared memory size for role (%s) not allowed; feature disabled by global KubeDirector config."
 
 	invalidResource = "Specified resource(\"%s\") value(\"%s\") for role(\"%s\") is invalid. Minimum value must be \"%s\"."
 	invalidStorage  = "Specified persistent storage size(\"%s\") for role(\"%s\") is invalid. Minimum size must be \"%s\"."

--- a/pkg/validator/types.go
+++ b/pkg/validator/types.go
@@ -89,6 +89,7 @@ const (
 
 	invalidShmemDef  = "Shared memory size for role (%s) is incorrectly defined."
 	invalidShmemSize = "Shared memory size for role (%s) should be greater than zero."
+	invalidShmemK8sVersion = "Specifying shared memory size for role (%s) requires K8s version >= 1.22."
 
 	invalidResource = "Specified resource(\"%s\") value(\"%s\") for role(\"%s\") is invalid. Minimum value must be \"%s\"."
 	invalidStorage  = "Specified persistent storage size(\"%s\") for role(\"%s\") is invalid. Minimum size must be \"%s\"."

--- a/pkg/validator/types.go
+++ b/pkg/validator/types.go
@@ -87,6 +87,9 @@ const (
 	noDefaultStorageClass   = "storageClassName is not specified for one or more roles, and no default storage class is available."
 	badDefaultStorageClass  = "storageClassName is not specified for one or more roles, and default storage class (%s) is not available on the system."
 
+	invalidShmemDef  = "Shared memory size for role (%s) is incorrectly defined."
+	invalidShmemSize = "Shared memory size for role (%s) should be greater than zero."
+
 	invalidResource = "Specified resource(\"%s\") value(\"%s\") for role(\"%s\") is invalid. Minimum value must be \"%s\"."
 	invalidStorage  = "Specified persistent storage size(\"%s\") for role(\"%s\") is invalid. Minimum size must be \"%s\"."
 	invalidSrcURL   = "Unable to access the specified URL(\"%s\") in file injection spec for the role (%s). error: %s."


### PR DESCRIPTION
The memory backing /dev/shm in a container is normally limited to 64MB. Some applications need (a lot) more than that, e.g. PyTorch jobs.

At a glance it seems like a solution would be to mount an emptyDir memory volume to /dev/shm. However until (somewhat) recently you couldn't specify the max size of such a volume, and it would be half of your host's RAM. That's ... not good.

K8s 1.20 add a feature flag (false by default) to enable setting a size limit on such volumes. With K8s 1.22, that feature flag is true by default. If all goes well it should eventually graduate out of feature-flag-land but hasn't yet.

=====

This change introduces an optional quantity for role spec in a kdcluster: "sharedMemory". So for example your kdcluster role spec could include
```yaml
sharedMemory: "1Gi"
```

We've been running test builds of this for quite a while with a user that has a demanding PyTorch setup and this seems to work great!

The problem is, how do you deal with K8s clusters that don't know about this setting? If you try to do this and your K8s cluster doesn't have the SizeMemoryBackedVolumes feature gate enabled, then you'll end up with the ginormous memory volume as mentioned above.

So...

By default, KD will assume that you are allowed to specify sharedMemory in a role spec if your K8s server is version 1.22 or better.

If you want to change this behavior -- let's say you've explicitly disabled the feature gate in your K8s 1.22+ cluster, or maybe you enabled the feature gate in an earlier K8s version -- you can indicate that with an optional boolean flag in the KD config: "forceSharedMemorySizeSupport".

If you leave that attribute unspecified in the KD config, you'll get the version-based gating described above, i.e. you can use sharedMemory in your role specs if your K8s cluster is 1.22+. However you can also choose to explicitly set this attribute to a value of true or false to suppress the version-based check in favor of your explicit declaration.

=====

Also included: a minor improvement to validateRoleStorageClass. If parsing a storage quantity in a role fails, it will continue to check the other roles rather than bailing immediately. If you have any similar issues in other roles this will let you see them all at once.